### PR TITLE
[RTM] Adds a catch-all route

### DIFF
--- a/src/Resources/contao/controllers/BackendIndex.php
+++ b/src/Resources/contao/controllers/BackendIndex.php
@@ -102,7 +102,6 @@ class BackendIndex extends \Backend
 		$objTemplate->username = $GLOBALS['TL_LANG']['tl_user']['username'][0];
 		$objTemplate->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$objTemplate->feLink = $GLOBALS['TL_LANG']['MSC']['feLink'];
-		$objTemplate->frontendFile = \Environment::get('base');
 		$objTemplate->disableCron = \Config::get('disableCron');
 		$objTemplate->default = $GLOBALS['TL_LANG']['MSC']['default'];
 

--- a/src/Resources/contao/controllers/BackendPreview.php
+++ b/src/Resources/contao/controllers/BackendPreview.php
@@ -72,7 +72,7 @@ class BackendPreview extends \Backend
 		}
 		else
 		{
-			$objTemplate->url = $kernel->getContainer()->get('router')->generate('contao_frontend', array('alias' => ''), UrlGeneratorInterface::ABSOLUTE_URL);
+			$objTemplate->url = $kernel->getContainer()->get('router')->generate('contao_root', [], UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 
 		// Switch to a particular member (see #6546)

--- a/src/Resources/contao/templates/backend/be_login.html5
+++ b/src/Resources/contao/templates/backend/be_login.html5
@@ -81,7 +81,7 @@
         <p>Contao Open Source CMS :: Copyright ©2005-<?= date('Y') ?> by Leo Feyer :: Extensions are copyright of their respective owners :: Visit <a href="https://contao.org" target="_blank">contao.org</a> for more information :: Obstructing the appearance of this notice is prohibited by law!</p>
         <p>Contao is distributed in the hope that it will be useful but WITHOUT ANY WARRANTY. Without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. Contao is free software. You can redistribute it and/or modify it under the terms of the GNU/LGPL as published by the Free Software Foundation.</p>
       </div>
-      <p id="go_to_frontend"><a href="<?= $this->frontendFile ?>" class="footer_preview" title="<?= $this->feLink ?>"><?= $this->feLink ?></a></p>
+      <p id="go_to_frontend"><a href="<?= $this->route('contao_root') ?>" class="footer_preview" title="<?= $this->feLink ?>"><?= $this->feLink ?></a></p>
     </div>
   </div>
 

--- a/src/Routing/FrontendLoader.php
+++ b/src/Routing/FrontendLoader.php
@@ -56,9 +56,33 @@ class FrontendLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        $pattern  = '/{alias}';
+        $routes   = new RouteCollection();
         $defaults = ['_controller' => 'ContaoCoreBundle:Frontend:index', '_scope' => 'frontend'];
-        $require  = ['alias' => '.*'];
+
+        $this->addFrontendRoute($routes, $defaults);
+        $this->addCatchAllRoute($routes, $defaults);
+
+        return $routes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'contao_frontend' === $type;
+    }
+
+    /**
+     * Adds the frontend route which is language-aware.
+     *
+     * @param RouteCollection $routes   A collection of routes
+     * @param array           $defaults Default parameters for the route
+     */
+    private function addFrontendRoute(RouteCollection $routes, array $defaults)
+    {
+        $pattern = '/{alias}';
+        $require = ['alias' => '.*'];
 
         // URL suffix
         if ($this->format) {
@@ -77,17 +101,22 @@ class FrontendLoader extends Loader
             $defaults['_locale'] = $this->defaultLocale;
         }
 
-        $routes = new RouteCollection();
         $routes->add('contao_frontend', new Route($pattern, $defaults, $require));
-
-        return $routes;
     }
 
     /**
-     * {@inheritdoc}
+     * Adds a catch-all route to redirect all request to the Contao frontend controller.
+     *
+     * @param RouteCollection $routes   A collection of routes
+     * @param array           $defaults Default parameters for the route
      */
-    public function supports($resource, $type = null)
+    private function addCatchAllRoute(RouteCollection $routes, array $defaults)
     {
-        return 'contao_frontend' === $type;
+        $pattern = '/{alias}';
+        $require = ['alias' => '.*'];
+
+        $defaults['alias'] = '';
+
+        $routes->add('contao_root', new Route($pattern, $defaults, $require));
     }
 }

--- a/src/Routing/FrontendLoader.php
+++ b/src/Routing/FrontendLoader.php
@@ -60,6 +60,7 @@ class FrontendLoader extends Loader
         $defaults = ['_controller' => 'ContaoCoreBundle:Frontend:index', '_scope' => 'frontend'];
 
         $this->addFrontendRoute($routes, $defaults);
+        $this->addRootRoute($routes, $defaults);
         $this->addCatchAllRoute($routes, $defaults);
 
         return $routes;
@@ -105,6 +106,17 @@ class FrontendLoader extends Loader
     }
 
     /**
+     * Adds a route to redirect a user to the installation root.
+     *
+     * @param RouteCollection $routes   A collection of routes
+     * @param array           $defaults Default parameters for the route
+     */
+    private function addRootRoute(RouteCollection $routes, array $defaults)
+    {
+        $routes->add('contao_root', new Route('/', $defaults));
+    }
+
+    /**
      * Adds a catch-all route to redirect all request to the Contao frontend controller.
      *
      * @param RouteCollection $routes   A collection of routes
@@ -112,11 +124,11 @@ class FrontendLoader extends Loader
      */
     private function addCatchAllRoute(RouteCollection $routes, array $defaults)
     {
-        $pattern = '/{alias}';
-        $require = ['alias' => '.*'];
+        $pattern = '/{_url_fragment}';
+        $require = ['_url_fragment' => '.*'];
 
-        $defaults['alias'] = '';
+        $defaults['_url_fragment'] = '';
 
-        $routes->add('contao_root', new Route($pattern, $defaults, $require));
+        $routes->add('contao_catch_all', new Route($pattern, $defaults, $require));
     }
 }


### PR DESCRIPTION
fixes #64, so that all routes are now handled by the legacy code.

Be aware that the problem of https://github.com/contao/core/issues/7666 still exists.

### TODOs
 - [x] Rename the parameter from `{alias}` to something like `{_catch_all}`