### PR TITLE
[RTM] Symfony Session Handling

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -48,6 +48,10 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('%s')
                     ->end()
                 ->end()
+                ->scalarNode('csrf_token_name')
+                    ->cannotBeEmpty()
+                    ->defaultValue('contao_csrf_token')
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -46,5 +46,6 @@ class ContaoCoreExtension extends ConfigurableExtension
         $container->setParameter('contao.prepend_locale', $mergedConfig['prepend_locale']);
         $container->setParameter('contao.url_suffix', $mergedConfig['url_suffix']);
         $container->setParameter('contao.upload_path', $mergedConfig['upload_path']);
+        $container->setParameter('contao.csrf_token_name', $mergedConfig['csrf_token_name']);
     }
 }

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -56,6 +56,11 @@ class InitializeSystemListener extends ScopeAwareListener
     private $rootDir;
 
     /**
+     * @var string
+     */
+    private $csrfTokenName;
+
+    /**
      * @var bool
      */
     private static $booted = false;
@@ -66,17 +71,20 @@ class InitializeSystemListener extends ScopeAwareListener
      * @param CsrfTokenManagerInterface $tokenManager The token manager service
      * @param SessionInterface          $session The session service
      * @param string                    $rootDir The kernel root directory
+     * @param string                    $csrfTokenName The name of the token to be used
      */
     public function __construct(
         RouterInterface $router,
         CsrfTokenManagerInterface $tokenManager,
         SessionInterface $session,
-        $rootDir
+        $rootDir,
+        $csrfTokenName = null
     ) {
-        $this->router       = $router;
-        $this->tokenManager = $tokenManager;
-        $this->session      = $session;
-        $this->rootDir      = dirname($rootDir);
+        $this->router        = $router;
+        $this->tokenManager  = $tokenManager;
+        $this->session       = $session;
+        $this->rootDir       = dirname($rootDir);
+        $this->csrfTokenName = $csrfTokenName;
     }
 
     /**
@@ -366,12 +374,12 @@ class InitializeSystemListener extends ScopeAwareListener
         // Backwards compatibility
         if (!defined('REQUEST_TOKEN')) {
             /** @var CsrfToken $token */
-            $token = $this->tokenManager->getToken('_csrf');
+            $token = $this->tokenManager->getToken($this->csrfTokenName);
             define('REQUEST_TOKEN', $token->getValue());
         }
 
         // Check the request token upon POST requests
-        $token = new CsrfToken('_csrf', Input::post('REQUEST_TOKEN'));
+        $token = new CsrfToken($this->csrfTokenName, Input::post('REQUEST_TOKEN'));
 
         // FIXME: This forces all routes handling POST data to pase a REQUEST_TOKEN
         if ($_POST && !$this->tokenManager->isTokenValid($token)) {

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -13,7 +13,7 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\ClassLoader;
 use Contao\Config;
 use Contao\CoreBundle\Command\ContaoFrameworkDependentInterface;
-use Contao\CoreBundle\Session\Attribute\AttributeBagMirror;
+use Contao\CoreBundle\Session\Attribute\AttributeBagAdapter;
 use Contao\Environment;
 use Contao\Input;
 use Contao\System;
@@ -406,7 +406,7 @@ class InitializeSystemListener extends ScopeAwareListener
         /** @var AttributeBagInterface $beBag */
         $beBag = $this->session->getBag('contao_backend');
 
-        $_SESSION['FE_DATA'] = new AttributeBagMirror($feBag);
-        $_SESSION['BE_DATA'] = new AttributeBagMirror($beBag);
+        $_SESSION['FE_DATA'] = new AttributeBagAdapter($feBag);
+        $_SESSION['BE_DATA'] = new AttributeBagAdapter($beBag);
     }
 }

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -62,9 +62,10 @@ class InitializeSystemListener extends ScopeAwareListener
 
     /**
      * Constructor.
-     *
-     * @param RouterInterface $router  The router object
-     * @param string          $rootDir The kernel root directory
+     * @param RouterInterface           $router The router service
+     * @param CsrfTokenManagerInterface $tokenManager The token manager service
+     * @param SessionInterface          $session The session service
+     * @param string                    $rootDir The kernel root directory
      */
     public function __construct(
         RouterInterface $router,

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -163,9 +163,6 @@ class InitializeSystemListener extends ScopeAwareListener
         // Log PHP errors
         $this->iniSet('error_log', $this->rootDir . '/system/logs/error.log');
 
-        // Support legacy Session access
-        $this->initializeLegacySessionAccess();
-
         $this->includeBasicClasses();
 
         // Preload the configuration (see #5872)
@@ -175,7 +172,7 @@ class InitializeSystemListener extends ScopeAwareListener
         ClassLoader::scanAndRegister();
 
         $this->setRelativePath($request ? $request->getBasePath() : '');
-        $this->startSession();
+        $this->initializeLegacySessionAccess();
         $this->setDefaultLanguage();
 
         // Fully load the configuration

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -19,6 +19,7 @@ use Contao\Input;
 use Contao\System;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Routing\RouterInterface;
@@ -399,7 +400,10 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     private function initializeLegacySessionAccess()
     {
+        /** @var AttributeBagInterface $feBag */
         $feBag = $this->session->getBag('contao_frontend');
+
+        /** @var AttributeBagInterface $beBag */
         $beBag = $this->session->getBag('contao_backend');
 
         $_SESSION['FE_DATA'] = new AttributeBagMirror($feBag);

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -374,6 +374,7 @@ class InitializeSystemListener extends ScopeAwareListener
         // Check the request token upon POST requests
         $token = new CsrfToken('_csrf', Input::post('REQUEST_TOKEN'));
 
+        // FIXME: This forces all routes handling POST data to pase a REQUEST_TOKEN
         if ($_POST && !$this->tokenManager->isTokenValid($token)) {
 
             // Force a JavaScript redirect upon Ajax requests (IE requires absolute link)

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -348,7 +348,7 @@ class InitializeSystemListener extends ScopeAwareListener
     }
 
     /**
-     * handles the request token.
+     * Handles the request token.
      */
     private function handleRequestToken()
     {

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -78,7 +78,7 @@ class InitializeSystemListener extends ScopeAwareListener
         CsrfTokenManagerInterface $tokenManager,
         SessionInterface $session,
         $rootDir,
-        $csrfTokenName = null
+        $csrfTokenName
     ) {
         $this->router        = $router;
         $this->tokenManager  = $tokenManager;

--- a/src/EventListener/SessionListener.php
+++ b/src/EventListener/SessionListener.php
@@ -38,7 +38,7 @@ class SessionListener
     /**
      * Registers the Contao front end and back end session bags.
      */
-    public function onKernelRequest()
+    public function registerContaoAttributeBags()
     {
         $beBag = new AttributeBag('_contao_be_attributes');
         $beBag->setName('contao_backend');

--- a/src/EventListener/SessionListener.php
+++ b/src/EventListener/SessionListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * Registers the Contao front end and back end session bags.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class SessionListener
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * Constructor.
+     *
+     * @param SessionInterface $session
+     */
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Registers the Contao front end and back end session bags.
+     */
+    public function onKernelRequest()
+    {
+        $beBag = new AttributeBag('_contao_be_attributes');
+        $beBag->setName('contao_backend');
+        $feBag = new AttributeBag('_contao_fe_attributes');
+        $feBag->setName('contao_frontend');
+
+        $this->session->registerBag($beBag);
+        $this->session->registerBag($feBag);
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
             - "@security.csrf.token_manager"
             - "@session"
             - "%kernel.root_dir%"
+            - "%contao.csrf_token_name%"
         calls:
             - [setContainer, ["@service_container"]]
         tags:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -36,6 +36,13 @@ services:
             # Priority must be lower than the one of the toggle_view listener.
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 24 }
 
+    contao.listener.session:
+        class: Contao\CoreBundle\EventListener\SessionListener
+        arguments:
+            - "@session"
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 64 }
+
     contao.listener.toggle_view:
         class: Contao\CoreBundle\EventListener\ToggleViewListener
         calls:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -42,6 +42,8 @@ services:
         arguments:
             - "@session"
         tags:
+            # Priority must be lower than Symfony\Bundle\FrameworkBundle\EventListener\SessionListener (default 128)
+            # but higher than the one of the Contao initialize system listener.
             - { name: kernel.event_listener, event: kernel.request, method: registerContaoAttributeBags, priority: 64 }
             - { name: kernel.event_listener, event: console.command, method: registerContaoAttributeBags, priority: 64 }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -42,7 +42,8 @@ services:
         arguments:
             - "@session"
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 64 }
+            - { name: kernel.event_listener, event: kernel.request, method: registerContaoAttributeBags, priority: 64 }
+            - { name: kernel.event_listener, event: console.command, method: registerContaoAttributeBags, priority: 64 }
 
     contao.listener.toggle_view:
         class: Contao\CoreBundle\EventListener\ToggleViewListener

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -18,6 +18,7 @@ services:
         class: Contao\CoreBundle\EventListener\InitializeSystemListener
         arguments:
             - "@router"
+            - "@security.csrf.token_manager"
             - "%kernel.root_dir%"
         calls:
             - [setContainer, ["@service_container"]]

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,6 +19,7 @@ services:
         arguments:
             - "@router"
             - "@security.csrf.token_manager"
+            - "@session"
             - "%kernel.root_dir%"
         calls:
             - [setContainer, ["@service_container"]]

--- a/src/Resources/contao/classes/RebuildIndex.php
+++ b/src/Resources/contao/classes/RebuildIndex.php
@@ -9,6 +9,8 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 
 /**
@@ -93,8 +95,14 @@ class RebuildIndex extends \Backend implements \executable
 			// Hide unpublished elements
 			$this->setCookie('FE_PREVIEW', 0, ($time - 86400));
 
+			/** @var KernelInterface $kernel */
+			global $kernel;
+
+			/** @var SessionInterface $session */
+			$session = $kernel->getContainer()->get('session');
+
 			// Calculate the hash
-			$strHash = sha1(session_id() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
+			$strHash = sha1($session->getId() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
 
 			// Remove old sessions
 			$this->Database->prepare("DELETE FROM tl_session WHERE tstamp<? OR hash=?")
@@ -105,7 +113,7 @@ class RebuildIndex extends \Backend implements \executable
 			{
 				// Insert a new session
 				$this->Database->prepare("INSERT INTO tl_session (pid, tstamp, name, sessionID, ip, hash) VALUES (?, ?, ?, ?, ?, ?)")
-							   ->execute(\Input::get('user'), $time, 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
+							   ->execute(\Input::get('user'), $time, 'FE_USER_AUTH', $session->getId(), \Environment::get('ip'), $strHash);
 
 				// Set the cookie
 				$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);

--- a/src/Resources/contao/controllers/BackendIndex.php
+++ b/src/Resources/contao/controllers/BackendIndex.php
@@ -55,7 +55,7 @@ class BackendIndex extends \Backend
 			$this->reload();
 		}
 
-		// Reload the page once after a logout to create a new session_id()
+		// Reload the page once after a logout to create a new session ID
 		elseif ($this->User->logout())
 		{
 			$this->reload();

--- a/src/Resources/contao/controllers/BackendInstall.php
+++ b/src/Resources/contao/controllers/BackendInstall.php
@@ -9,6 +9,8 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 
 /**
@@ -687,8 +689,14 @@ class BackendInstall extends \Backend
 	 */
 	protected function setAuthCookie()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
+
 		$_SESSION['TL_INSTALL_EXPIRE'] = (time() + 300);
-		$_SESSION['TL_INSTALL_AUTH'] = md5(uniqid(mt_rand(), true) . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . session_id());
+		$_SESSION['TL_INSTALL_AUTH'] = md5(uniqid(mt_rand(), true) . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . $session->getId());
 		$this->setCookie('TL_INSTALL_AUTH', $_SESSION['TL_INSTALL_AUTH'], $_SESSION['TL_INSTALL_EXPIRE'], null, null, false, true);
 	}
 

--- a/src/Resources/contao/controllers/BackendMain.php
+++ b/src/Resources/contao/controllers/BackendMain.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 
 /**
@@ -52,8 +54,14 @@ class BackendMain extends \Backend
 		// Password change required
 		if ($this->User->pwChange)
 		{
+			/** @var KernelInterface $kernel */
+			global $kernel;
+
+			/** @var SessionInterface $session */
+			$session = $kernel->getContainer()->get('session');
+
 			$objSession = $this->Database->prepare("SELECT su FROM tl_session WHERE sessionID=? AND pid=?")
-										 ->execute(session_id(), $this->User->id);
+										 ->execute($session->getId(), $this->User->id);
 
 			if (!$objSession->su)
 			{

--- a/src/Resources/contao/controllers/BackendPreview.php
+++ b/src/Resources/contao/controllers/BackendPreview.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -83,7 +84,13 @@ class BackendPreview extends \Backend
 
 			if ($objUser !== null)
 			{
-				$strHash = sha1(session_id() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
+				/** @var KernelInterface $kernel */
+				global $kernel;
+
+				/** @var SessionInterface $session */
+				$session = $kernel->getContainer()->get('session');
+
+				$strHash = sha1($session->getId() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
 
 				// Remove old sessions
 				$this->Database->prepare("DELETE FROM tl_session WHERE tstamp<? OR hash=?")
@@ -91,7 +98,7 @@ class BackendPreview extends \Backend
 
 				// Insert the new session
 				$this->Database->prepare("INSERT INTO tl_session (pid, tstamp, name, sessionID, ip, hash) VALUES (?, ?, ?, ?, ?, ?)")
-							   ->execute($objUser->id, time(), 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
+							   ->execute($objUser->id, time(), 'FE_USER_AUTH', $session->getId(), \Environment::get('ip'), $strHash);
 
 				// Set the cookie
 				$this->setCookie('FE_USER_AUTH', $strHash, (time() + \Config::get('sessionTimeout')), null, null, false, true);

--- a/src/Resources/contao/controllers/BackendSwitch.php
+++ b/src/Resources/contao/controllers/BackendSwitch.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 
@@ -55,8 +56,14 @@ class BackendSwitch extends \Backend
 			$this->getDatalistOptions();
 		}
 
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
+
 		$strUser = '';
-		$strHash = sha1(session_id() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
+		$strHash = sha1($session->getId() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
 
 		// Get the front end user
 		if (FE_USER_LOGGED_IN)
@@ -112,7 +119,7 @@ class BackendSwitch extends \Backend
 					{
 						// Insert the new session
 						$this->Database->prepare("INSERT INTO tl_session (pid, tstamp, name, sessionID, ip, hash) VALUES (?, ?, ?, ?, ?, ?)")
-									   ->execute($objUser->id, $time, 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
+									   ->execute($objUser->id, $time, 'FE_USER_AUTH', $session->getId(), \Environment::get('ip'), $strHash);
 
 						// Set the cookie
 						$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -9,6 +9,8 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 
 /**
@@ -686,33 +688,23 @@ class File extends \System
 	 */
 	public function sendToBrowser($filename=null)
 	{
-		// Make sure no output buffer is active
-		// @see http://ch2.php.net/manual/en/function.fpassthru.php#74080
-		while (@ob_end_clean());
+		$response = new BinaryFileResponse(TL_ROOT . '/' . $this->strFile);
 
-		// FIXME: Session closing is irrelevant here when switching to StreamedResponse
-		// Prevent session locking (see #2804)
-		//session_write_close();
+		$response->setContentDisposition
+		(
+			ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+			$filename,
+			$this->basename
+		);
 
-		// Disable zlib.output_compression (see #6717)
-		ini_set('zlib.output_compression', 'Off');
+		$response->headers->addCacheControlDirective('must-revalidate');
+		$response->headers->addCacheControlDirective('post-check', 0);
+		$response->headers->addCacheControlDirective('pre-check', 0);
 
-		// Open the "save as …" dialogue
-		header('Content-Type: ' . $this->mime);
-		header('Content-Transfer-Encoding: binary');
-		header('Content-Disposition: attachment; filename="' . ($filename ?: $this->basename) . '"');
-		header('Content-Length: ' . $this->filesize);
-		header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-		header('Pragma: public');
-		header('Expires: 0');
-		header('Connection: close');
+		$response->headers->set('Connection', 'close');
 
-		// Output the file
-		$resFile = fopen(TL_ROOT . '/' . $this->strFile, 'rb');
-		fpassthru($resFile);
-		fclose($resFile);
-
-		// Stop the script
+		// FIXME: Throw a ResponseException here
+		$response->send();
 		exit;
 	}
 

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -690,8 +690,9 @@ class File extends \System
 		// @see http://ch2.php.net/manual/en/function.fpassthru.php#74080
 		while (@ob_end_clean());
 
+		// FIXME: Session closing should be irrelevant here when switching to StreamedResponse?
 		// Prevent session locking (see #2804)
-		session_write_close();
+		//session_write_close();
 
 		// Disable zlib.output_compression (see #6717)
 		ini_set('zlib.output_compression', 'Off');

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -690,7 +690,7 @@ class File extends \System
 		// @see http://ch2.php.net/manual/en/function.fpassthru.php#74080
 		while (@ob_end_clean());
 
-		// FIXME: Session closing should be irrelevant here when switching to StreamedResponse?
+		// FIXME: Session closing is irrelevant here when switching to StreamedResponse
 		// Prevent session locking (see #2804)
 		//session_write_close();
 

--- a/src/Resources/contao/library/Contao/RequestToken.php
+++ b/src/Resources/contao/library/Contao/RequestToken.php
@@ -59,7 +59,7 @@ class RequestToken
 		$tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
 
 		/** @var CsrfToken $token */
-		$token = $tokenManager->getToken('_csrf');
+		$token = $tokenManager->getToken($kernel->getContainer()->getParameter('contao.csrf_token_name'));
 
 		return $token->getValue();
 	}
@@ -100,7 +100,7 @@ class RequestToken
 		/** @var CsrfTokenManagerInterface $tokenManager */
 		$tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
 
-		$token = new CsrfToken('_csrf', $strToken);
+		$token = new CsrfToken($kernel->getContainer()->getParameter('contao.csrf_token_name'), $strToken);
 
 		return $tokenManager->isTokenValid($token);
 	}

--- a/src/Resources/contao/library/Contao/RequestToken.php
+++ b/src/Resources/contao/library/Contao/RequestToken.php
@@ -52,16 +52,16 @@ class RequestToken
 	 */
 	public static function get()
 	{
-        /** @var KernelInterface $kernel */
-        global $kernel;
+		/** @var KernelInterface $kernel */
+		global $kernel;
 
-        /** @var CsrfTokenManagerInterface $tokenManager */
-        $tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
+		/** @var CsrfTokenManagerInterface $tokenManager */
+		$tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
 
-        /** @var CsrfToken $token */
-        $token = $tokenManager->getToken('_csrf');
+		/** @var CsrfToken $token */
+		$token = $tokenManager->getToken('_csrf');
 
-        return $token->getValue();
+		return $token->getValue();
 	}
 
 
@@ -74,34 +74,34 @@ class RequestToken
 	 */
 	public static function validate($strToken)
 	{
-        // The feature has been disabled
-        if (\Config::get('disableRefererCheck') || defined('BYPASS_TOKEN_CHECK'))
-        {
-            return true;
-        }
+		// The feature has been disabled
+		if (\Config::get('disableRefererCheck') || defined('BYPASS_TOKEN_CHECK'))
+		{
+			return true;
+		}
 
-        // Check against the whitelist (thanks to Tristan Lins) (see #3164)
-        if (\Config::get('requestTokenWhitelist'))
-        {
-            $strHostname = gethostbyaddr($_SERVER['REMOTE_ADDR']);
+		// Check against the whitelist (thanks to Tristan Lins) (see #3164)
+		if (\Config::get('requestTokenWhitelist'))
+		{
+			$strHostname = gethostbyaddr($_SERVER['REMOTE_ADDR']);
 
-            foreach (\Config::get('requestTokenWhitelist') as $strDomain)
-            {
-                if ($strDomain == $strHostname || preg_match('/\.' . preg_quote($strDomain, '/') . '$/', $strHostname))
-                {
-                    return true;
-                }
-            }
-        }
+			foreach (\Config::get('requestTokenWhitelist') as $strDomain)
+			{
+				if ($strDomain == $strHostname || preg_match('/\.' . preg_quote($strDomain, '/') . '$/', $strHostname))
+				{
+					return true;
+				}
+			}
+		}
 
-        /** @var KernelInterface $kernel */
-        global $kernel;
+		/** @var KernelInterface $kernel */
+		global $kernel;
 
-        /** @var CsrfTokenManagerInterface $tokenManager */
-        $tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
+		/** @var CsrfTokenManagerInterface $tokenManager */
+		$tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
 
-        $token = new CsrfToken('_csrf', $strToken);
+		$token = new CsrfToken('_csrf', $strToken);
 
-        return $tokenManager->isTokenValid($token);
+		return $tokenManager->isTokenValid($token);
 	}
 }

--- a/src/Resources/contao/library/Contao/RequestToken.php
+++ b/src/Resources/contao/library/Contao/RequestToken.php
@@ -9,6 +9,9 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 
 /**
@@ -27,49 +30,18 @@ namespace Contao;
  *     }
  *
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @deprecated Deprecated since version 4.0, to be removed in version 5.0, use
+ * the Symfony CSRF service via the container instead!
  */
 class RequestToken
 {
-
-	/**
-	 * Object instance (Singleton)
-	 * @var \RequestToken
-	 */
-	protected static $objInstance;
-
-	/**
-	 * Token
-	 * @var string
-	 */
-	protected static $strToken;
-
-
 	/**
 	 * Read the token from the session or generate a new one
 	 */
 	public static function initialize()
 	{
-		static::$strToken = @$_SESSION['REQUEST_TOKEN'];
-
 		// Backwards compatibility
-		if (is_array(static::$strToken))
-		{
-			static::$strToken = null;
-			unset($_SESSION['REQUEST_TOKEN']);
-		}
-
-		// Generate a new token
-		if (static::$strToken == '')
-		{
-			static::$strToken = md5(uniqid(mt_rand(), true));
-			$_SESSION['REQUEST_TOKEN'] = static::$strToken;
-		}
-
-		// Set the REQUEST_TOKEN constant
-		if (!defined('REQUEST_TOKEN'))
-		{
-			define('REQUEST_TOKEN', static::$strToken);
-		}
 	}
 
 
@@ -80,7 +52,16 @@ class RequestToken
 	 */
 	public static function get()
 	{
-		return static::$strToken;
+        /** @var KernelInterface $kernel */
+        global $kernel;
+
+        /** @var CsrfTokenManagerInterface $tokenManager */
+        $tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
+
+        /** @var CsrfToken $token */
+        $token = $tokenManager->getToken('_csrf');
+
+        return $token->getValue();
 	}
 
 
@@ -93,69 +74,34 @@ class RequestToken
 	 */
 	public static function validate($strToken)
 	{
-		// The feature has been disabled
-		if (\Config::get('disableRefererCheck') || defined('BYPASS_TOKEN_CHECK'))
-		{
-			return true;
-		}
+        // The feature has been disabled
+        if (\Config::get('disableRefererCheck') || defined('BYPASS_TOKEN_CHECK'))
+        {
+            return true;
+        }
 
-		// Validate the token
-		if ($strToken != '' && static::$strToken != '' && $strToken == static::$strToken)
-		{
-			return true;
-		}
+        // Check against the whitelist (thanks to Tristan Lins) (see #3164)
+        if (\Config::get('requestTokenWhitelist'))
+        {
+            $strHostname = gethostbyaddr($_SERVER['REMOTE_ADDR']);
 
-		// Check against the whitelist (thanks to Tristan Lins) (see #3164)
-		if (\Config::get('requestTokenWhitelist'))
-		{
-			$strHostname = gethostbyaddr($_SERVER['REMOTE_ADDR']);
+            foreach (\Config::get('requestTokenWhitelist') as $strDomain)
+            {
+                if ($strDomain == $strHostname || preg_match('/\.' . preg_quote($strDomain, '/') . '$/', $strHostname))
+                {
+                    return true;
+                }
+            }
+        }
 
-			foreach (\Config::get('requestTokenWhitelist') as $strDomain)
-			{
-				if ($strDomain == $strHostname || preg_match('/\.' . preg_quote($strDomain, '/') . '$/', $strHostname))
-				{
-					return true;
-				}
-			}
-		}
+        /** @var KernelInterface $kernel */
+        global $kernel;
 
-		return false;
-	}
+        /** @var CsrfTokenManagerInterface $tokenManager */
+        $tokenManager = $kernel->getContainer()->get('security.csrf.token_manager');
 
+        $token = new CsrfToken('_csrf', $strToken);
 
-	/**
-	 * Load the token or generate a new one
-	 *
-	 * @deprecated RequestToken is now a static class
-	 */
-	protected function __construct()
-	{
-		static::initialize();
-	}
-
-
-	/**
-	 * Prevent cloning of the object (Singleton)
-	 *
-	 * @deprecated RequestToken is now a static class
-	 */
-	final public function __clone() {}
-
-
-	/**
-	 * Return the object instance (Singleton)
-	 *
-	 * @return \RequestToken The object instance
-	 *
-	 * @deprecated RequestToken is now a static class
-	 */
-	public static function getInstance()
-	{
-		if (static::$objInstance === null)
-		{
-			static::$objInstance = new static();
-		}
-
-		return static::$objInstance;
+        return $tokenManager->isTokenValid($token);
 	}
 }

--- a/src/Resources/contao/library/Contao/Session.php
+++ b/src/Resources/contao/library/Contao/Session.php
@@ -155,10 +155,7 @@ class Session
 		/** @var AttributeBagInterface $bag */
 		$bag = $this->session->getBag($this->getSessionBagKey());
 
-		foreach ($arrData as $k => $v)
-		{
-			$bag->set($k, $v);
-		}
+		$bag->replace($arrData);
 	}
 
 

--- a/src/Resources/contao/library/Contao/Session.php
+++ b/src/Resources/contao/library/Contao/Session.php
@@ -12,7 +12,6 @@ namespace Contao;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 
 
 /**
@@ -47,12 +46,6 @@ class Session
 	 */
 	protected $arrSession;
 
-	/**
-	 * Symfony session service
-	 * @var SessionInterface
-	 */
-	private $session;
-
 
 	/**
 	 * Get the session data
@@ -65,8 +58,11 @@ class Session
 		/** @var SessionInterface $session */
 		$session = $kernel->getContainer()->get('session');
 
-		$beBag = new AttributeBag('_contao_be_attributes');
-		$feBag = new AttributeBag('_contao_fe_attributes');
+		/** @var AttributeBagInterface $beBag */
+		$beBag = $session->getBag('contao_backend');
+
+		/** @var AttributeBagInterface $feBag */
+		$feBag = $session->getBag('contao_frontend');
 
 		switch (TL_MODE)
 		{
@@ -82,11 +78,6 @@ class Session
 				$this->arrSession = (array) $_SESSION;
 				break;
 		}
-
-		$session->registerBag($beBag);
-		$session->registerBag($feBag);
-
-		$this->session = $session;
 	}
 
 
@@ -95,11 +86,17 @@ class Session
 	 */
 	public function __destruct()
 	{
-		/** @var AttributeBagInterface $beBag */
-		$beBag = $this->session->getBag('_contao_be_attributes');
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
 
 		/** @var AttributeBagInterface $beBag */
-		$feBag = $this->session->getBag('_contao_fe_attributes');
+		$beBag = $session->getBag('contao_backend');
+
+		/** @var AttributeBagInterface $feBag */
+		$feBag = $session->getBag('contao_frontend');
 
 		switch (TL_MODE)
 		{

--- a/src/Resources/contao/library/Contao/Session.php
+++ b/src/Resources/contao/library/Contao/Session.php
@@ -47,11 +47,11 @@ class Session
 	 */
 	protected $arrSession;
 
-    /**
-     * Symfony session service
-     * @var SessionInterface
-     */
-    private $session;
+	/**
+	 * Symfony session service
+	 * @var SessionInterface
+	 */
+	private $session;
 
 
 	/**
@@ -59,14 +59,14 @@ class Session
 	 */
 	protected function __construct()
 	{
-        /** @var KernelInterface $kernel */
-        global $kernel;
+		/** @var KernelInterface $kernel */
+		global $kernel;
 
-        /** @var SessionInterface $session */
-        $session = $kernel->getContainer()->get('session');
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
 
-        $beBag = new AttributeBag('_contao_be_attributes');
-        $feBag = new AttributeBag('_contao_fe_attributes');
+		$beBag = new AttributeBag('_contao_be_attributes');
+		$feBag = new AttributeBag('_contao_fe_attributes');
 
 		switch (TL_MODE)
 		{
@@ -83,10 +83,10 @@ class Session
 				break;
 		}
 
-        $session->registerBag($beBag);
-        $session->registerBag($feBag);
+		$session->registerBag($beBag);
+		$session->registerBag($feBag);
 
-        $this->session = $session;
+		$this->session = $session;
 	}
 
 
@@ -95,11 +95,11 @@ class Session
 	 */
 	public function __destruct()
 	{
-        /** @var AttributeBagInterface $beBag */
-        $beBag = $this->session->getBag('_contao_be_attributes');
+		/** @var AttributeBagInterface $beBag */
+		$beBag = $this->session->getBag('_contao_be_attributes');
 
-        /** @var AttributeBagInterface $beBag */
-        $feBag = $this->session->getBag('_contao_fe_attributes');
+		/** @var AttributeBagInterface $beBag */
+		$feBag = $this->session->getBag('_contao_fe_attributes');
 
 		switch (TL_MODE)
 		{
@@ -108,7 +108,7 @@ class Session
 				break;
 
 			case 'FE':
-                $feBag->replace($this->arrSession);
+				$feBag->replace($this->arrSession);
 				break;
 
 			default:

--- a/src/Resources/contao/library/Contao/Session.php
+++ b/src/Resources/contao/library/Contao/Session.php
@@ -41,12 +41,6 @@ class Session
 	protected static $objInstance;
 
 	/**
-	 * Session data
-	 * @var array
-	 */
-	protected $arrSession;
-
-	/**
 	 * Symfony session object
 	 * @var SessionInterface
 	 */

--- a/src/Resources/contao/library/Contao/User.php
+++ b/src/Resources/contao/library/Contao/User.php
@@ -637,15 +637,13 @@ abstract class User extends \System
 		$this->setCookie($this->strCookie, $this->strHash, ($time - 86400), null, null, false, true);
 		$this->strHash = '';
 
-		// FIXME: What do we need to do with the session handling here?
+		/** @var KernelInterface $kernel */
+		global $kernel;
 
-		// Destroy the current session
-		session_destroy();
-		session_write_close();
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
 
-		// Reset the session cookie
-		$params = session_get_cookie_params();
-		$this->setCookie(session_name(), session_id(), ($time - 86400), $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+		$session->invalidate();
 
 		// Add a log entry
 		if ($this->findBy('id', $intUserid) != false)

--- a/src/Resources/contao/library/Contao/User.php
+++ b/src/Resources/contao/library/Contao/User.php
@@ -9,6 +9,8 @@
  */
 
 namespace Contao;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 
 /**
@@ -253,8 +255,14 @@ abstract class User extends \System
 	 */
 	public function authenticate()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
+
 		// Check the cookie hash
-		if ($this->strHash != sha1(session_id() . (!\Config::get('disableIpCheck') ? $this->strIp : '') . $this->strCookie))
+		if ($this->strHash != sha1($session->getId() . (!\Config::get('disableIpCheck') ? $this->strIp : '') . $this->strCookie))
 		{
 			return false;
 		}
@@ -273,7 +281,7 @@ abstract class User extends \System
 		$time = time();
 
 		// Validate the session
-		if ($objSession->sessionID != session_id() || (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp) || $objSession->hash != $this->strHash || ($objSession->tstamp + \Config::get('sessionTimeout')) < $time)
+		if ($objSession->sessionID != $session->getId() || (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp) || $objSession->hash != $this->strHash || ($objSession->tstamp + \Config::get('sessionTimeout')) < $time)
 		{
 			$this->log('Could not verify the session', __METHOD__, TL_ACCESS);
 
@@ -294,7 +302,7 @@ abstract class User extends \System
 
 		// Update session
 		$this->Database->prepare("UPDATE tl_session SET tstamp=$time WHERE sessionID=?")
-					   ->execute(session_id());
+					   ->execute($session->getId());
 
 		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
 
@@ -568,10 +576,16 @@ abstract class User extends \System
 	 */
 	protected function generateSession()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $session */
+		$session = $kernel->getContainer()->get('session');
+
 		$time = time();
 
 		// Generate the cookie hash
-		$this->strHash = sha1(session_id() . (!\Config::get('disableIpCheck') ? $this->strIp : '') . $this->strCookie);
+		$this->strHash = sha1($session->getId() . (!\Config::get('disableIpCheck') ? $this->strIp : '') . $this->strCookie);
 
 		// Clean up old sessions
 		$this->Database->prepare("DELETE FROM tl_session WHERE tstamp<? OR hash=?")
@@ -579,7 +593,7 @@ abstract class User extends \System
 
 		// Save the session in the database
 		$this->Database->prepare("INSERT INTO tl_session (pid, tstamp, name, sessionID, ip, hash) VALUES (?, ?, ?, ?, ?, ?)")
-					   ->execute($this->intId, $time, $this->strCookie, session_id(), $this->strIp, $this->strHash);
+					   ->execute($this->intId, $time, $this->strCookie, $session->getId(), $this->strIp, $this->strHash);
 
 		// Set the authentication cookie
 		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
@@ -622,6 +636,8 @@ abstract class User extends \System
 		// Remove cookie and hash
 		$this->setCookie($this->strCookie, $this->strHash, ($time - 86400), null, null, false, true);
 		$this->strHash = '';
+
+		// FIXME: What do we need to do with the session handling here?
 
 		// Destroy the current session
 		session_destroy();

--- a/src/Resources/contao/templates/analytics/analytics_google.html5
+++ b/src/Resources/contao/templates/analytics/analytics_google.html5
@@ -9,8 +9,14 @@ $GoogleAnalyticsId = 'UA-XXXXX-X';
 /**
  * DO NOT EDIT ANYTHING BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!
  */
-// FIXME: Add a helper method here so the manual session check does not need to be done in the template?
-if ($GoogleAnalyticsId != 'UA-XXXXX-X' && !BE_USER_LOGGED_IN && sha1(session_id() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
+// FIXME: Add a helper method here so the manual session check does not need to be done in the template
+/** @var KernelInterface $kernel */
+global $kernel;
+
+/** @var SessionInterface $session */
+$session = $kernel->getContainer()->get('session');
+
+if ($GoogleAnalyticsId != 'UA-XXXXX-X' && !BE_USER_LOGGED_IN && sha1($session->getId() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');

--- a/src/Resources/contao/templates/analytics/analytics_google.html5
+++ b/src/Resources/contao/templates/analytics/analytics_google.html5
@@ -9,6 +9,7 @@ $GoogleAnalyticsId = 'UA-XXXXX-X';
 /**
  * DO NOT EDIT ANYTHING BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!
  */
+// FIXME: Add a helper method here so the manual session check does not need to be done in the template?
 if ($GoogleAnalyticsId != 'UA-XXXXX-X' && !BE_USER_LOGGED_IN && sha1(session_id() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
 
 <script>

--- a/src/Resources/contao/templates/analytics/analytics_piwik.html5
+++ b/src/Resources/contao/templates/analytics/analytics_piwik.html5
@@ -9,8 +9,15 @@ $PiwikPath = 'www.example.com/piwik/';
 
 /**
  * DO NOT EDIT ANYTHING BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!
- */// FIXME: Add a helper method here so the manual session check does not need to be done in the template?
-if ($PiwikSite > 0 && $PiwikPath != 'www.example.com/piwik/' && !BE_USER_LOGGED_IN && sha1(session_id() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
+ */
+// FIXME: Add a helper method here so the manual session check does not need to be done in the template
+/** @var KernelInterface $kernel */
+global $kernel;
+
+/** @var SessionInterface $session */
+$session = $kernel->getContainer()->get('session');
+
+if ($PiwikSite > 0 && $PiwikPath != 'www.example.com/piwik/' && !BE_USER_LOGGED_IN && sha1($session->getId() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
 
 <script>
   var _paq = _paq || [];

--- a/src/Resources/contao/templates/analytics/analytics_piwik.html5
+++ b/src/Resources/contao/templates/analytics/analytics_piwik.html5
@@ -9,7 +9,7 @@ $PiwikPath = 'www.example.com/piwik/';
 
 /**
  * DO NOT EDIT ANYTHING BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!
- */
+ */// FIXME: Add a helper method here so the manual session check does not need to be done in the template?
 if ($PiwikSite > 0 && $PiwikPath != 'www.example.com/piwik/' && !BE_USER_LOGGED_IN && sha1(session_id() . (!Config::get('disableIpCheck') ? Environment::get('ip') : '') . 'BE_USER_AUTH') != Input::cookie('BE_USER_AUTH')): ?>
 
 <script>

--- a/src/Session/Attribute/AttributeBagAdapter.php
+++ b/src/Session/Attribute/AttributeBagAdapter.php
@@ -9,6 +9,7 @@
  */
 
 namespace Contao\CoreBundle\Session\Attribute;
+
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 /**
@@ -17,7 +18,7 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
  *
  * @author Yanick Witschi <https://github.com/toflar>
  */
-class AttributeBagMirror implements \ArrayAccess
+class AttributeBagAdapter implements \ArrayAccess
 {
     /**
      * @var AttributeBagInterface
@@ -26,7 +27,7 @@ class AttributeBagMirror implements \ArrayAccess
 
 
     /**
-     * Creates an AttributeBagMirror with a target bag
+     * Creates an AttributeBagAdapter with a target bag
      *
      * @param AttributeBagInterface $targetBag
      */

--- a/src/Session/Attribute/AttributeBagMirror.php
+++ b/src/Session/Attribute/AttributeBagMirror.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Session\Attribute;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+
+/**
+ * Provides an ArrayAccess mirror for a session AttributeBag.
+ * Used for BC for $_SESSION['FE_DATA'] and $_SESSION['BE_DATA'].
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class AttributeBagMirror implements \ArrayAccess
+{
+    /**
+     * @var AttributeBag
+     */
+    private $targetBag;
+
+
+    /**
+     * Creates an AttributeBagMirror with a target bag
+     *
+     * @param AttributeBag $targetBag
+     */
+    public function __construct(AttributeBag $targetBag)
+    {
+        $this->targetBag = $targetBag;
+    }
+
+    /**
+    * ArrayAccess has argument.
+    *
+    * @param string $key Array key.
+    *
+    * @return bool
+    */
+    public function offsetExists($key)
+    {
+        return $this->targetBag->has($key);
+    }
+
+    /**
+     * ArrayAccess for argument getter.
+     *
+     * @param string $key Array key.
+     *
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->targetBag->get($key);
+    }
+
+    /**
+     * ArrayAccess for argument setter.
+     *
+     * @param string $key   Array key to set.
+     * @param mixed  $value Value.
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->targetBag->set($key, $value);
+    }
+
+    /**
+     * ArrayAccess for unset argument.
+     *
+     * @param string $key Array key.
+     */
+    public function offsetUnset($key)
+    {
+        $this->targetBag->remove($key);
+    }
+}

--- a/src/Session/Attribute/AttributeBagMirror.php
+++ b/src/Session/Attribute/AttributeBagMirror.php
@@ -9,7 +9,7 @@
  */
 
 namespace Contao\CoreBundle\Session\Attribute;
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 /**
  * Provides an ArrayAccess mirror for a session AttributeBag.
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 class AttributeBagMirror implements \ArrayAccess
 {
     /**
-     * @var AttributeBag
+     * @var AttributeBagInterface
      */
     private $targetBag;
 
@@ -28,9 +28,9 @@ class AttributeBagMirror implements \ArrayAccess
     /**
      * Creates an AttributeBagMirror with a target bag
      *
-     * @param AttributeBag $targetBag
+     * @param AttributeBagInterface $targetBag
      */
-    public function __construct(AttributeBag $targetBag)
+    public function __construct(AttributeBagInterface $targetBag)
     {
         $this->targetBag = $targetBag;
     }

--- a/tests/EventListener/AddToSearchIndexListenerTest.php
+++ b/tests/EventListener/AddToSearchIndexListenerTest.php
@@ -62,7 +62,8 @@ class AddToSearchIndexListenerTest extends TestCase
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $this->bootContaoFramework($listener);

--- a/tests/EventListener/AddToSearchIndexListenerTest.php
+++ b/tests/EventListener/AddToSearchIndexListenerTest.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\Test\EventListener;
 
 use Contao\CoreBundle\EventListener\AddToSearchIndexListener;
+use Contao\CoreBundle\EventListener\InitializeSystemListener;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,7 +58,14 @@ class AddToSearchIndexListenerTest extends TestCase
      */
     public function testWithContaoFramework()
     {
-        $this->bootContaoFramework();
+        $listener = new InitializeSystemListener(
+            $this->mockRouter('/index.html'),
+            $this->mockTokenManager(),
+            $this->mockSession(),
+            $this->getRootDir() . '/app'
+        );
+
+        $this->bootContaoFramework($listener);
 
         $listener = new AddToSearchIndexListener();
         $event    = $this->mockPostResponseEvent();

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -276,7 +276,8 @@ class InitializeSystemListenerTest extends TestCase
                 $this->mockRouter('/index.html'),
                 $this->mockTokenManager(),
                 $this->mockSession(),
-                $this->getRootDir()
+                $this->getRootDir(),
+                'contao_csrf_token'
             ]
         );
 
@@ -351,7 +352,8 @@ class InitializeSystemListenerTest extends TestCase
                 $this->mockRouter('/index.html'),
                 $this->mockTokenManager(),
                 $this->mockSession(),
-                $this->getRootDir()
+                $this->getRootDir(),
+                'contao_csrf_token'
             ]
         );
 

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Tests the BootstrapLegacyListener class.
@@ -42,6 +43,7 @@ class InitializeSystemListenerTest extends TestCase
     {
         $listener = new InitializeSystemListener(
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'),
             $this->getRootDir()
         );
 
@@ -66,6 +68,7 @@ class InitializeSystemListenerTest extends TestCase
 
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
+            $this->mockTokenManager(),
             $this->getRootDir() . '/app'
         );
 
@@ -104,6 +107,7 @@ class InitializeSystemListenerTest extends TestCase
 
         $listener = new InitializeSystemListener(
             $this->mockRouter('/contao/install'),
+            $this->mockTokenManager(),
             $this->getRootDir() . '/app'
         );
 
@@ -143,6 +147,7 @@ class InitializeSystemListenerTest extends TestCase
 
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
+            $this->mockTokenManager(),
             $this->getRootDir() . '/app'
         );
 
@@ -184,6 +189,7 @@ class InitializeSystemListenerTest extends TestCase
 
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
+            $this->mockTokenManager(),
             $this->getRootDir() . '/app'
         );
 
@@ -288,6 +294,7 @@ class InitializeSystemListenerTest extends TestCase
 
         $listener = new InitializeSystemListener(
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->mockTokenManager(),
             $this->getRootDir() . '/app'
         );
 
@@ -431,5 +438,17 @@ class InitializeSystemListenerTest extends TestCase
         ;
 
         return $router;
+    }
+
+    /**
+     * Mocks a CSRF token manager
+     *
+     * @return CsrfTokenManagerInterface The token manager object
+     */
+    private function mockTokenManager()
+    {
+        $tokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+
+        return $tokenManager;
     }
 }

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
@@ -368,6 +369,9 @@ class InitializeSystemListenerTest extends TestCase
     private function mockKernel()
     {
         Config::set('bypassCache', true);
+        Config::set('timeZone', 'GMT');
+        Config::set('characterSet', 'UTF-8');
+
         Environment::set('httpAcceptLanguage', []);
 
         $kernel = $this->getMock(
@@ -458,7 +462,15 @@ class InitializeSystemListenerTest extends TestCase
      */
     private function mockTokenManager()
     {
-        $tokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $tokenManager = $this
+            ->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')
+            ->setMethods(array('getToken'))
+            ->getMockForAbstractClass();
+
+        $tokenManager
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn(new CsrfToken('_csrf', 'testValue'));
 
         return $tokenManager;
     }

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -23,6 +23,10 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -33,6 +37,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  * Tests the BootstrapLegacyListener class.
  *
  * @author Christian Schiffler <https://github.com/discordier>
+ * @author Yanick Witschi <https://github.com/toflar>
  */
 class InitializeSystemListenerTest extends TestCase
 {
@@ -44,6 +49,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
             $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'),
+            $this->mockSession(),
             $this->getRootDir()
         );
 
@@ -69,6 +75,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
+            $this->mockSession(),
             $this->getRootDir() . '/app'
         );
 
@@ -108,6 +115,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->mockRouter('/contao/install'),
             $this->mockTokenManager(),
+            $this->mockSession(),
             $this->getRootDir() . '/app'
         );
 
@@ -148,6 +156,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
+            $this->mockSession(),
             $this->getRootDir() . '/app'
         );
 
@@ -190,6 +199,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
+            $this->mockSession(),
             $this->getRootDir() . '/app'
         );
 
@@ -295,6 +305,7 @@ class InitializeSystemListenerTest extends TestCase
         $listener = new InitializeSystemListener(
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
             $this->mockTokenManager(),
+            $this->mockSession(),
             $this->getRootDir() . '/app'
         );
 
@@ -450,5 +461,27 @@ class InitializeSystemListenerTest extends TestCase
         $tokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
 
         return $tokenManager;
+    }
+
+    /**
+     * Mocks a Symfony session containing the Contao attribute bags
+     *
+     * @return SessionInterface
+     */
+    private function mockSession()
+    {
+        $session = new Session(
+            new MockArraySessionStorage()
+        );
+
+        $beBag = new AttributeBag('_contao_be_attributes');
+        $beBag->setName('contao_backend');
+        $feBag = new AttributeBag('_contao_fe_attributes');
+        $feBag->setName('contao_frontend');
+
+        $session->registerBag($beBag);
+        $session->registerBag($feBag);
+        
+        return $session;
     }
 }

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -51,7 +51,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
             $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'),
             $this->mockSession(),
-            $this->getRootDir()
+            $this->getRootDir(),
+            'contao_csrf_token'
         );
 
         $this->assertInstanceOf('Contao\CoreBundle\EventListener\InitializeSystemListener', $listener);
@@ -77,7 +78,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $listener->setContainer($container);
@@ -117,7 +119,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->mockRouter('/contao/install'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $listener->setContainer($container);
@@ -158,7 +161,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $listener->setContainer($container);
@@ -201,7 +205,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $listener->setContainer($container);
@@ -233,6 +238,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->mockRouter('/index.html'),
             $this->mockTokenManager(),
             $this->mockSession(),
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $request = new Request();
@@ -310,7 +317,8 @@ class InitializeSystemListenerTest extends TestCase
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
             $this->mockTokenManager(),
             $this->mockSession(),
-            $this->getRootDir() . '/app'
+            $this->getRootDir() . '/app',
+            'contao_csrf_token'
         );
 
         $listener->onConsoleCommand(

--- a/tests/EventListener/SessionListenerTest.php
+++ b/tests/EventListener/SessionListenerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\EventListener\SessionListener;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * Tests the SessionListenerTest class.
+ *
+ * @author Yanick Witschi <https:/github.com/toflar>
+ */
+class SessionListenerTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $listener = new SessionListener($this->getSession());
+
+        $this->assertInstanceOf('Contao\CoreBundle\EventListener\SessionListener', $listener);
+    }
+
+    /**
+     * Tests attribute bags are registered.
+     */
+    public function testAttributeBagsRegistered()
+    {
+        $session = $this->getSession();
+
+        $listener = new SessionListener($session);
+        $listener->onKernelRequest();
+
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag',
+            $session->getBag('contao_backend')
+        );
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag',
+            $session->getBag('contao_frontend')
+        );
+    }
+
+    /**
+     * Gets a session for unit tests.
+     *
+     * @return SessionInterface
+     */
+    private function getSession()
+    {
+        return new Session(
+            new MockArraySessionStorage()
+        );
+    }
+}

--- a/tests/EventListener/SessionListenerTest.php
+++ b/tests/EventListener/SessionListenerTest.php
@@ -41,7 +41,7 @@ class SessionListenerTest extends TestCase
         $session = $this->getSession();
 
         $listener = new SessionListener($session);
-        $listener->onKernelRequest();
+        $listener->registerContaoAttributeBags();
 
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag',

--- a/tests/Session/Attribute/AttributeBagMirrorTest.php
+++ b/tests/Session/Attribute/AttributeBagMirrorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Session\Attribute;
+use Contao\CoreBundle\Session\Attribute\AttributeBagMirror;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+
+/**
+ * Tests the AttributeBagMirror class.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $attributeBag = new AttributeBag('foobar_storageKey');
+        $mirror = new AttributeBagMirror($attributeBag);
+
+        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\AttributeBagMirror', $mirror);
+        $this->assertInstanceOf('ArrayAccess', $mirror);
+    }
+
+    /**
+     * Tests offsetSet.
+     */
+    public function testOffsetSet()
+    {
+        $attributeBag = new AttributeBag('foobar_storageKey');
+        $mirror = new AttributeBagMirror($attributeBag);
+
+        $mirror['foo'] = 'bar';
+
+        $this->assertSame('bar', $attributeBag->get('foo'));
+    }
+
+    /**
+     * Tests offsetExists.
+     */
+    public function testOffsetExists()
+    {
+        $attributeBag = new AttributeBag('foobar_storageKey');
+        $mirror = new AttributeBagMirror($attributeBag);
+
+        $mirror['foo'] = 'bar';
+
+        $this->assertTrue(isset($mirror['foo']));
+    }
+
+    /**
+     * Tests offsetGet.
+     */
+    public function testOffsetGet()
+    {
+        $attributeBag = new AttributeBag('foobar_storageKey');
+        $mirror = new AttributeBagMirror($attributeBag);
+
+        $attributeBag->set('foo', 'bar');
+
+        $this->assertSame('bar', $mirror['foo']);
+    }
+
+    /**
+     * Tests offsetUnset.
+     */
+    public function testOffsetUnset()
+    {
+        $attributeBag = new AttributeBag('foobar_storageKey');
+        $mirror = new AttributeBagMirror($attributeBag);
+
+        $attributeBag->set('foo', 'bar');
+
+        unset($mirror['foo']);
+
+        $this->assertFalse($attributeBag->has('foo'));
+    }
+}

--- a/tests/Session/Attribute/AttributeBagMirrorTest.php
+++ b/tests/Session/Attribute/AttributeBagMirrorTest.php
@@ -26,10 +26,10 @@ class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
     public function testInstantiation()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagAdapter($attributeBag);
+        $adapter = new AttributeBagAdapter($attributeBag);
 
-        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\AttributeBagAdapter', $mirror);
-        $this->assertInstanceOf('ArrayAccess', $mirror);
+        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\AttributeBagAdapter', $adapter);
+        $this->assertInstanceOf('ArrayAccess', $adapter);
     }
 
     /**
@@ -38,9 +38,9 @@ class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
     public function testOffsetSet()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagAdapter($attributeBag);
+        $adapter = new AttributeBagAdapter($attributeBag);
 
-        $mirror['foo'] = 'bar';
+        $adapter['foo'] = 'bar';
 
         $this->assertSame('bar', $attributeBag->get('foo'));
     }
@@ -51,11 +51,11 @@ class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
     public function testOffsetExists()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagAdapter($attributeBag);
+        $adapter = new AttributeBagAdapter($attributeBag);
 
-        $mirror['foo'] = 'bar';
+        $adapter['foo'] = 'bar';
 
-        $this->assertTrue(isset($mirror['foo']));
+        $this->assertTrue(isset($adapter['foo']));
     }
 
     /**
@@ -64,11 +64,11 @@ class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
     public function testOffsetGet()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagAdapter($attributeBag);
+        $adapter = new AttributeBagAdapter($attributeBag);
 
         $attributeBag->set('foo', 'bar');
 
-        $this->assertSame('bar', $mirror['foo']);
+        $this->assertSame('bar', $adapter['foo']);
     }
 
     /**
@@ -77,11 +77,11 @@ class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
     public function testOffsetUnset()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagAdapter($attributeBag);
+        $adapter = new AttributeBagAdapter($attributeBag);
 
         $attributeBag->set('foo', 'bar');
 
-        unset($mirror['foo']);
+        unset($adapter['foo']);
 
         $this->assertFalse($attributeBag->has('foo'));
     }

--- a/tests/Session/Attribute/AttributeBagMirrorTest.php
+++ b/tests/Session/Attribute/AttributeBagMirrorTest.php
@@ -9,15 +9,16 @@
  */
 
 namespace Contao\CoreBundle\Test\Session\Attribute;
-use Contao\CoreBundle\Session\Attribute\AttributeBagMirror;
+
+use Contao\CoreBundle\Session\Attribute\AttributeBagAdapter;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 
 /**
- * Tests the AttributeBagMirror class.
+ * Tests the AttributeBagAdapter class.
  *
  * @author Yanick Witschi <https://github.com/toflar>
  */
-class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
+class AttributeBagAdapterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Tests the object instantiation.
@@ -25,9 +26,9 @@ class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
     public function testInstantiation()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagMirror($attributeBag);
+        $mirror = new AttributeBagAdapter($attributeBag);
 
-        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\AttributeBagMirror', $mirror);
+        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\AttributeBagAdapter', $mirror);
         $this->assertInstanceOf('ArrayAccess', $mirror);
     }
 
@@ -37,7 +38,7 @@ class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
     public function testOffsetSet()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagMirror($attributeBag);
+        $mirror = new AttributeBagAdapter($attributeBag);
 
         $mirror['foo'] = 'bar';
 
@@ -50,7 +51,7 @@ class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
     public function testOffsetExists()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagMirror($attributeBag);
+        $mirror = new AttributeBagAdapter($attributeBag);
 
         $mirror['foo'] = 'bar';
 
@@ -63,7 +64,7 @@ class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
     public function testOffsetGet()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagMirror($attributeBag);
+        $mirror = new AttributeBagAdapter($attributeBag);
 
         $attributeBag->set('foo', 'bar');
 
@@ -76,7 +77,7 @@ class AttributeBagMirrorTest extends \PHPUnit_Framework_TestCase
     public function testOffsetUnset()
     {
         $attributeBag = new AttributeBag('foobar_storageKey');
-        $mirror = new AttributeBagMirror($attributeBag);
+        $mirror = new AttributeBagAdapter($attributeBag);
 
         $attributeBag->set('foo', 'bar');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,14 +14,20 @@ use Contao\Config;
 use Contao\CoreBundle\Config\CombinedFileLocator;
 use Contao\CoreBundle\Config\FileLocator;
 use Contao\CoreBundle\EventListener\InitializeSystemListener;
-use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\Environment;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Abstract TestCase class.
@@ -41,29 +47,31 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Returns the path to the fixtures cache directory.
+     *
+     * @return string The cache directory path
+     */
+    public function getCacheDir()
+    {
+        return __DIR__ . '/Fixtures/app/cache';
+    }
+
+
+    /**
      * Initializes the Contao framework.
      *
-     * @param string $scope The container scope
+     * @param InitializeSystemListener $listener The listener instance to be used
+     * @param string                   $scope The container scope
      */
-    protected function bootContaoFramework($scope = 'frontend')
-    {
+    protected function bootContaoFramework(
+        InitializeSystemListener $listener,
+        $scope = 'frontend'
+    ) {
         /** @var Kernel $kernel */
         global $kernel;
 
         $kernel    = $this->mockKernel();
         $container = $kernel->getContainer();
-        $router    = $this->getMock('Symfony\Component\Routing\RouterInterface');
-
-        $router
-            ->expects($this->any())
-            ->method('generate')
-            ->willReturn('/index.html')
-        ;
-
-        $listener = new InitializeSystemListener(
-            $router,
-            $this->getRootDir() . '/app'
-        );
 
         $listener->setContainer($container);
 
@@ -80,9 +88,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @return Kernel The kernel object
      */
-    private function mockKernel()
+    protected function mockKernel()
     {
         Config::set('bypassCache', true);
+        Config::set('timeZone', 'GMT');
+        Config::set('characterSet', 'UTF-8');
         Environment::set('httpAcceptLanguage', []);
 
         $kernel = $this->getMock(
@@ -146,12 +156,64 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Returns the path to the fixtures cache directory.
+     * Mocks a router returning the given URL.
      *
-     * @return string The cache directory path
+     * @param string $url The URL to return
+     *
+     * @return RouterInterface The router object
      */
-    public function getCacheDir()
+    protected function mockRouter($url)
     {
-        return __DIR__ . '/Fixtures/app/cache';
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+
+        $router
+            ->expects($this->any())
+            ->method('generate')
+            ->willReturn($url)
+        ;
+
+        return $router;
+    }
+
+    /**
+     * Mocks a CSRF token manager
+     *
+     * @return CsrfTokenManagerInterface The token manager object
+     */
+    protected function mockTokenManager()
+    {
+        $tokenManager = $this
+            ->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')
+            ->setMethods(array('getToken'))
+            ->getMockForAbstractClass();
+
+        $tokenManager
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn(new CsrfToken('_csrf', 'testValue'));
+
+        return $tokenManager;
+    }
+
+    /**
+     * Mocks a Symfony session containing the Contao attribute bags
+     *
+     * @return SessionInterface
+     */
+    protected function mockSession()
+    {
+        $session = new Session(
+            new MockArraySessionStorage()
+        );
+
+        $beBag = new AttributeBag('_contao_be_attributes');
+        $beBag->setName('contao_backend');
+        $feBag = new AttributeBag('_contao_fe_attributes');
+        $feBag->setName('contao_frontend');
+
+        $session->registerBag($beBag);
+        $session->registerBag($feBag);
+
+        return $session;
     }
 }


### PR DESCRIPTION
Requires the following changes in `contao/standard-edition`'s `config.yml`:

```diff
-    session: false
+    csrf_protection: ~
+    session:
+        handler_id: ~
```

(I did not make a separate PR because of the effort :-)).

I know it's mixing session handling with CSRF token handling but they sort of belong together and I had to make sure I could log in again, so I hacked it all together :-)

## ToDo's
* [x] Should we add an `ArrayAccess` wrapper for `$_SESSION`? Should writing and fetching from `$_SESSION['BE_DATA']` and `$_SESSION['FE_DATA']` still be supported? Ideas?
* [x] Should we add `public function getToken()` to `Template` because one should not use `REQUEST_TOKEN` anymore?
* [x] Tests
* [x] CS
* [x] Remove all internal usages of any PHP `session_*` function calls (e.g. in `User::authenticate()` - maybe @aschempp needs to have a look?)
* [x] Fix `Session::setData()` mapping
* [x] Check Request Token only if needed