### PR TITLE
Improve routing

### DIFF
--- a/src/Controller/BackendController.php
+++ b/src/Controller/BackendController.php
@@ -31,6 +31,8 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @Route("/contao", defaults={"_scope" = "backend"})
  */
 class BackendController extends Controller
 {
@@ -39,7 +41,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao", name="contao_backend", defaults={"_scope" = "backend"})
+     * @Route("/", name="contao_backend")
      */
     public function mainAction()
     {
@@ -53,7 +55,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/login", name="contao_backend_login", defaults={"_scope" = "backend"})
+     * @Route("/login", name="contao_backend_login")
      */
     public function loginAction()
     {
@@ -69,7 +71,7 @@ class BackendController extends Controller
      *
      * @todo Make the install tool stand-alone
      *
-     * @Route("/contao/install", name="contao_backend_install", defaults={"_scope" = "backend"})
+     * @Route("/install", name="contao_backend_install")
      */
     public function installAction()
     {
@@ -86,7 +88,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/password", name="contao_backend_password", defaults={"_scope" = "backend"})
+     * @Route("/password", name="contao_backend_password")
      */
     public function passwordAction()
     {
@@ -100,7 +102,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/preview", name="contao_backend_preview", defaults={"_scope" = "backend"})
+     * @Route("/preview", name="contao_backend_preview")
      */
     public function previewAction()
     {
@@ -114,7 +116,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/changelog", name="contao_backend_changelog", defaults={"_scope" = "backend"})
+     * @Route("/changelog", name="contao_backend_changelog")
      */
     public function changelogAction()
     {
@@ -128,7 +130,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/confirm", name="contao_backend_confirm", defaults={"_scope" = "backend"})
+     * @Route("/confirm", name="contao_backend_confirm")
      */
     public function confirmAction()
     {
@@ -142,7 +144,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/file", name="contao_backend_file", defaults={"_scope" = "backend"})
+     * @Route("/file", name="contao_backend_file")
      */
     public function fileAction()
     {
@@ -156,7 +158,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/help", name="contao_backend_help", defaults={"_scope" = "backend"})
+     * @Route("/help", name="contao_backend_help")
      */
     public function helpAction()
     {
@@ -170,7 +172,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/page", name="contao_backend_page", defaults={"_scope" = "backend"})
+     * @Route("/page", name="contao_backend_page")
      */
     public function pageAction()
     {
@@ -184,7 +186,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/popup", name="contao_backend_popup", defaults={"_scope" = "backend"})
+     * @Route("/popup", name="contao_backend_popup")
      */
     public function popupAction()
     {
@@ -198,7 +200,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/contao/switch", name="contao_backend_switch", defaults={"_scope" = "backend"})
+     * @Route("/switch", name="contao_backend_switch")
      */
     public function switchAction()
     {

--- a/src/Controller/FrontendController.php
+++ b/src/Controller/FrontendController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @Route(defaults={"_scope" = "frontend"})
  */
 class FrontendController extends Controller
 {
@@ -42,7 +44,7 @@ class FrontendController extends Controller
      *
      * @return Response
      *
-     * @Route("/_contao/cron", name="contao_frontend_cron", defaults={"_scope" = "frontend"})
+     * @Route("/_contao/cron", name="contao_frontend_cron")
      */
     public function cronAction()
     {
@@ -56,7 +58,7 @@ class FrontendController extends Controller
      *
      * @return Response
      *
-     * @Route("/_contao/share", name="contao_frontend_share", defaults={"_scope" = "frontend"})
+     * @Route("/_contao/share", name="contao_frontend_share")
      */
     public function shareAction()
     {

--- a/src/Routing/FrontendLoader.php
+++ b/src/Routing/FrontendLoader.php
@@ -57,7 +57,7 @@ class FrontendLoader extends Loader
     public function load($resource, $type = null)
     {
         $pattern  = '/{alias}';
-        $defaults = ['_controller' => 'ContaoCoreBundle:Frontend:index'];
+        $defaults = ['_controller' => 'ContaoCoreBundle:Frontend:index', '_scope' => 'frontend'];
         $require  = ['alias' => '.*'];
 
         // URL suffix

--- a/tests/Routing/FrontendLoaderTest.php
+++ b/tests/Routing/FrontendLoaderTest.php
@@ -48,6 +48,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.*', $routes['contao_frontend']->getRequirement('alias'));
         $this->assertEquals('html', $routes['contao_frontend']->getRequirement('_format'));
         $this->assertEquals('', $routes['contao_frontend']->getRequirement('_locale'));
+        $this->assertEquals('frontend', $routes['contao_frontend']->getDefault('_scope'));
     }
 
     /**
@@ -69,6 +70,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.*', $routes['contao_frontend']->getRequirement('alias'));
         $this->assertEquals('html', $routes['contao_frontend']->getRequirement('_format'));
         $this->assertEquals('[a-z]{2}(\-[A-Z]{2})?', $routes['contao_frontend']->getRequirement('_locale'));
+        $this->assertEquals('frontend', $routes['contao_frontend']->getDefault('_scope'));
     }
 
     /**
@@ -90,6 +92,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.*', $routes['contao_frontend']->getRequirement('alias'));
         $this->assertEquals('', $routes['contao_frontend']->getRequirement('_format'));
         $this->assertEquals('', $routes['contao_frontend']->getRequirement('_locale'));
+        $this->assertEquals('frontend', $routes['contao_frontend']->getDefault('_scope'));
     }
 
     /**
@@ -111,6 +114,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.*', $routes['contao_frontend']->getRequirement('alias'));
         $this->assertEquals('', $routes['contao_frontend']->getRequirement('_format'));
         $this->assertEquals('[a-z]{2}(\-[A-Z]{2})?', $routes['contao_frontend']->getRequirement('_locale'));
+        $this->assertEquals('frontend', $routes['contao_frontend']->getDefault('_scope'));
     }
 
     /**


### PR DESCRIPTION
This fixes a missing container scope in the frontend and improves the loader.

We could even go as far as define the backend prefix in the `routing.yml`, which would allow people to change the route to the backend. Which would be a cool feature for Contao 4 to show off whats possible with Symfony ;-)