### PR TITLE
j_slider template get lost from autoload.php.

### DIFF
--- a/contao/config/autoload.php
+++ b/contao/config/autoload.php
@@ -342,6 +342,7 @@ TemplateLoader::addFiles(array
 	'j_accordion'         => 'vendor/contao/core-bundle/contao/templates/jquery',
 	'j_colorbox'          => 'vendor/contao/core-bundle/contao/templates/jquery',
 	'j_mediaelement'      => 'vendor/contao/core-bundle/contao/templates/jquery',
+	'j_slider'            => 'vendor/contao/core-bundle/contao/templates/jquery',
 	'j_tablesort'         => 'vendor/contao/core-bundle/contao/templates/jquery',
 	'js_highlight'        => 'vendor/contao/core-bundle/contao/templates/js',
 	'js_slider'           => 'vendor/contao/core-bundle/contao/templates/js',


### PR DESCRIPTION
Just a bugfix.
