### PR TITLE
The legacy code must only be initialized on master request

### DIFF
--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -61,6 +61,10 @@ class InitializeSystemListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         if (!$request->attributes->has('_route')) {


### PR DESCRIPTION
Otherwise subrequests will not be possible because of redeclared functions, `ini_set` after session-start etc.