### PR TITLE
[WIP] Use events to initialize the Contao framework

### DIFF
--- a/src/EventListener/CheckRequestTokenListener.php
+++ b/src/EventListener/CheckRequestTokenListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\Environment;
+use Contao\Input;
+use Contao\RequestToken;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Checks the Contao request token
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class CheckRequestTokenListener
+{
+    /**
+     * Initializes the system upon kernel.request.
+     *
+     * @param GetResponseEvent $event The event object
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        RequestToken::initialize();
+
+        // Check the request token upon POST requests
+        if (!$_POST || RequestToken::validate(Input::post('REQUEST_TOKEN'))) {
+            return;
+        }
+
+        // Force a JavaScript redirect upon Ajax requests (IE requires absolute link)
+        if (Environment::get('isAjaxRequest')) {
+            header('HTTP/1.1 204 No Content');
+            header('X-Ajax-Location: ' . Environment::get('base') . 'contao/');
+            exit;
+        } else {
+            header('HTTP/1.1 400 Bad Request');
+            die_nicely(
+                'be_referer',
+                'Invalid request token. Please <a href="javascript:window.location.href=window.location.href">go back</a> and try again.'
+            );
+        }
+    }
+}

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -163,7 +163,6 @@ class InitializeSystemListener
         }
 
         $this->triggerInitializeSystemHook();
-        $this->checkRequestToken();
     }
 
     /**
@@ -343,32 +342,6 @@ class InitializeSystemListener
 
         if (file_exists($this->rootDir . '/system/config/initconfig.php')) {
             include $this->rootDir . '/system/config/initconfig.php';
-        }
-    }
-
-    /**
-     * Checks the request token.
-     */
-    private function checkRequestToken()
-    {
-        RequestToken::initialize();
-
-        // Check the request token upon POST requests
-        if ($_POST && !RequestToken::validate(Input::post('REQUEST_TOKEN'))) {
-
-            // Force a JavaScript redirect upon Ajax requests (IE requires absolute link)
-            if (Environment::get('isAjaxRequest')) {
-                header('HTTP/1.1 204 No Content');
-                header('X-Ajax-Location: ' . Environment::get('base') . 'contao/');
-            } else {
-                header('HTTP/1.1 400 Bad Request');
-                die_nicely(
-                    'be_referer',
-                    'Invalid request token. Please <a href="javascript:window.location.href=window.location.href">go back</a> and try again.'
-                );
-            }
-
-            exit; // FIXME: throw a ResponseException instead
         }
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -27,10 +27,16 @@ services:
         class: Contao\CoreBundle\EventListener\OutputFromCacheListener
         tags:
             # Priority must be lower than the one of the Contao initialize system listener.
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 26 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 24 }
 
     contao.listener.toggle_view:
         class: Contao\CoreBundle\EventListener\ToggleViewListener
+        tags:
+            # Priority must be lower than the one of the Contao initialize system listener.
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 26 }
+
+    contao.listener.check_request_token:
+        class: Contao\CoreBundle\EventListener\CheckRequestTokenListener
         tags:
             # Priority must be lower than the one of the Contao initialize system listener.
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 28 }


### PR DESCRIPTION
As a proof of concept, I have moved the request token check to a separate event listener. IMHO we could optimize the `InitializeSystemListener` this way:

- Define the SwiftMailer defaults in the `config.yml` file.
- Use a separate event listener to set the relative path in the `Environment` class.
- Use a separate event listener to set the default language.
- Use a separate event listener to validate the installation.
- Use a separate event listener to check the request token (POC included in this PR).

@contao/developers Is this generally something we want?