### PR TITLE
Remove the ignoreInsecureRoot flag

### DIFF
--- a/contao/config/default.php
+++ b/contao/config/default.php
@@ -160,4 +160,3 @@ $GLOBALS['TL_CONFIG']['proxyServerIps']       = '';
 $GLOBALS['TL_CONFIG']['sslProxyDomain']       = '';
 $GLOBALS['TL_CONFIG']['maintenanceMode']      = true;
 $GLOBALS['TL_CONFIG']['errorReporting']       = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED;
-$GLOBALS['TL_CONFIG']['ignoreInsecureRoot']   = false; // FIXME: remove this option?

--- a/contao/languages/en/exception.xlf
+++ b/contao/languages/en/exception.xlf
@@ -126,7 +126,7 @@
         <source>Please set the document root to the &lt;code&gt;web/&lt;/code&gt; subfolder. This is usually done in the domain routing section of your server administration panel or in the vhosts file of your web server.</source>
       </trans-unit>
       <trans-unit id="XPT.insecureExplain">
-        <source>Contao 4 does not rely on &lt;code&gt;.htaccess&lt;/code&gt; files anymore and uses a public subfolder as document root instead. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensible data such as configuration files.</source>
+        <source>Contao 4 does no longer rely on &lt;code&gt;.htaccess&lt;/code&gt; files to protect folders and uses a public subfolder as document root instead. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensible data such as configuration files.</source>
       </trans-unit>
     </body>
   </file>

--- a/contao/languages/en/exception.xlf
+++ b/contao/languages/en/exception.xlf
@@ -125,11 +125,8 @@
       <trans-unit id="XPT.insecureFix">
         <source>Please set the document root to the &lt;code&gt;web/&lt;/code&gt; subfolder. This is usually done in the domain routing section of your server administration panel or in the vhosts file of your web server.</source>
       </trans-unit>
-      <trans-unit id="XPT.insecureExplainOne">
-        <source>Contao 4 does not rely on &lt;code&gt;.htaccess&lt;/code&gt; files anymore and uses a public subfolder as document root instead. If you cannot set the document root to this subfolder, you can bypass this check by adding the following line to your local configuration file:</source>
-      </trans-unit>
-      <trans-unit id="XPT.insecureExplainTwo">
-        <source>However, please note that you &lt;strong&gt;must take additional measures&lt;/strong&gt; to secure your installation in this case. If you do not, any file, including user and configuration files, will be publicy accessible!</source>
+      <trans-unit id="XPT.insecureExplain">
+        <source>Contao 4 does not rely on &lt;code&gt;.htaccess&lt;/code&gt; files anymore and uses a public subfolder as document root instead. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensible data such as configuration files.</source>
       </trans-unit>
     </body>
   </file>

--- a/contao/languages/en/exception.xlf
+++ b/contao/languages/en/exception.xlf
@@ -126,7 +126,7 @@
         <source>Please set the document root to the &lt;code&gt;web/&lt;/code&gt; subfolder. This is usually done in the domain routing section of your server administration panel or in the vhosts file of your web server.</source>
       </trans-unit>
       <trans-unit id="XPT.insecureExplain">
-        <source>Contao 4 does no longer rely on &lt;code&gt;.htaccess&lt;/code&gt; files to protect folders and uses a public subfolder as document root instead. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensible data such as configuration files.</source>
+        <source>Contao 4 does no longer rely on &lt;code&gt;.htaccess&lt;/code&gt; files to protect folders but uses a public subfolder as document root instead. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensible data such as configuration files.</source>
       </trans-unit>
     </body>
   </file>

--- a/contao/templates/backend/be_insecure.html5
+++ b/contao/templates/backend/be_insecure.html5
@@ -40,9 +40,7 @@ $lang = (object) $GLOBALS['TL_LANG']['XPT'];
       <p><?= $lang->insecureFix ?></p>
 
       <h3><?= $lang->more ?></h3>
-      <p><?= $lang->insecureExplainOne ?></p>
-      <pre>$GLOBALS['TL_CONFIG']['ignoreInsecureRoot'] = true;</pre>
-      <p><?= $lang->insecureExplainTwo ?></p>
+      <p><?= $lang->insecureExplain ?></p>
 
     </div>
 

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -297,7 +297,7 @@ class InitializeSystemListener
         }
 
         // Show the "insecure document root" message
-        if ('/web' === substr(Environment::get('path'), -4) && !Config::get('ignoreInsecureRoot')) {
+        if ('/web' === substr(Environment::get('path'), -4)) {
             die_nicely('be_insecure', 'Your installation is not secure. Please set the document root to the <code>/web</code> subfolder.');
         }
 


### PR DESCRIPTION
This PR removes the `ignoreInsecureRoot` flag as discussed in Ahrweiler. @contao/developers Please vote.