### PR TITLE
[RFC] Prevent boot twice

### DIFF
--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -44,7 +44,7 @@ class InitializeSystemListener extends ScopeAwareListener
     /**
      * @var bool
      */
-    private static $isBooted = false;
+    private static $booted = false;
 
     /**
      * Constructor.
@@ -65,7 +65,7 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$this->isFrontendMasterRequest($event) && !$this->isBackendMasterRequest($event)) {
+        if (true === static::$booted || !$this->isFrontendMasterRequest($event) && !$this->isBackendMasterRequest($event)) {
             return;
         }
 
@@ -89,7 +89,9 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
-        if (!$event->getCommand() instanceof ContaoFrameworkDependentInterface) {
+        if (true === static::$booted
+            || (!$event->getCommand() instanceof ContaoFrameworkDependentInterface)
+        ) {
             return;
         }
 
@@ -144,10 +146,7 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     private function boot(Request $request = null)
     {
-        // do not boot twice
-        if ($this->booted()) {
-            return;
-        }
+        static::$booted = true;
 
         $this->includeHelpers();
 
@@ -191,19 +190,6 @@ class InitializeSystemListener extends ScopeAwareListener
 
         $this->triggerInitializeSystemHook();
         $this->checkRequestToken();
-
-        // set booted
-        InitializeSystemListener::$isBooted = true;
-    }
-
-    /**
-     * Check is booted
-     *
-     * @return bool
-     */
-    private function booted()
-    {
-        return InitializeSystemListener::$isBooted;
     }
 
     /**

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -65,9 +65,12 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (true === static::$booted || !$this->isFrontendMasterRequest($event) && !$this->isBackendMasterRequest($event)) {
+        if (true === self::$booted || !$this->isFrontendMasterRequest($event) && !$this->isBackendMasterRequest($event)) {
             return;
         }
+
+        // Set before calling any methods to prevent recursive booting
+        self::$booted = true;
 
         $request = $event->getRequest();
 
@@ -89,11 +92,14 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
-        if (true === static::$booted
+        if (true === self::$booted
             || (!$event->getCommand() instanceof ContaoFrameworkDependentInterface)
         ) {
             return;
         }
+
+        // Set before calling any methods to prevent recursive booting
+        self::$booted = true;
 
         $this->setConstants('FE', 'console');
         $this->boot();
@@ -122,8 +128,10 @@ class InitializeSystemListener extends ScopeAwareListener
      *
      * @param string $scope The scope (BE or FE)
      * @param string $route The route
+     *
+     * @internal only protected for unit tests
      */
-    private function setConstants($scope, $route)
+    protected function setConstants($scope, $route)
     {
         // The constants are deprecated and will be removed in version 5.0.
         define('TL_MODE', $scope);
@@ -143,11 +151,11 @@ class InitializeSystemListener extends ScopeAwareListener
      * Boots the Contao framework.
      *
      * @param Request $request The request object
+     *
+     * @internal only protected for unit tests
      */
-    private function boot(Request $request = null)
+    protected function boot(Request $request = null)
     {
-        static::$booted = true;
-
         $this->includeHelpers();
 
         // Try to disable the PHPSESSID

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -44,7 +44,7 @@ class InitializeSystemListener extends ScopeAwareListener
     /**
      * @var bool
      */
-    private $isBooted = false;
+    private static $isBooted = false;
 
     /**
      * Constructor.
@@ -193,7 +193,7 @@ class InitializeSystemListener extends ScopeAwareListener
         $this->checkRequestToken();
 
         // set booted
-        $this->isBooted = true;
+        InitializeSystemListener::$isBooted = true;
     }
 
     /**
@@ -203,7 +203,7 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     private function booted()
     {
-        return $this->isBooted;
+        return InitializeSystemListener::$isBooted;
     }
 
     /**

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -65,7 +65,7 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (true === self::$booted || !$this->isFrontendMasterRequest($event) && !$this->isBackendMasterRequest($event)) {
+        if (true === self::$booted || (!$this->isFrontendScope() && !$this->isBackendScope())) {
             return;
         }
 

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -42,6 +42,11 @@ class InitializeSystemListener extends ScopeAwareListener
     private $rootDir;
 
     /**
+     * @var bool
+     */
+    private $isBooted = false;
+
+    /**
      * Constructor.
      *
      * @param RouterInterface $router  The router object
@@ -139,6 +144,11 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     private function boot(Request $request = null)
     {
+        // do not boot twice
+        if ($this->booted()) {
+            return;
+        }
+
         $this->includeHelpers();
 
         // Try to disable the PHPSESSID
@@ -181,6 +191,19 @@ class InitializeSystemListener extends ScopeAwareListener
 
         $this->triggerInitializeSystemHook();
         $this->checkRequestToken();
+
+        // set booted
+        $this->isBooted = true;
+    }
+
+    /**
+     * Check is booted
+     *
+     * @return bool
+     */
+    private function booted()
+    {
+        return $this->isBooted;
     }
 
     /**

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -73,6 +73,10 @@ class InitializeSystemListenerTest extends TestCase
         $isBooted = $ref->getMethod('booted');
         $isBooted->setAccessible(true);
         $this->assertTrue($isBooted->invoke($listener));
+
+        // invoke boot again
+        $boot->invoke($listener, null, null);
+
     }
 
     /**

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -48,6 +48,34 @@ class InitializeSystemListenerTest extends TestCase
     }
 
     /**
+     * Test if $isBooted is set correctly
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testPreventBootTwice()
+    {
+        global $kernel;
+
+        /** @var Kernel $kernel */
+        $kernel = $this->mockKernel();
+
+        $listener = new InitializeSystemListener(
+            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->getRootDir()
+        );
+
+        $ref = new \ReflectionClass('Contao\CoreBundle\EventListener\InitializeSystemListener');
+        $boot = $ref->getMethod('boot');
+        $boot->setAccessible(true);
+        $boot->invoke($listener, null, null);
+
+        $isBooted = $ref->getMethod('booted');
+        $isBooted->setAccessible(true);
+        $this->assertTrue($isBooted->invoke($listener));
+    }
+
+    /**
      * Tests a front end request.
      *
      * @runInSeparateProcess


### PR DESCRIPTION
Includes commits from @dtomasi 

The framework is now also booted on a subrequest if the master request did not boot it.