### PR TITLE
Added helper methods url() and path() to template class

### DIFF
--- a/contao/library/Contao/Template.php
+++ b/contao/library/Contao/Template.php
@@ -9,6 +9,8 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 
 /**
@@ -199,6 +201,48 @@ abstract class Template extends \Controller
 	public function getFormat()
 	{
 		return $this->strFormat;
+	}
+
+
+	/**
+	 * Return the absolute URL for a route
+	 *
+	 * @param string $strRoute The route name
+	 * @param array $arrParameters The route parameters
+	 *
+	 * @return string The absolute URL for the route
+	 */
+	public function url($strRoute, $arrParameters = array())
+	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		return $kernel->getContainer()->get('router')->generate(
+			$strRoute,
+			$arrParameters,
+			UrlGeneratorInterface::ABSOLUTE_URL
+		);
+	}
+
+
+	/**
+	 * Return the relative path for a route
+	 *
+	 * @param string $strRoute The route name
+	 * @param array $arrParameters The route parameters
+	 *
+	 * @return string The relative path for the route
+	 */
+	public function path($strRoute, $arrParameters = array())
+	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		return $kernel->getContainer()->get('router')->generate(
+			$strRoute,
+			$arrParameters,
+			UrlGeneratorInterface::RELATIVE_PATH
+		);
 	}
 
 


### PR DESCRIPTION
Tested with a simple `fe_page.html5` in `templates` and the following code:

```php
<?php echo $this->url('contao_share'); ?>
<br>
<?php echo $this->path('contao_share'); ?>
<br>
<?php echo $this->url('_profiler_info', array('about' => 'foobar')); ?>
<br>
<?php echo $this->path('_profiler_info', array('about' => 'foobar')); ?>
```

Returns this:
```
http://localhost/contao4/web/app_dev.php/_contao/share
../_contao/share
http://localhost/contao4/web/app_dev.php/_profiler/info/foobar
../_profiler/info/foobar
```