### PR TITLE
[WIP/RFC] Regular and normalized package versions

### DIFF
--- a/src/Composer/VersionParser.php
+++ b/src/Composer/VersionParser.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Contao\CoreBundle\Composer;
+
+/**
+ * Version parser
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class VersionParser
+{
+    private static $modifierRegex = '[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?';
+
+    /**
+     * Returns the stability of a version
+     *
+     * @param  string $version
+     * @return string
+     */
+    public static function parseStability($version)
+    {
+        $version = preg_replace('{#.+$}i', '', $version);
+
+        if ('dev-' === substr($version, 0, 4) || '-dev' === substr($version, -4)) {
+            return 'dev';
+        }
+
+        preg_match('{'.self::$modifierRegex.'$}i', strtolower($version), $match);
+        if (!empty($match[3])) {
+            return 'dev';
+        }
+
+        if (!empty($match[1])) {
+            if ('beta' === $match[1] || 'b' === $match[1]) {
+                return 'beta';
+            }
+            if ('alpha' === $match[1] || 'a' === $match[1]) {
+                return 'alpha';
+            }
+            if ('rc' === $match[1]) {
+                return 'RC';
+            }
+        }
+
+        return 'stable';
+    }
+
+    public static function normalizeStability($stability)
+    {
+        $stability = strtolower($stability);
+
+        return $stability === 'rc' ? 'RC' : $stability;
+    }
+
+    /**
+     * Normalizes a version string to be able to perform comparisons on it
+     *
+     * @param  string                    $version
+     * @param  string                    $fullVersion optional complete version string to give more context
+     * @throws \UnexpectedValueException
+     * @return string
+     */
+    public function normalize($version, $fullVersion = null)
+    {
+        $version = trim($version);
+        if (null === $fullVersion) {
+            $fullVersion = $version;
+        }
+
+        // ignore aliases and just assume the alias is required instead of the source
+        if (preg_match('{^([^,\s]+) +as +([^,\s]+)$}', $version, $match)) {
+            $version = $match[1];
+        }
+
+        // ignore build metadata
+        if (preg_match('{^([^,\s+]+)\+[^\s]+$}', $version, $match)) {
+            $version = $match[1];
+        }
+
+        // match master-like branches
+        if (preg_match('{^(?:dev-)?(?:master|trunk|default)$}i', $version)) {
+            return '9999999-dev';
+        }
+
+        if ('dev-' === strtolower(substr($version, 0, 4))) {
+            return 'dev-'.substr($version, 4);
+        }
+
+        // match classical versioning
+        if (preg_match('{^v?(\d{1,3})(\.\d+)?(\.\d+)?(\.\d+)?'.self::$modifierRegex.'$}i', $version, $matches)) {
+            $version = $matches[1]
+                .(!empty($matches[2]) ? $matches[2] : '.0')
+                .(!empty($matches[3]) ? $matches[3] : '.0')
+                .(!empty($matches[4]) ? $matches[4] : '.0');
+            $index = 5;
+        } elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3})?)'.self::$modifierRegex.'$}i', $version, $matches)) { // match date-based versioning
+            $version = preg_replace('{\D}', '-', $matches[1]);
+            $index = 2;
+        } elseif (preg_match('{^v?(\d{4,})(\.\d+)?(\.\d+)?(\.\d+)?'.self::$modifierRegex.'$}i', $version, $matches)) {
+            $version = $matches[1]
+                .(!empty($matches[2]) ? $matches[2] : '.0')
+                .(!empty($matches[3]) ? $matches[3] : '.0')
+                .(!empty($matches[4]) ? $matches[4] : '.0');
+            $index = 5;
+        }
+
+        // add version modifiers if a version was matched
+        if (isset($index)) {
+            if (!empty($matches[$index])) {
+                if ('stable' === $matches[$index]) {
+                    return $version;
+                }
+                $version .= '-' . $this->expandStability($matches[$index]) . (!empty($matches[$index+1]) ? $matches[$index+1] : '');
+            }
+
+            if (!empty($matches[$index+2])) {
+                $version .= '-dev';
+            }
+
+            return $version;
+        }
+
+        // match dev branches
+        if (preg_match('{(.*?)[.-]?dev$}i', $version, $match)) {
+            try {
+                return $this->normalizeBranch($match[1]);
+            } catch (\Exception $e) {
+            }
+        }
+
+        $extraMessage = '';
+        if (preg_match('{ +as +'.preg_quote($version).'$}', $fullVersion)) {
+            $extraMessage = ' in "'.$fullVersion.'", the alias must be an exact version';
+        } elseif (preg_match('{^'.preg_quote($version).' +as +}', $fullVersion)) {
+            $extraMessage = ' in "'.$fullVersion.'", the alias source must be an exact version, if it is a branch name you should prefix it with dev-';
+        }
+
+        throw new \UnexpectedValueException('Invalid version string "'.$version.'"'.$extraMessage);
+    }
+
+    /**
+     * Extract numeric prefix from alias, if it is in numeric format, suitable for
+     * version comparison
+     *
+     * @param string $branch Branch name (e.g. 2.1.x-dev)
+     * @return string|false Numeric prefix if present (e.g. 2.1.) or false
+     */
+    public function parseNumericAliasPrefix($branch)
+    {
+        if (preg_match('/^(?P<version>(\d+\\.)*\d+)(?:\.x)?-dev$/i', $branch, $matches)) {
+            return $matches['version'].".";
+        }
+
+        return false;
+    }
+
+    /**
+     * Normalizes a branch name to be able to perform comparisons on it
+     *
+     * @param  string $name
+     * @return string
+     */
+    public function normalizeBranch($name)
+    {
+        $name = trim($name);
+
+        if (in_array($name, array('master', 'trunk', 'default'))) {
+            return $this->normalize($name);
+        }
+
+        if (preg_match('#^v?(\d+)(\.(?:\d+|[xX*]))?(\.(?:\d+|[xX*]))?(\.(?:\d+|[xX*]))?$#i', $name, $matches)) {
+            $version = '';
+            for ($i = 1; $i < 5; $i++) {
+                $version .= isset($matches[$i]) ? str_replace(array('*', 'X'), 'x', $matches[$i]) : '.x';
+            }
+
+            return str_replace('x', '9999999', $version).'-dev';
+        }
+
+        return 'dev-'.$name;
+    }
+
+    private function expandStability($stability)
+    {
+        $stability = strtolower($stability);
+
+        switch ($stability) {
+            case 'a':
+                return 'alpha';
+            case 'b':
+                return 'beta';
+            case 'p':
+            case 'pl':
+                return 'patch';
+            case 'rc':
+                return 'RC';
+            default:
+                return $stability;
+        }
+    }
+}

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle;
 
+use Contao\CoreBundle\Composer\VersionParser;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -51,7 +52,10 @@ class ContaoCoreBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(
-            new AddPackagesPass($container->getParameter('kernel.root_dir') . '/../vendor/composer/installed.json')
+            new AddPackagesPass(
+                $container->getParameter('kernel.root_dir') . '/../vendor/composer/installed.json',
+                new VersionParser()
+            )
         );
 
         $container->addCompilerPass(new AddResourcesPathsPass());

--- a/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\Test\DependencyInjection\Compiler;
 
+use Contao\CoreBundle\Composer\VersionParser;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -26,7 +27,7 @@ class AddPackagesPassTest extends TestCase
      */
     public function testInstantiation()
     {
-        $pass = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json');
+        $pass = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json', new VersionParser());
 
         $this->assertInstanceOf('Contao\\CoreBundle\\DependencyInjection\\Compiler\\AddPackagesPass', $pass);
     }
@@ -34,9 +35,9 @@ class AddPackagesPassTest extends TestCase
     /**
      * Tests processing the pass.
      */
-    public function testProcess()
+    public function testVersions()
     {
-        $pass      = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json');
+        $pass      = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json', new VersionParser());
         $container = new ContainerBuilder();
 
         $pass->process($container);
@@ -47,12 +48,40 @@ class AddPackagesPassTest extends TestCase
 
         $this->assertInternalType('array', $packages);
         $this->assertArrayHasKey('contao/test-bundle1', $packages);
-        $this->assertArrayNotHasKey('contao/test-bundle2', $packages);
+        $this->assertArrayHasKey('contao/test-bundle2', $packages);
         $this->assertArrayHasKey('contao/test-bundle3', $packages);
-        $this->assertArrayNotHasKey('contao/test-bundle4', $packages);
+        $this->assertArrayHasKey('contao/test-bundle4', $packages);
 
         $this->assertEquals('1.0.0', $packages['contao/test-bundle1']);
-        $this->assertEquals('1.0.9999999', $packages['contao/test-bundle3']);
+        $this->assertEquals('dev-develop', $packages['contao/test-bundle2']);
+        $this->assertEquals('1.0.x-dev', $packages['contao/test-bundle3']);
+        $this->assertEquals('invalid-dev', $packages['contao/test-bundle4']);
+    }
+
+    /**
+     * Tests processing the pass.
+     */
+    public function testNormalized()
+    {
+        $pass      = new AddPackagesPass($this->getRootDir() . '/vendor/composer/installed.json', new VersionParser());
+        $container = new ContainerBuilder();
+
+        $pass->process($container);
+
+        $this->assertTrue($container->hasParameter('kernel.normalized_packages'));
+
+        $packages = $container->getParameter('kernel.normalized_packages');
+
+        $this->assertInternalType('array', $packages);
+        $this->assertArrayHasKey('contao/test-bundle1', $packages);
+        $this->assertArrayHasKey('contao/test-bundle2', $packages);
+        $this->assertArrayHasKey('contao/test-bundle3', $packages);
+        $this->assertArrayHasKey('contao/test-bundle4', $packages);
+
+        $this->assertEquals('1.0.0.0', $packages['contao/test-bundle1']);
+        $this->assertEquals('dev-develop', $packages['contao/test-bundle2']);
+        $this->assertEquals('1.0.9999999.9999999-dev', $packages['contao/test-bundle3']);
+        $this->assertEquals('dev-invalid', $packages['contao/test-bundle4']);
     }
 
     /**
@@ -60,7 +89,7 @@ class AddPackagesPassTest extends TestCase
      */
     public function testFileNotFound()
     {
-        $pass      = new AddPackagesPass($this->getRootDir() . '/vendor/composer/invalid.json');
+        $pass      = new AddPackagesPass($this->getRootDir() . '/vendor/composer/invalid.json', new VersionParser());
         $container = new ContainerBuilder();
 
         $pass->process($container);

--- a/tests/Fixtures/vendor/composer/installed.json
+++ b/tests/Fixtures/vendor/composer/installed.json
@@ -6,11 +6,11 @@
     },
     {
         "name": "contao/test-bundle2",
-        "version_normalized": "dev-develop"
+        "version": "dev-develop"
     },
     {
         "name": "contao/test-bundle3",
-        "version_normalized": "dev-develop",
+        "version": "dev-develop",
         "extra": {
             "branch-alias": {
                 "dev-develop": "1.0.x-dev"
@@ -19,7 +19,7 @@
     },
     {
         "name": "contao/test-bundle4",
-        "version_normalized": "dev-develop",
+        "version": "dev-develop",
         "extra": {
             "branch-alias": {
                 "dev-develop": "invalid-dev"


### PR DESCRIPTION
People usually want the "real" installed version and not a normalized version of a package. This is especially true for our profiler, which currently shows *4.0.9999999* is installed.

This PR adds the Composer version parser and a new parameter to the kernel. We don't actually need the normalized version (because we only need packages for jQuery and MooTools), so we might think about not adding that information to the kernel but let Devs use the VersionParser directly.