### PR TITLE
[WIP] Move the BackendUser session storage process to a separate listener

### DIFF
--- a/src/EventListener/StoreSessionListener.php
+++ b/src/EventListener/StoreSessionListener.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Session\Attribute\AttributeBagAdapter;
+use Doctrine\DBAL\Driver\Connection;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+
+/**
+ * Stores the session data of a back end user so the state can be recreated
+ * on the next login.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class StoreSessionListener extends ScopeAwareListener
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * Constructor.
+     *
+     * @param SessionInterface $session
+     */
+    public function __construct(
+        SessionInterface $session,
+        Connection $connection
+    ) {
+        $this->session = $session;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Stores the referer data of a back end user so the state can be recreated
+     * on the next login.
+     *
+     * @param FilterResponseEvent $event The event object
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$this->isBackendMasterRequest($event)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->storeReferer($request)) {
+            $this->storeSession();
+            return;
+        }
+
+        $key = $this->getRefererKey($request);
+        $session = $this->getSessionBag();
+
+        // FIXME: Write this part of the code in beautiful instead of using
+        // the adapter
+        $session = new AttributeBagAdapter($session);
+
+        if (!is_array($session[$key]) || !is_array($session[$key][TL_REFERER_ID])) {
+            $session[$key][TL_REFERER_ID]['last'] = '';
+        }
+
+        while (count($session[$key]) >= 25) {
+            array_shift($session[$key]);
+        }
+
+        $ref = \Input::get('ref');
+
+        if ($ref != '' && isset($session[$key][$ref])) {
+            if (!isset($session[$key][TL_REFERER_ID])) {
+                $session[$key][TL_REFERER_ID] = array();
+            }
+
+            $session[$key][TL_REFERER_ID]         = array_merge($session[$key][TL_REFERER_ID], $session[$key][$ref]);
+            $session[$key][TL_REFERER_ID]['last'] = $session[$key][$ref]['current'];
+        } elseif (count($session[$key]) > 1) {
+            $session[$key][TL_REFERER_ID] = end($session[$key]);
+        }
+
+        $session[$key][TL_REFERER_ID]['current'] = substr(\Environment::get('requestUri'), strlen(\Environment::get('path')) + 1);
+
+        $this->storeSession();
+    }
+
+    /**
+     * Check if we need to store the referer
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function storeReferer(Request $request)
+    {
+        if (!$request->query->has('act')
+            && !$request->query->has('key')
+            && !$request->query->has('token')
+            && !$request->query->has('state')
+            && 'feRedirect' !== $request->query->get('do')
+            && !$request->isXmlHttpRequest()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets the referer key
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    private function getRefererKey(Request $request)
+    {
+        return $request->query->has('popup') ? 'popupReferer' : 'referer';
+    }
+
+    /**
+     * Gets the session bag
+     *
+     * @return AttributeBagInterface
+     */
+    private function getSessionBag()
+    {
+        return $this->session->getBag('contao_backend');
+    }
+
+    /**
+     * Stores the session data in the database
+     */
+    private function storeSession()
+    {
+        // FIXME: Replace with security component
+        $userId = BackendUser::getInstance()->id;
+
+        $this->connection->prepare('UPDATE tl_user SET session=? WHERE id=?')
+            ->execute([
+                    serialize($this->getSessionBag()->all()),
+                    $userId
+                ]
+            );
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -92,6 +92,17 @@ services:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
         public: false
 
+    contao.store.session:
+        class: Contao\CoreBundle\EventListener\StoreSessionListener
+        calls:
+            - [setContainer, ["@service_container"]]
+        arguments:
+            - '@session'
+            - '@doctrine.dbal.default_connection'
+        tags:
+            # Priority must be higher than the framework bundle save session listener (-1000)
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+
     contao.warmer.internal_cache:
         class: Contao\CoreBundle\Cache\ContaoCacheWarmer
         public: false

--- a/src/Resources/contao/classes/BackendUser.php
+++ b/src/Resources/contao/classes/BackendUser.php
@@ -106,68 +106,6 @@ class BackendUser extends \User
 
 		$this->strIp = \Environment::get('ip');
 		$this->strHash = \Input::cookie($this->strCookie);
-
-		register_shutdown_function(array($this, 'storeSession'));
-	}
-
-
-	/**
-	 * Set the current referer and save the session
-	 */
-	public function storeSession()
-	{
-		$session = $this->Session->getData();
-
-		if (!isset($_GET['act']) && !isset($_GET['key']) && !isset($_GET['token']) && !isset($_GET['state']) && \Input::get('do') != 'feRedirect' && !\Environment::get('isAjaxRequest'))
-		{
-			$key = null;
-
-			list($path) = explode('?', \Environment::get('request'), 2);
-
-			if (substr($path, -7) == '/contao')
-			{
-				$key = \Input::get('popup') ? 'popupReferer' : 'referer';
-			}
-
-			if ($key !== null)
-			{
-				if (!is_array($session[$key]) || !is_array($session[$key][TL_REFERER_ID]))
-				{
-					$session[$key][TL_REFERER_ID]['last'] = '';
-				}
-
-				while (count($session[$key]) >= 25)
-				{
-					array_shift($session[$key]);
-				}
-
-				$ref = \Input::get('ref');
-
-				if ($ref != '' && isset($session[$key][$ref]))
-				{
-					if (!isset($session[$key][TL_REFERER_ID]))
-					{
-						$session[$key][TL_REFERER_ID] = array();
-					}
-
-					$session[$key][TL_REFERER_ID] = array_merge($session[$key][TL_REFERER_ID], $session[$key][$ref]);
-					$session[$key][TL_REFERER_ID]['last'] = $session[$key][$ref]['current'];
-				}
-				elseif (count($session[$key]) > 1)
-				{
-					$session[$key][TL_REFERER_ID] = end($session[$key]);
-				}
-
-				$session[$key][TL_REFERER_ID]['current'] = substr(\Environment::get('requestUri'), strlen(\Environment::get('path')) + 1);
-			}
-		}
-
-		// Store the session data
-		if ($this->intId != '')
-		{
-			$this->Database->prepare("UPDATE " . $this->strTable . " SET session=? WHERE id=?")
-						   ->execute(serialize($session), $this->intId);
-		}
 	}
 
 


### PR DESCRIPTION
This restores the back end user session storage process so you can navigate again. We can make it even more beautiful as soon as my other PR #183 is merged :-)

Also, tests are still missing but that's a starting point!