### PR TITLE
Fix wrong path in is_writeable

### DIFF
--- a/src/Resources/contao/library/Contao/Files.php
+++ b/src/Resources/contao/library/Contao/Files.php
@@ -303,7 +303,7 @@ class Files
 	{
 		$this->validate($strFile);
 
-		return is_writeable(TL_ROOT . '/' . $strFile);
+		return is_writeable($strFile);
 	}
 
 


### PR DESCRIPTION
The `TL_ROOT` is wrong here, `$strFile` contains the full path already as you pass in `__FILE__` (see https://github.com/contao/core-bundle/blob/develop/src/Resources/contao/controllers/BackendInstall.php#L66).