### PR TITLE
[RTM] Do not use legacy code

### DIFF
--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -291,6 +291,7 @@ class InitializeSystemListener extends ScopeAwareListener
 
             foreach ($langs as $lang) {
                 if (is_dir(__DIR__ . '/../../src/Resources/contao/languages/' . str_replace('-', '_', $lang))) {
+                    $_SESSION['TL_LANGUAGE'] = $lang; // backwards compatibility
                     $this->session->set('TL_LANGUAGE', $lang);
                     break;
                 }

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\ClassLoader;
 use Contao\Config;
 use Contao\CoreBundle\Session\Attribute\AttributeBagAdapter;
-use Contao\Environment;
 use Contao\Input;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -179,7 +179,7 @@ class InitializeSystemListener extends ScopeAwareListener
 
         $this->setRelativePath($request ? $request->getBasePath() : '');
         $this->initializeLegacySessionAccess();
-        $this->setDefaultLanguage();
+        $this->setDefaultLanguage($request);
 
         // Fully load the configuration
         $objConfig = Config::getInstance();
@@ -282,22 +282,26 @@ class InitializeSystemListener extends ScopeAwareListener
 
     /**
      * Sets the default language.
+     *
+     * @param Request $request
      */
-    private function setDefaultLanguage()
+    private function setDefaultLanguage(Request $request = null)
     {
-        if (!isset($_SESSION['TL_LANGUAGE'])) {
-            $langs = Environment::get('httpAcceptLanguage');
+        if (!$this->session->has('TL_LANGUAGE')) {
+            $langs = null !== $request ? $request->getLanguages() : [];
             array_push($langs, 'en'); // see #6533
 
             foreach ($langs as $lang) {
                 if (is_dir(__DIR__ . '/../../src/Resources/contao/languages/' . str_replace('-', '_', $lang))) {
-                    $_SESSION['TL_LANGUAGE'] = $lang;
+                    $this->session->set('TL_LANGUAGE', $lang);
                     break;
                 }
             }
         }
 
-        $GLOBALS['TL_LANGUAGE'] = $_SESSION['TL_LANGUAGE'];
+        if ($this->session->has('TL_LANGUAGE')) {
+            $GLOBALS['TL_LANGUAGE'] = $this->session->get('TL_LANGUAGE');
+        }
     }
 
     /**

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -297,9 +297,7 @@ class InitializeSystemListener extends ScopeAwareListener
             }
         }
 
-        if ($this->session->has('TL_LANGUAGE')) {
-            $GLOBALS['TL_LANGUAGE'] = $this->session->get('TL_LANGUAGE');
-        }
+        $GLOBALS['TL_LANGUAGE'] = $this->session->get('TL_LANGUAGE');
     }
 
     /**

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -401,16 +401,19 @@ class Environment
 	/**
 	 * Return the relative path to the base directory (e.g. /path)
 	 *
-	 * The real path is being set during the Contao initialization process, so
-	 * this method is only called if static::$arrCache['path'] is not set. It is
-	 * required to prevent the Environment class from returning the value of the
-	 * global $_SERVER['path'] variable.
-	 *
 	 * @return string The relative path to the installation
 	 */
 	protected static function path()
 	{
-		return '';
+	   /** @var KernelInterface $kernel */
+		global $kernel;
+
+		$container = $kernel->getContainer();
+
+		/** @var Request $request */
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		return $request->getBasePath();
 	}
 
 

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -405,7 +405,7 @@ class Environment
 	 */
 	protected static function path()
 	{
-	   /** @var KernelInterface $kernel */
+		/** @var KernelInterface $kernel */
 		global $kernel;
 
 		$container = $kernel->getContainer();


### PR DESCRIPTION
We need to get rid of as much legacy code as possible in the `InitializeSystemListener`. @discordier and I are having issues with all tests failing due to (newly introducing) proper error handling and need to fix those tests which is impossible without those cleanups :)