### PR TITLE
Implement contao templating engine.

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -6,7 +6,7 @@ services:
 
     # The template engine for contao templates
     templating.engine.contao:
-        class: Contao\Bundle\CoreBundle\Templating\ContaoEngine
+        class: Contao\CoreBundle\Templating\ContaoEngine
 
     contao.routing_loader:
         class:     Contao\CoreBundle\Config\Loader\ContaoLoader

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,6 +4,11 @@ services:
         factory_class: Contao\Config
         factory_method: getInstance
 
+    # The template engine for contao templates
+    templating.engine.contao:
+        class:     Contao\Bundle\CoreBundle\Templating\ContaoEngine
+        arguments: ['@contao.config'] # FIXME: remove
+
     contao.routing_loader:
         class:     Contao\CoreBundle\Config\Loader\ContaoLoader
         arguments: ['@contao.config'] # FIXME: remove

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -6,8 +6,7 @@ services:
 
     # The template engine for contao templates
     templating.engine.contao:
-        class:     Contao\Bundle\CoreBundle\Templating\ContaoEngine
-        arguments: ['@contao.config'] # FIXME: remove
+        class: Contao\Bundle\CoreBundle\Templating\ContaoEngine
 
     contao.routing_loader:
         class:     Contao\CoreBundle\Config\Loader\ContaoLoader

--- a/src/Templating/ContaoEngine.php
+++ b/src/Templating/ContaoEngine.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2014 Leo Feyer
+ *
+ * @link    https://contao.org
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
+ */
+
+namespace Contao\Bundle\CoreBundle\Templating;
+
+use Contao\BackendTemplate;
+use Contao\Config;
+use Contao\FrontendTemplate;
+use Contao\TemplateLoader;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Template engine that use the "old" contao templating system.
+ *
+ * @author Tristan Lins <https://bit3.de>
+ */
+class ContaoEngine implements EngineInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $parameters = array())
+    {
+        if ('BE' == TL_MODE) {
+            $template = new BackendTemplate($name);
+        } else {
+            $template = new FrontendTemplate($name);
+        }
+        $template->setData($parameters);
+        return $template->parse();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exists($name)
+    {
+        try {
+            TemplateLoader::getPath($name, 'html5'); // FIXME static format
+            return true;
+        } catch (\Exception $exception) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($name)
+    {
+        return $this->exists($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderResponse($view, array $parameters = array(), Response $response = null)
+    {
+        if (!$response) {
+            $response = new Response();
+        }
+
+        $response->setContent($this->render($view, $parameters));
+
+        $response->headers->set('Vary', 'User-Agent', false);
+        $response->headers->set('Content-Type', 'text/html; charset=' . Config::get('characterSet')); // FIXME: content type hardcoded
+
+        return $response;
+    }
+}

--- a/src/Templating/ContaoEngine.php
+++ b/src/Templating/ContaoEngine.php
@@ -9,7 +9,7 @@
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
  */
 
-namespace Contao\Bundle\CoreBundle\Templating;
+namespace Contao\CoreBundle\Templating;
 
 use Contao\BackendTemplate;
 use Contao\Config;

--- a/src/Templating/ContaoEngine.php
+++ b/src/Templating/ContaoEngine.php
@@ -36,6 +36,7 @@ class ContaoEngine implements EngineInterface
             $template = new FrontendTemplate($name);
         }
         $template->setData($parameters);
+
         return $template->parse();
     }
 
@@ -46,6 +47,7 @@ class ContaoEngine implements EngineInterface
     {
         try {
             TemplateLoader::getPath($name, 'html5'); // FIXME static format
+
             return true;
         } catch (\Exception $exception) {
             return false;


### PR DESCRIPTION
The contao template engine allow us to use `$container->get('templating')->render('mod_x', ['foo' => 'bar']);` which renders the template `mod_x.html5`.
It's the same as do `$template = new FrontendTemplate('mod_x'); return $template->parse();` in the FE mode, or `$template = new BackendTemplate('mod_x'); return $template->parse();` in the BE mode.