### PR TITLE
Remove the `System::getKernel()` method

### DIFF
--- a/contao/classes/Backend.php
+++ b/contao/classes/Backend.php
@@ -243,11 +243,13 @@ abstract class Backend extends \Controller
 	 */
 	protected function handleRunOnce()
 	{
+		global $kernel;
+
 		$this->import('Files');
 		$arrFiles = array(TL_ROOT . '/system/runonce.php');
 
 		// Always scan all folders and not just the active modules (see #4200)
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$arrFiles[] = $bundle->getContaoResourcesPath() . '/config/runonce.php';
 		}

--- a/contao/controllers/BackendInstall.php
+++ b/contao/controllers/BackendInstall.php
@@ -754,9 +754,11 @@ class BackendInstall extends \Backend
 
 		if (!\Config::get('coreOnlyMode'))
 		{
+			global $kernel;
+
 			$modules = array();
 
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				$modules[] = $bundle->getName();
 			}

--- a/contao/dca/tl_templates.php
+++ b/contao/dca/tl_templates.php
@@ -206,11 +206,13 @@ class tl_templates extends Backend
 	 */
 	public function addNewTemplate()
 	{
+		global $kernel;
+
 		$arrAllTemplates = array();
 		$arrAllowed = trimsplit(',', Config::get('templateFiles'));
 
 		// Get all templates
-		foreach (System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strModule = $bundle->getName();
 			$strFolder = $bundle->getContaoResourcesPath() . '/templates';

--- a/contao/dca/tl_user_group.php
+++ b/contao/dca/tl_user_group.php
@@ -306,9 +306,11 @@ class tl_user_group extends Backend
 	 */
 	public function getExcludedFields()
 	{
+		global $kernel;
+
 		$included = array();
 
-		foreach (System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strDir = $bundle->getContaoResourcesPath() . '/dca';
 

--- a/contao/library/Contao/Automator.php
+++ b/contao/library/Contao/Automator.php
@@ -550,9 +550,11 @@ class Automator extends \System
 	 */
 	protected function getPublicModuleFolders()
 	{
+		global $kernel;
+
 		$arrPublic = array();
 
-		foreach (\System::getKernel()->getContaoBundles() as $bundle) # FIXME
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			foreach ($bundle->getPublicFolders() as $strPath)
 			{
@@ -574,7 +576,9 @@ class Automator extends \System
 	 */
 	protected function symlinkThemes()
 	{
-		foreach (\System::getKernel()->getContaoBundles() as $bundle) # FIXME
+		global $kernel;
+
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strPath = $bundle->getContaoResourcesPath() . '/themes';
 
@@ -620,11 +624,13 @@ class Automator extends \System
 	 */
 	public function generateConfigCache()
 	{
+		global $kernel;
+
 		// Generate the class/template laoder cache file
 		$objCacheFile = new \File('system/cache/config/autoload.php');
 		$objCacheFile->write('<?php '); // add one space to prevent the "unexpected $end" error
 
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strFile = $bundle->getContaoResourcesPath() . '/config/autoload.php';
 
@@ -641,7 +647,7 @@ class Automator extends \System
 		$objCacheFile = new \File('system/cache/config/config.php');
 		$objCacheFile->write('<?php '); // add one space to prevent the "unexpected $end" error
 
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strFile = $bundle->getContaoResourcesPath() . '/config/config.php';
 
@@ -664,10 +670,12 @@ class Automator extends \System
 	 */
 	public function generateDcaCache()
 	{
+		global $kernel;
+
 		$arrFiles = array();
 
 		// Parse all active modules
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strDir = $bundle->getContaoResourcesPath() . '/dca';
 
@@ -696,7 +704,7 @@ class Automator extends \System
 			$objCacheFile->write('<?php '); // add one space to prevent the "unexpected $end" error
 
 			// Parse all active modules
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				$strFile = $bundle->getContaoResourcesPath() . '/dca/' . $strName . '.php';
 
@@ -720,6 +728,8 @@ class Automator extends \System
 	 */
 	public function generateLanguageCache()
 	{
+		global $kernel;
+
 		$arrLanguages = array();
 		$objLanguages = \Database::getInstance()->query("SELECT language FROM tl_member UNION SELECT language FROM tl_user UNION SELECT REPLACE(language, '-', '_') FROM tl_page WHERE type='root'");
 
@@ -747,7 +757,7 @@ class Automator extends \System
 			$arrFiles = array();
 
 			// Parse all active modules
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				$strDir = $bundle->getContaoResourcesPath() . '/languages/' . $strLanguage;
 
@@ -793,7 +803,7 @@ class Automator extends \System
 				$objCacheFile->write(sprintf($strHeader, $strLanguage));
 
 				// Parse all active modules and append to the cache file
-				foreach (\System::getKernel()->getContaoBundles() as $bundle)
+				foreach ($kernel->getContaoBundles() as $bundle)
 				{
 					$strFile = $bundle->getContaoResourcesPath() . '/languages/' . $strLanguage . '/' . $strName;
 
@@ -822,11 +832,13 @@ class Automator extends \System
 	 */
 	public function generateDcaExtracts()
 	{
+		global $kernel;
+
 		$included = array();
 		$arrExtracts = array();
 
 		// Only check the active modules (see #4541)
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strDir = $bundle->getContaoResourcesPath() . '/dca';
 

--- a/contao/library/Contao/Config.php
+++ b/contao/library/Contao/Config.php
@@ -135,7 +135,9 @@ class Config
 		}
 		else
 		{
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			global $kernel;
+
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				$strFile = $bundle->getContaoResourcesPath() . '/config/config.php';
 

--- a/contao/library/Contao/Database/Installer.php
+++ b/contao/library/Contao/Database/Installer.php
@@ -272,6 +272,8 @@ class Installer extends \Controller
 	 */
 	public function getFromDca()
 	{
+		global $kernel;
+
 		$return = array();
 		$included = array();
 
@@ -280,7 +282,7 @@ class Installer extends \Controller
 		\Config::set('bypassCache', true);
 
 		// Only check the active modules (see #4541)
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strDir = $bundle->getContaoResourcesPath() . '/dca';
 
@@ -333,11 +335,13 @@ class Installer extends \Controller
 	 */
 	public function getFromFile()
 	{
+		global $kernel;
+
 		$table = '';
 		$return = array();
 
 		// Only check the active modules (see #4541)
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			// Ignore the database.sql of the not renamed core modules
 			if (in_array($bundle->getName(), array('calendar', 'comments', 'faq', 'listing', 'news', 'newsletter')))

--- a/contao/library/Contao/Database/Updater.php
+++ b/contao/library/Contao/Database/Updater.php
@@ -724,10 +724,12 @@ class Updater extends \Controller
 	 */
 	public function updateFileTreeFields()
 	{
+		global $kernel;
+
 		$arrFiles = array();
 
 		// Parse all modules (see #6058)
-		foreach (\System::getKernel()->getContaoBundles() as $bundle)
+		foreach ($kernel->getContaoBundles() as $bundle)
 		{
 			$strDir = $bundle->getContaoResourcesPath() . '/dca';
 

--- a/contao/library/Contao/DcaLoader.php
+++ b/contao/library/Contao/DcaLoader.php
@@ -81,7 +81,9 @@ class DcaLoader extends \Controller
 		}
 		else
 		{
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			global $kernel;
+
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				$strFile = $bundle->getContaoResourcesPath() . '/dca/' . $this->strTable . '.php';
 

--- a/contao/library/Contao/ModuleLoader.php
+++ b/contao/library/Contao/ModuleLoader.php
@@ -53,7 +53,9 @@ class ModuleLoader
 	{
 		if (empty(static::$active))
 		{
-			foreach (\System::getKernel()->getContaoBundles() as $bundle)
+			global $kernel;
+
+			foreach ($kernel->getContaoBundles() as $bundle)
 			{
 				static::$active[] = $bundle->getName();
 			}

--- a/contao/library/Contao/System.php
+++ b/contao/library/Contao/System.php
@@ -313,7 +313,9 @@ abstract class System
 			}
 			else
 			{
-				foreach (\System::getKernel()->getContaoBundles() as $bundle)
+				global $kernel;
+
+				foreach ($kernel->getContaoBundles() as $bundle)
 				{
 					$strFile = $bundle->getContaoResourcesPath() . '/languages/' . $strCreateLang . '/' . $strName;
 
@@ -853,19 +855,6 @@ abstract class System
 		}
 
 		return null;
-	}
-
-
-	/**
-	 * Return the Symfony kernel
-	 *
-	 * @return ContaoKernelInterface
-	 */
-	public static function getKernel()
-	{
-		global $kernel;
-
-		return $kernel; # FIXME: replace with getContainer()->getKernel()
 	}
 
 


### PR DESCRIPTION
This PR removes the `System::getKernel()` method as discussed. You can still get the kernel object using one of the following:

``` php
// Use the container
$kernel = System::getContainer()->getKernel();

// Use the global variable
global $kernel;
```

The first method assumes that the container is available, which however is not the case during the bundle autoloading process. I have therefore used the global variable variant.

@contao/developers Please vote :)
