### PR TITLE
[RTM] Always use double backslashes in string literals

### DIFF
--- a/tests/Analyzer/HtaccessAnalyzerTest.php
+++ b/tests/Analyzer/HtaccessAnalyzerTest.php
@@ -45,7 +45,7 @@ class HtaccessAnalyzerTest extends TestCase
     {
         $htaccess = new HtaccessAnalyzer($this->file);
 
-        $this->assertInstanceOf('Contao\CoreBundle\Analyzer\HtaccessAnalyzer', $htaccess);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Analyzer\\HtaccessAnalyzer', $htaccess);
     }
 
     /**

--- a/tests/Command/AutomatorCommandTest.php
+++ b/tests/Command/AutomatorCommandTest.php
@@ -31,7 +31,7 @@ class AutomatorCommandTest extends TestCase
     {
         $command = new AutomatorCommand('contao:automator');
 
-        $this->assertInstanceOf('Contao\CoreBundle\Command\AutomatorCommand', $command);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Command\\AutomatorCommand', $command);
     }
 
     /**

--- a/tests/Command/FilesyncCommandTest.php
+++ b/tests/Command/FilesyncCommandTest.php
@@ -29,7 +29,7 @@ class FilesyncCommandTest extends TestCase
     {
         $command = new FilesyncCommand('contao:filesync');
 
-        $this->assertInstanceOf('Contao\CoreBundle\Command\FilesyncCommand', $command);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Command\\FilesyncCommand', $command);
     }
 
     /**

--- a/tests/Command/VersionCommandTest.php
+++ b/tests/Command/VersionCommandTest.php
@@ -28,7 +28,7 @@ class VersionCommandTest extends TestCase
     {
         $command = new VersionCommand('contao:version');
 
-        $this->assertInstanceOf('Contao\CoreBundle\Command\VersionCommand', $command);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Command\\VersionCommand', $command);
     }
 
     /**

--- a/tests/Config/BundleFileLocatorTest.php
+++ b/tests/Config/BundleFileLocatorTest.php
@@ -42,7 +42,7 @@ class BundleFileLocatorTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\Config\BundleFileLocator', $this->locator);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Config\\BundleFileLocator', $this->locator);
     }
 
     /**
@@ -120,7 +120,7 @@ class BundleFileLocatorTest extends TestCase
     private function mockKernel()
     {
         $kernel = $this->getMock(
-            'Symfony\Component\HttpKernel\Kernel',
+            'Symfony\\Component\\HttpKernel\\Kernel',
             [
                 // KernelInterface
                 'registerBundles',
@@ -152,7 +152,7 @@ class BundleFileLocatorTest extends TestCase
         );
 
         $bundle = $this->getMock(
-            'Symfony\Component\HttpKernel\Bundle\Bundle',
+            'Symfony\\Component\\HttpKernel\\Bundle\\Bundle',
             ['getName', 'getPath'],
             [],
             'TestBundle'

--- a/tests/Config/ChainFileLocatorTest.php
+++ b/tests/Config/ChainFileLocatorTest.php
@@ -50,7 +50,7 @@ class ChainFileLocatorTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\Config\ChainFileLocator', $this->locator);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Config\\ChainFileLocator', $this->locator);
     }
 
     /**

--- a/tests/Config/Dumper/CombinedFileDumperTest.php
+++ b/tests/Config/Dumper/CombinedFileDumperTest.php
@@ -28,10 +28,10 @@ class CombinedFileDumperTest extends TestCase
     public function testInstantiation()
     {
         $this->assertInstanceOf(
-            'Contao\CoreBundle\Config\Dumper\CombinedFileDumper',
+            'Contao\\CoreBundle\\Config\\Dumper\\CombinedFileDumper',
             new CombinedFileDumper(
-                $this->getMock('Symfony\Component\Filesystem\Filesystem'),
-                $this->getMock('Contao\CoreBundle\Config\Loader\PhpFileLoader'),
+                $this->getMock('Symfony\\Component\\Filesystem\\Filesystem'),
+                $this->getMock('Contao\\CoreBundle\\Config\\Loader\\PhpFileLoader'),
                 $this->getCacheDir()
             )
         );
@@ -75,8 +75,8 @@ class CombinedFileDumperTest extends TestCase
     public function testInvalidHeader()
     {
         $dumper = new CombinedFileDumper(
-            $this->getMock('Symfony\Component\Filesystem\Filesystem'),
-            $this->getMock('Contao\CoreBundle\Config\Loader\PhpFileLoader'),
+            $this->getMock('Symfony\\Component\\Filesystem\\Filesystem'),
+            $this->getMock('Contao\\CoreBundle\\Config\\Loader\\PhpFileLoader'),
             $this->getCacheDir()
         );
 
@@ -93,7 +93,7 @@ class CombinedFileDumperTest extends TestCase
     private function mockFilesystem($expects)
     {
         $filesystem = $this->getMock(
-            'Symfony\Component\Filesystem\Filesystem',
+            'Symfony\\Component\\Filesystem\\Filesystem',
             ['dumpFile']
         );
 
@@ -114,7 +114,7 @@ class CombinedFileDumperTest extends TestCase
     private function mockLoader()
     {
         $loader = $this->getMock(
-            'Contao\CoreBundle\Config\Loader\PhpFileLoader',
+            'Contao\\CoreBundle\\Config\\Loader\\PhpFileLoader',
             ['load']
         );
 

--- a/tests/Config/FileLocatorAggregateTest.php
+++ b/tests/Config/FileLocatorAggregateTest.php
@@ -45,7 +45,7 @@ class FileLocatorAggregateTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\Config\FileLocatorAggregate', $this->locator);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Config\\FileLocatorAggregate', $this->locator);
     }
 
     /**

--- a/tests/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Config/Loader/PhpFileLoaderTest.php
@@ -38,7 +38,7 @@ class PhpFileLoaderTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\Config\Loader\PhpFileLoader', $this->loader);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Config\\Loader\\PhpFileLoader', $this->loader);
     }
 
     /**

--- a/tests/Config/Loader/XliffFileLoaderTest.php
+++ b/tests/Config/Loader/XliffFileLoaderTest.php
@@ -26,7 +26,7 @@ class XliffFileLoaderTest extends TestCase
     public function testInstantiation()
     {
         $this->assertInstanceOf(
-            'Contao\CoreBundle\Config\Loader\XliffFileLoader',
+            'Contao\\CoreBundle\\Config\\Loader\\XliffFileLoader',
             new XliffFileLoader($this->getRootDir() . '/app')
         );
     }

--- a/tests/Config/StrictFileLocatorTest.php
+++ b/tests/Config/StrictFileLocatorTest.php
@@ -39,7 +39,7 @@ class StrictFileLocatorTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\Config\StrictFileLocator', $this->locator);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Config\\StrictFileLocator', $this->locator);
     }
 
     /**

--- a/tests/Contao/GdImageTest.php
+++ b/tests/Contao/GdImageTest.php
@@ -62,7 +62,7 @@ class GdImageTest extends TestCase
         $resource = imagecreate(1, 1);
         $image    = new GdImage($resource);
 
-        $this->assertInstanceOf('Contao\GdImage', $image);
+        $this->assertInstanceOf('Contao\\GdImage', $image);
         $this->assertSame($resource, $image->getResource());
     }
 

--- a/tests/Contao/ImageTest.php
+++ b/tests/Contao/ImageTest.php
@@ -76,7 +76,7 @@ class ImageTest extends TestCase
      */
     public function testConstruct()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -96,7 +96,7 @@ class ImageTest extends TestCase
             }
         ));
 
-        $this->assertInstanceOf('Contao\Image', new Image($fileMock));
+        $this->assertInstanceOf('Contao\\Image', new Image($fileMock));
     }
 
     /**
@@ -106,7 +106,7 @@ class ImageTest extends TestCase
      */
     public function testConstructWithNonexistentFile()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -123,7 +123,7 @@ class ImageTest extends TestCase
      */
     public function testConstructWithInvalidExtension()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -161,7 +161,7 @@ class ImageTest extends TestCase
      */
     public function testComputeResizeWithoutImportantPart($arguments, $expectedResult)
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -604,7 +604,7 @@ class ImageTest extends TestCase
      */
     public function testComputeResizeWithImportantPart($arguments, $expectedResult)
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -790,7 +790,7 @@ class ImageTest extends TestCase
      */
     public function testSettersAndGetters()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -876,7 +876,7 @@ class ImageTest extends TestCase
      */
     public function testGetCacheName($arguments, $expectedCacheName)
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -942,7 +942,7 @@ class ImageTest extends TestCase
      */
     public function testSetZoomOutOfBoundsNegative()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();
@@ -971,7 +971,7 @@ class ImageTest extends TestCase
      */
     public function testSetZoomOutOfBoundsPositive()
     {
-        $fileMock = $this->getMockBuilder('Contao\File')
+        $fileMock = $this->getMockBuilder('Contao\\File')
             ->setMethods(['__get', 'exists'])
             ->setConstructorArgs(['dummy.jpg'])
             ->getMock();

--- a/tests/Contao/PictureTest.php
+++ b/tests/Contao/PictureTest.php
@@ -97,7 +97,7 @@ class PictureTest extends TestCase
             }
         ));
 
-        $this->assertInstanceOf('Contao\Picture', new Picture($fileMock));
+        $this->assertInstanceOf('Contao\\Picture', new Picture($fileMock));
     }
 
     /**

--- a/tests/Controller/BackendControllerTest.php
+++ b/tests/Controller/BackendControllerTest.php
@@ -27,7 +27,7 @@ class BackendControllerTest extends TestCase
     {
         $controller = new BackendController();
 
-        $this->assertInstanceOf('Contao\CoreBundle\Controller\BackendController', $controller);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Controller\\BackendController', $controller);
     }
 
     /**
@@ -37,17 +37,17 @@ class BackendControllerTest extends TestCase
     {
         $controller = new BackendController();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->mainAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->loginAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->installAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->passwordAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->previewAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->changelogAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->confirmAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->fileAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->helpAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->pageAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->popupAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->switchAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->mainAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->loginAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->installAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->passwordAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->previewAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->changelogAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->confirmAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->fileAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->helpAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->pageAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->popupAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->switchAction());
     }
 }

--- a/tests/Controller/FrontendControllerTest.php
+++ b/tests/Controller/FrontendControllerTest.php
@@ -27,7 +27,7 @@ class FrontendControllerTest extends TestCase
     {
         $controller = new FrontendController();
 
-        $this->assertInstanceOf('Contao\CoreBundle\Controller\FrontendController', $controller);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Controller\\FrontendController', $controller);
     }
 
     /**
@@ -37,8 +37,8 @@ class FrontendControllerTest extends TestCase
     {
         $controller = new FrontendController();
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->indexAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->cronAction());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $controller->shareAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->indexAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->cronAction());
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $controller->shareAction());
     }
 }

--- a/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
@@ -28,7 +28,7 @@ class AddPackagesPassTest extends TestCase
     {
         $pass = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json');
 
-        $this->assertInstanceOf('Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass', $pass);
+        $this->assertInstanceOf('Contao\\CoreBundle\\DependencyInjection\\Compiler\\AddPackagesPass', $pass);
     }
 
     /**

--- a/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -39,7 +39,7 @@ class ContaoCoreExtensionTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\DependencyInjection\ContaoCoreExtension', $this->extension);
+        $this->assertInstanceOf('Contao\\CoreBundle\\DependencyInjection\\ContaoCoreExtension', $this->extension);
     }
 
     /**

--- a/tests/EventListener/AddToSearchIndexListenerTest.php
+++ b/tests/EventListener/AddToSearchIndexListenerTest.php
@@ -30,7 +30,7 @@ class AddToSearchIndexListenerTest extends TestCase
     {
         $listener = new AddToSearchIndexListener();
 
-        $this->assertInstanceOf('Contao\CoreBundle\EventListener\AddToSearchIndexListener', $listener);
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\AddToSearchIndexListener', $listener);
     }
 
     /**
@@ -77,12 +77,12 @@ class AddToSearchIndexListenerTest extends TestCase
      */
     private function mockPostResponseEvent()
     {
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request();
         $response = new Response();
 
         $event = $this->getMock(
-            'Symfony\Component\HttpKernel\Event\PostResponseEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\PostResponseEvent',
             ['getResponse'],
             [$kernel, $request, $response]
         );

--- a/tests/EventListener/ContainerScopeListenerTest.php
+++ b/tests/EventListener/ContainerScopeListenerTest.php
@@ -34,7 +34,7 @@ class ContainerScopeListenerTest extends TestCase
     {
         $listener = new ContainerScopeListener(new ContainerBuilder());
 
-        $this->assertInstanceOf('Contao\CoreBundle\EventListener\ContainerScopeListener', $listener);
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\ContainerScopeListener', $listener);
     }
 
     /**
@@ -46,7 +46,7 @@ class ContainerScopeListenerTest extends TestCase
         $listener  = new ContainerScopeListener($container);
 
         /** @var HttpKernelInterface $kernel */
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request();
 
         $container->addScope(new Scope('backend'));
@@ -67,7 +67,7 @@ class ContainerScopeListenerTest extends TestCase
         $listener  = new ContainerScopeListener($container);
 
         /** @var HttpKernelInterface $kernel */
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request();
         $response = new Response();
 
@@ -90,7 +90,7 @@ class ContainerScopeListenerTest extends TestCase
         $listener  = new ContainerScopeListener($container);
 
         /** @var HttpKernelInterface $kernel */
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request();
 
         $container->addScope(new Scope('backend'));
@@ -110,7 +110,7 @@ class ContainerScopeListenerTest extends TestCase
         $listener  = new ContainerScopeListener($container);
 
         /** @var HttpKernelInterface $kernel */
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request();
 
         $request->attributes->set('_scope', 'backend');

--- a/tests/EventListener/InitializeSystemListenerTest.php
+++ b/tests/EventListener/InitializeSystemListenerTest.php
@@ -41,11 +41,11 @@ class InitializeSystemListenerTest extends TestCase
     public function testInstantiation()
     {
         $listener = new InitializeSystemListener(
-            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
             $this->getRootDir()
         );
 
-        $this->assertInstanceOf('Contao\CoreBundle\EventListener\InitializeSystemListener', $listener);
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\InitializeSystemListener', $listener);
     }
 
     /**
@@ -245,10 +245,10 @@ class InitializeSystemListenerTest extends TestCase
 
         /** @var \PHPUnit_Framework_MockObject_MockObject|InitializeSystemListener $listener */
         $listener = $this->getMock(
-            'Contao\CoreBundle\EventListener\InitializeSystemListener',
+            'Contao\\CoreBundle\\EventListener\\InitializeSystemListener',
             ['setConstants', 'boot'],
             [
-                $this->getMock('Symfony\Component\Routing\RouterInterface'),
+                $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
                 $this->getRootDir()
             ]
         );
@@ -287,7 +287,7 @@ class InitializeSystemListenerTest extends TestCase
         $kernel = $this->mockKernel();
 
         $listener = new InitializeSystemListener(
-            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
             $this->getRootDir() . '/app'
         );
 
@@ -315,10 +315,10 @@ class InitializeSystemListenerTest extends TestCase
 
         /** @var \PHPUnit_Framework_MockObject_MockObject|InitializeSystemListener $listener */
         $listener = $this->getMock(
-            'Contao\CoreBundle\EventListener\InitializeSystemListener',
+            'Contao\\CoreBundle\\EventListener\\InitializeSystemListener',
             ['setConstants', 'boot'],
             [
-                $this->getMock('Symfony\Component\Routing\RouterInterface'),
+                $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
                 $this->getRootDir()
             ]
         );
@@ -353,7 +353,7 @@ class InitializeSystemListenerTest extends TestCase
         Environment::set('httpAcceptLanguage', []);
 
         $kernel = $this->getMock(
-            'Symfony\Component\HttpKernel\Kernel',
+            'Symfony\\Component\\HttpKernel\\Kernel',
             [
                 // KernelInterface
                 'registerBundles',
@@ -414,7 +414,7 @@ class InitializeSystemListenerTest extends TestCase
      */
     private function mockRouter($url)
     {
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
 
         $router
             ->expects($this->any())

--- a/tests/EventListener/OutputFromCacheListenerTest.php
+++ b/tests/EventListener/OutputFromCacheListenerTest.php
@@ -32,7 +32,7 @@ class OutputFromCacheListenerTest extends TestCase
     {
         $listener = new OutputFromCacheListener();
 
-        $this->assertInstanceOf('Contao\CoreBundle\EventListener\OutputFromCacheListener', $listener);
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\OutputFromCacheListener', $listener);
     }
 
     /**
@@ -41,7 +41,7 @@ class OutputFromCacheListenerTest extends TestCase
     public function testFrontendScope()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request();
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -64,7 +64,7 @@ class OutputFromCacheListenerTest extends TestCase
     public function testInvalidScope()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request();
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -87,7 +87,7 @@ class OutputFromCacheListenerTest extends TestCase
     public function testWithoutContainer()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request   = new Request();
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener  = new OutputFromCacheListener();

--- a/tests/EventListener/ToggleViewListenerTest.php
+++ b/tests/EventListener/ToggleViewListenerTest.php
@@ -34,7 +34,7 @@ class ToggleViewListenerTest extends TestCase
     {
         $listener = new ToggleViewListener();
 
-        $this->assertInstanceOf('Contao\CoreBundle\EventListener\ToggleViewListener', $listener);
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\ToggleViewListener', $listener);
     }
 
     /**
@@ -43,7 +43,7 @@ class ToggleViewListenerTest extends TestCase
     public function testWithoutContainer()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel   = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel   = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $request  = new Request(['toggle_view' => 'desktop']);
         $event    = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener = new ToggleViewListener();
@@ -61,7 +61,7 @@ class ToggleViewListenerTest extends TestCase
     public function testNotInFrontend()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request(['toggle_view' => 'desktop']);
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -84,7 +84,7 @@ class ToggleViewListenerTest extends TestCase
     public function testNoView()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request();
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -107,7 +107,7 @@ class ToggleViewListenerTest extends TestCase
     public function testDesktopView()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request(['toggle_view' => 'desktop']);
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -131,7 +131,7 @@ class ToggleViewListenerTest extends TestCase
     public function testMobileView()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request(['toggle_view' => 'mobile']);
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -155,7 +155,7 @@ class ToggleViewListenerTest extends TestCase
     public function testInvalidView()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel    = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel    = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container = new Container();
         $request   = new Request(['toggle_view' => 'foobar']);
         $event     = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
@@ -179,7 +179,7 @@ class ToggleViewListenerTest extends TestCase
     public function testCookiePath()
     {
         /** @var HttpKernelInterface $kernel */
-        $kernel     = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+        $kernel     = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Kernel', ['test', false]);
         $container  = new Container();
         $request    = new Request(['toggle_view' => 'desktop']);
         $event      = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);

--- a/tests/HttpKernel/Bundle/ContaoModuleBundleTest.php
+++ b/tests/HttpKernel/Bundle/ContaoModuleBundleTest.php
@@ -38,7 +38,7 @@ class ContaoModuleBundleTest extends TestCase
      */
     public function testInstantiation()
     {
-        $this->assertInstanceOf('Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle', $this->bundle);
+        $this->assertInstanceOf('Contao\\CoreBundle\\HttpKernel\\Bundle\\ContaoModuleBundle', $this->bundle);
     }
 
     /**

--- a/tests/Routing/FrontendLoaderTest.php
+++ b/tests/Routing/FrontendLoaderTest.php
@@ -26,7 +26,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = new FrontendLoader('', 'en', false);
 
-        $this->assertInstanceOf('Contao\CoreBundle\Routing\FrontendLoader', $loader);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Routing\\FrontendLoader', $loader);
     }
 
     /**
@@ -37,7 +37,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $loader     = new FrontendLoader('.html', 'en', false);
         $collection = $loader->load('.', 'bundles');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $collection);
+        $this->assertInstanceOf('Symfony\\Component\\Routing\\RouteCollection', $collection);
 
         $routes = $collection->all();
 
@@ -59,7 +59,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $loader     = new FrontendLoader('.html', 'en', true);
         $collection = $loader->load('.', 'bundles');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $collection);
+        $this->assertInstanceOf('Symfony\\Component\\Routing\\RouteCollection', $collection);
 
         $routes = $collection->all();
 
@@ -81,7 +81,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $loader     = new FrontendLoader('', 'en', false);
         $collection = $loader->load('.', 'bundles');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $collection);
+        $this->assertInstanceOf('Symfony\\Component\\Routing\\RouteCollection', $collection);
 
         $routes = $collection->all();
 
@@ -103,7 +103,7 @@ class FrontendLoaderTest extends \PHPUnit_Framework_TestCase
         $loader     = new FrontendLoader('', 'en', true);
         $collection = $loader->load('.', 'bundles');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $collection);
+        $this->assertInstanceOf('Symfony\\Component\\Routing\\RouteCollection', $collection);
 
         $routes = $collection->all();
 

--- a/tests/Security/Authentication/ContaoTokenTest.php
+++ b/tests/Security/Authentication/ContaoTokenTest.php
@@ -33,7 +33,7 @@ class ContaoTokenTest extends TestCase
     {
         $token = new ContaoToken(FrontendUser::getInstance());
 
-        $this->assertInstanceOf('Contao\CoreBundle\Security\Authentication\ContaoToken', $token);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Security\\Authentication\\ContaoToken', $token);
     }
 
     /**

--- a/tests/Security/ContaoAuthenticatorTest.php
+++ b/tests/Security/ContaoAuthenticatorTest.php
@@ -33,7 +33,7 @@ class ContaoAuthenticatorTest extends TestCase
     {
         $authenticator = new ContaoAuthenticator(new ContaoUserProvider());
 
-        $this->assertInstanceOf('Contao\CoreBundle\Security\ContaoAuthenticator', $authenticator);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Security\\ContaoAuthenticator', $authenticator);
     }
 
     /**
@@ -44,7 +44,7 @@ class ContaoAuthenticatorTest extends TestCase
         $authenticator = new ContaoAuthenticator(new ContaoUserProvider());
         $token         = $authenticator->createToken(new Request(), 'frontend');
 
-        $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', $token);
+        $this->assertInstanceOf('Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken', $token);
         $this->assertEquals('frontend', $token->getKey());
         $this->assertEquals('anon.', $token->getUsername());
     }
@@ -57,12 +57,12 @@ class ContaoAuthenticatorTest extends TestCase
         $authenticator = new ContaoAuthenticator(new ContaoUserProvider());
 
         $this->assertInstanceOf(
-            'Contao\CoreBundle\Security\Authentication\ContaoToken',
+            'Contao\\CoreBundle\\Security\\Authentication\\ContaoToken',
             $authenticator->authenticateToken(new ContaoToken(FrontendUser::getInstance()), new ContaoUserProvider(), 'frontend')
         );
 
         $this->assertInstanceOf(
-            'Contao\CoreBundle\Security\Authentication\ContaoToken',
+            'Contao\\CoreBundle\\Security\\Authentication\\ContaoToken',
             $authenticator->authenticateToken(new AnonymousToken('frontend', 'anon.'), new ContaoUserProvider(), 'frontend')
         );
 

--- a/tests/Security/User/ContaoUserProviderTest.php
+++ b/tests/Security/User/ContaoUserProviderTest.php
@@ -28,7 +28,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider();
 
-        $this->assertInstanceOf('Contao\CoreBundle\Security\User\ContaoUserProvider', $provider);
+        $this->assertInstanceOf('Contao\\CoreBundle\\Security\\User\\ContaoUserProvider', $provider);
     }
 
     /**
@@ -41,7 +41,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider();
 
-        $this->assertInstanceOf('Contao\BackendUser', $provider->loadUserByUsername('backend'));
+        $this->assertInstanceOf('Contao\\BackendUser', $provider->loadUserByUsername('backend'));
     }
 
     /**
@@ -54,7 +54,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider();
 
-        $this->assertInstanceOf('Contao\FrontendUser', $provider->loadUserByUsername('frontend'));
+        $this->assertInstanceOf('Contao\\FrontendUser', $provider->loadUserByUsername('frontend'));
     }
 
     /**
@@ -86,6 +86,6 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider();
 
-        $this->assertTrue($provider->supportsClass('Contao\FrontendUser'));
+        $this->assertTrue($provider->supportsClass('Contao\\FrontendUser'));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,7 +50,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         $kernel    = $this->mockKernel();
         $container = $kernel->getContainer();
-        $router    = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router    = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
 
         $router
             ->expects($this->any())
@@ -84,7 +84,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         Environment::set('httpAcceptLanguage', []);
 
         $kernel = $this->getMock(
-            'Symfony\Component\HttpKernel\Kernel',
+            'Symfony\\Component\\HttpKernel\\Kernel',
             [
                 // KernelInterface
                 'registerBundles',


### PR DESCRIPTION
To be merged after #169.