### PR TITLE
Ignore _locale parameter if prepend_locale is off

### DIFF
--- a/contao/classes/Frontend.php
+++ b/contao/classes/Frontend.php
@@ -437,12 +437,7 @@ abstract class Frontend extends \Controller
 
 		$arrParams = array();
 		$arrParams['alias'] = $pageId . $strParams . \Config::get('urlSuffix');
-
-		// Add the language
-		if (\Config::get('addLanguageToUrl'))
-		{
-			$arrParams['_locale'] = $objPage->rootLanguage;
-		}
+		$arrParams['_locale'] = $objPage->rootLanguage;
 
 		$strUrl = $objRouter->generate('contao_frontend', $arrParams);
 		$strUrl = substr($strUrl, strlen(\Environment::get('path')) + 1);

--- a/contao/library/Contao/Controller.php
+++ b/contao/library/Contao/Controller.php
@@ -1110,23 +1110,20 @@ abstract class Controller extends \System
 			$arrParams['alias'] = ($arrRow['alias'] ?: $arrRow['id']) . $strParams . \Config::get('urlSuffix');
 		}
 
-		if (\Config::get('addLanguageToUrl'))
+		if ($strForceLang != '')
 		{
-			if ($strForceLang != '')
-			{
-				$arrParams['_locale'] = $strForceLang;
-			}
-			elseif (isset($arrRow['language']) && $arrRow['type'] == 'root')
-			{
-				$arrParams['_locale'] = $arrRow['language'];
-			}
-			elseif (TL_MODE == 'FE')
-			{
-				/** @var \PageModel $objPage */
-				global $objPage;
+			$arrParams['_locale'] = $strForceLang;
+		}
+		elseif (isset($arrRow['language']) && $arrRow['type'] == 'root')
+		{
+			$arrParams['_locale'] = $arrRow['language'];
+		}
+		elseif (TL_MODE == 'FE')
+		{
+			/** @var \PageModel $objPage */
+			global $objPage;
 
-				$arrParams['_locale'] = $objPage->rootLanguage;
-			}
+			$arrParams['_locale'] = $objPage->rootLanguage;
 		}
 
 		$strUrl = $objRouter->generate('contao_frontend', $arrParams);

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -55,6 +55,7 @@ services:
         arguments:
             - "%prepend_locale%"
             - "%url_suffix%"
+            - "%locale%"
         tags:
             - { name: routing.bundle_loader, priority: -250 }
 

--- a/src/Routing/FrontendLoader.php
+++ b/src/Routing/FrontendLoader.php
@@ -33,15 +33,22 @@ class FrontendLoader extends Loader
     private $format;
 
     /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
      * Constructor.
      *
      * @param bool   $prependLocale Prepend the locale
      * @param string $format        The URL suffix
+     * @param string $defaultLocale The default locale
      */
-    public function __construct($prependLocale, $format)
+    public function __construct($prependLocale, $format, $defaultLocale)
     {
         $this->prependLocale = $prependLocale;
         $this->format        = isset($format[2]) ? substr($format, 1) : '';
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -66,6 +73,8 @@ class FrontendLoader extends Loader
             $pattern = '/{_locale}' . $pattern;
 
             $require['_locale'] = '[a-z]{2}(\-[A-Z]{2})?';
+        } else {
+            $defaults['_locale'] = $this->defaultLocale;
         }
 
         $routes = new RouteCollection();


### PR DESCRIPTION
I read the Symfony UrlGenerator code. If a default is set, the parameter will not be added to the query string.