### PR TITLE
[RFC] Make the trailing slash for the backend route (/contao) optional

### DIFF
--- a/src/Controller/BackendController.php
+++ b/src/Controller/BackendController.php
@@ -40,7 +40,7 @@ class BackendController extends Controller
      *
      * @return Response
      *
-     * @Route("/", name="contao_backend")
+     * @Route("{optionalSlash}", requirements={"optionalSlash" = "[/]{0,1}"}, defaults={"optionalSlash" = "/"}, name="contao_backend")
      */
     public function mainAction()
     {


### PR DESCRIPTION
I'm (and probably others are) used to just type `http://example.com/contao` to get to the backend login.

Without this change, you have to type in the trailing slash (`http://example.com/contao/`) to get to the backend without any exception.

What do you think about?