### PR TITLE
Fix the redirect urls in the controller.

### DIFF
--- a/contao/library/Contao/Controller.php
+++ b/contao/library/Contao/Controller.php
@@ -1008,7 +1008,7 @@ abstract class Controller extends \System
 		// Make the location an absolute URL
 		if (!preg_match('@^https?://@i', $strLocation))
 		{
-			$strLocation = \Environment::get('base') . $strLocation;
+			$strLocation = rtrim(\Environment::get('base'), '/') . '/' . ltrim($strLocation, '/');
 		}
 
 		// Ajax request


### PR DESCRIPTION
I was kept being redirected to `http://host//app.php/foo` which caused the router to not find any valid route anymore (note the double slash).