### PR TITLE
Call parent TestCase::setUp() method in derived testcase classes.

### DIFF
--- a/tests/Analyzer/HtaccessAnalyzerTest.php
+++ b/tests/Analyzer/HtaccessAnalyzerTest.php
@@ -42,6 +42,7 @@ class HtaccessAnalyzerTest extends TestCase
      */
     public function testGrantsAccess()
     {
+        parent::setUp();
         $file = new SplFileInfo(
             $this->getRootDir() . '/system/modules/foobar/assets/.htaccess',
             'system/modules/foobar/assets',

--- a/tests/Contao/GdImageTest.php
+++ b/tests/Contao/GdImageTest.php
@@ -51,6 +51,7 @@ class GdImageTest extends TestCase
      */
     protected function setUp()
     {
+        parent::setUp();
         define('TL_ROOT', self::$rootDir);
     }
 

--- a/tests/Contao/ImageTest.php
+++ b/tests/Contao/ImageTest.php
@@ -60,6 +60,7 @@ class ImageTest extends TestCase
      */
     protected function setUp()
     {
+        parent::setUp();
         copy(__DIR__ . '/../Fixtures/images/dummy.jpg', self::$rootDir . '/dummy.jpg');
 
         $GLOBALS['TL_CONFIG']['debugMode'] = false;

--- a/tests/Contao/PictureTest.php
+++ b/tests/Contao/PictureTest.php
@@ -60,6 +60,7 @@ class PictureTest extends TestCase
      */
     protected function setUp()
     {
+        parent::setUp();
         copy(__DIR__ . '/../Fixtures/images/dummy.jpg', self::$rootDir . '/dummy.jpg');
 
         $GLOBALS['TL_CONFIG']['debugMode'] = false;

--- a/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -31,6 +31,7 @@ class ContaoCoreExtensionTest extends TestCase
      */
     protected function setUp()
     {
+        parent::setUp();
         $this->extension = new ContaoCoreExtension();
     }
 

--- a/tests/HttpKernel/Bundle/ContaoModuleBundleTest.php
+++ b/tests/HttpKernel/Bundle/ContaoModuleBundleTest.php
@@ -30,6 +30,7 @@ class ContaoModuleBundleTest extends TestCase
      */
     protected function setUp()
     {
+        parent::setUp();
         $this->bundle = new ContaoModuleBundle('foobar', $this->getRootDir() . '/app');
     }
 


### PR DESCRIPTION
As discussed in https://github.com/contao/core-bundle/pull/70#issuecomment-92273553 here is the separate PR for calling the setup method of the parent test case class.