### PR TITLE
Enable doctrine database connection.

### DIFF
--- a/autoload.json
+++ b/autoload.json
@@ -3,6 +3,9 @@
         "Contao\\CoreBundle\\ContaoCoreBundle": {
             "replace": ["core"],
             "environments": ["all"]
+        },
+        "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": {
+            "environments": ["all"]
         }
     }
 }


### PR DESCRIPTION
I'm not sure if we load the doctrine bundle with the core bundle or hardcode it in the kernel class. Personally I would prefer to hardcode it in the kernel class.

Related to https://github.com/contao/contao/pull/30
