### PR TITLE
[RTM] Move the user session handling to a separate listener

### DIFF
--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -218,14 +218,13 @@ class UserSessionListener extends ScopeAwareListener
         $bag = $this->getSessionBag();
 
         $refererOld = $bag->get('referer');
-
         if (!$this->canModifyFrontendSession($request, $refererOld)) {
             $this->storeSession();
             return;
         }
 
         $refererNew = [
-            'last'      => $refererOld['current'],
+            'last'      => (string) $refererOld['current'],
             'current'   => $this->getRelativeRequestUri($request)
         ];
 

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -147,20 +147,13 @@ class UserSessionListener extends ScopeAwareListener
 
         $ref = $request->query->get('ref', '');
 
+        // If the referer param is in the URL and in the session,
+        // current is moved to last
         if ('' !== $ref && isset($refererOld[$ref])) {
-            if (!isset($refererOld[$refererId])) {
-                $refererOld[$refererId] = [];
-            }
-
-            $refererNew[$refererId] = array_merge(
-                $refererOld[$refererId],
-                $refererOld[$ref]
-            );
             $refererNew[$refererId]['last'] = $refererOld[$ref]['current'];
-        } elseif (count($refererOld) > 1) {
-            $refererNew[$refererId] = end($refererOld);
         }
 
+        // Set new current referer
         $refererNew[$refererId]['current'] = $this->getRelativeRequestUri($request);
 
         $bag->set($key, $refererNew);

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -228,7 +228,7 @@ class UserSessionListener extends ScopeAwareListener
             'current'   => $this->getRelativeRequestUri($request)
         ];
 
-        $this->session->set('referer', $refererNew);
+        $bag->set('referer', $refererNew);
 
         $this->storeSession();
     }
@@ -252,7 +252,9 @@ class UserSessionListener extends ScopeAwareListener
         if (!$request->query->has('pdf')
             && !$request->query->has('file')
             && !$request->query->has('id')
-            && $refererOld['current'] !==  $this->getRelativeRequestUri($request)
+            && (isset($refererOld['current'])
+                && $refererOld['current'] !== $this->getRelativeRequestUri($request)
+            )
         ) {
             return true;
         }

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -142,21 +142,20 @@ class UserSessionListener extends ScopeAwareListener
         $key        = $request->query->has('popup') ? 'popupReferer' : 'referer';
         $refererId  = $request->attributes->get('_contao_referer_id');
         $bag        = $this->getSessionBag();
-        $refererOld = $this->prepareBackendReferer($bag->get($key), $refererId);
-        $refererNew = [];
+        $referer    = $this->prepareBackendReferer($bag->get($key), $refererId);
 
         $ref = $request->query->get('ref', '');
 
         // If the referer param is in the URL and in the session,
         // current is moved to last
-        if ('' !== $ref && isset($refererOld[$ref])) {
-            $refererNew[$refererId]['last'] = $refererOld[$ref]['current'];
+        if ('' !== $ref && isset($referer[$ref])) {
+            $referer[$refererId]['last'] = $referer[$ref]['current'];
         }
 
         // Set new current referer
-        $refererNew[$refererId]['current'] = $this->getRelativeRequestUri($request);
+        $referer[$refererId]['current'] = $this->getRelativeRequestUri($request);
 
-        $bag->set($key, $refererNew);
+        $bag->set($key, $referer);
 
         $this->storeSession();
     }
@@ -283,7 +282,7 @@ class UserSessionListener extends ScopeAwareListener
      */
     private function storeSession()
     {
-        $user   = $this->getUserObject();
+        $user = $this->getUserObject();
 
         $this->connection->prepare('UPDATE ' . $user->getTable() . ' SET session=? WHERE id=?')
             ->execute([
@@ -312,7 +311,7 @@ class UserSessionListener extends ScopeAwareListener
      */
     private function getRelativeRequestUri(Request $request)
     {
-        return substr(
+        return (string) substr(
             $request->getRequestUri(),
             strlen($request->getBasePath()) + 1
         );

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -257,6 +257,11 @@ class UserSessionListenerTest extends TestCase
         $request->attributes->set('_contao_referer_id', 'dummyTestRefererId');
         $request->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
 
+        $requestWithRefInUrl = new Request();
+        $requestWithRefInUrl->attributes->set('_contao_referer_id', 'dummyTestRefererId');
+        $requestWithRefInUrl->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
+        $requestWithRefInUrl->query->set('ref', 'dummyTestRefererId');
+
         return [
             'Test current referer null returns correct new referer for back end scope' => [
                 ContaoCoreBundle::SCOPE_BACKEND,
@@ -269,6 +274,27 @@ class UserSessionListenerTest extends TestCase
                 [
                     'dummyTestRefererId' => [
                         'last'      => '',
+                        // Make sure this one never contains a / at the beginning
+                        'current'   => 'path/of/contao?having&query&string=1'
+                    ]
+                ]
+            ],
+            'Test referer returns correct new referer for back end scope' => [
+                ContaoCoreBundle::SCOPE_BACKEND,
+                'contao_backend',
+                'Contao\\BackendUser',
+                'tl_user',
+                $requestWithRefInUrl,
+                'referer',
+                [
+                    'dummyTestRefererId' => [
+                        'last'      => '',
+                        'current'   => 'hi/I/am/your_current_referer.html'
+                    ]
+                ],
+                [
+                    'dummyTestRefererId' => [
+                        'last'      => 'hi/I/am/your_current_referer.html',
                         // Make sure this one never contains a / at the beginning
                         'current'   => 'path/of/contao?having&query&string=1'
                     ]

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -211,6 +211,7 @@ class UserSessionListenerTest extends TestCase
         $userClass,
         $userTable,
         Request $request,
+        $refererKey,
         $currentReferer,
         $expectedReferer
     ) {
@@ -234,7 +235,6 @@ class UserSessionListenerTest extends TestCase
         $token->expects($this->any())->method('getUser')->willReturn($user);
         $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         $tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
-        $refererKey = $request->query->has('popup') ? 'popupReferer' : 'referer';
         $container = $this->mockContainerWithContaoScopes();
         $container->enterScope($scope);
         $session = $this->mockSession();
@@ -264,6 +264,7 @@ class UserSessionListenerTest extends TestCase
                 'Contao\\BackendUser',
                 'tl_user',
                 $request,
+                'referer',
                 null,
                 [
                     'dummyTestRefererId' => [
@@ -272,7 +273,17 @@ class UserSessionListenerTest extends TestCase
                         'current'   => 'path/of/contao?having&query&string=1'
                     ]
                 ]
-            ]
+            ],
+            'Test current referer null returns null for front end scope' => [
+                ContaoCoreBundle::SCOPE_FRONTEND,
+                'contao_frontend',
+                'Contao\\FrontendUser',
+                'tl_member',
+                $request,
+                'referer',
+                null,
+                null
+            ],
         ];
     }
 

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -42,9 +42,11 @@ class UserSessionListenerTest extends TestCase
     /**
      * Test session bag is never requested when having no user on kernel.request.
      *
+     * @param   null|AnonymousToken $noUserReturn
+     *
      * @dataProvider noUserProvider
      */
-    public function testListenerSkipIfNoUserOnKernelRequest($return)
+    public function testListenerSkipIfNoUserOnKernelRequest($noUserReturn)
     {
         $request = new Request();
         $responseEvent = new GetResponseEvent(
@@ -57,7 +59,7 @@ class UserSessionListenerTest extends TestCase
         $session->expects($this->never())->method('getBag');
 
         $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-        $tokenStorage->expects($this->once())->method('getToken')->willReturn($return);
+        $tokenStorage->expects($this->once())->method('getToken')->willReturn($noUserReturn);
 
         $listener = $this->getListener($session, null, $tokenStorage);
         $listener->onKernelRequest($responseEvent);
@@ -87,9 +89,11 @@ class UserSessionListenerTest extends TestCase
      * Test neither session bag nor doctrine is requested when
      * having no user on kernel.response.
      *
+     * @param   null|AnonymousToken $noUserReturn
+     *
      * @dataProvider noUserProvider
      */
-    public function testListenerSkipIfNoUserOnKernelResponse($return)
+    public function testListenerSkipIfNoUserOnKernelResponse($noUserReturn)
     {
         $request = new Request();
         $response = new Response();
@@ -104,7 +108,7 @@ class UserSessionListenerTest extends TestCase
         $session->expects($this->never())->method('getBag');
 
         $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-        $tokenStorage->expects($this->once())->method('getToken')->willReturn($return);
+        $tokenStorage->expects($this->once())->method('getToken')->willReturn($noUserReturn);
 
         $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
         $connection->expects($this->never())->method('prepare');

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -310,6 +310,23 @@ class UserSessionListenerTest extends TestCase
                 null,
                 null
             ],
+            'Test referer returns correct new referer for front end scope' => [
+                ContaoCoreBundle::SCOPE_FRONTEND,
+                'contao_frontend',
+                'Contao\\FrontendUser',
+                'tl_member',
+                $requestWithRefInUrl,
+                'referer',
+                [
+                    'last'      => '',
+                    'current'   => 'hi/I/am/your_current_referer.html'
+                ],
+                [
+                    'last'      => 'hi/I/am/your_current_referer.html',
+                    // Make sure this one never contains a / at the beginning
+                    'current'   => 'path/of/contao?having&query&string=1'
+                ]
+            ],
         ];
     }
 

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -112,7 +112,7 @@ class UserSessionListenerTest extends TestCase
 
         $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
         $connection->expects($this->never())->method('prepare');
-        $connection->expects($this->never())->method('excecute');
+        $connection->expects($this->never())->method('execute');
 
         $listener = $this->getListener($session, $connection, $tokenStorage);
 
@@ -137,7 +137,7 @@ class UserSessionListenerTest extends TestCase
         $session->expects($this->never())->method('getBag');
         $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
         $connection->expects($this->never())->method('prepare');
-        $connection->expects($this->never())->method('excecute');
+        $connection->expects($this->never())->method('execute');
 
         $listener = $this->getListener($session, $connection);
 

--- a/tests/Fixtures/library/User.php
+++ b/tests/Fixtures/library/User.php
@@ -10,4 +10,6 @@ abstract class User
     }
 
     public function __get($key) {}
+
+    public function getTable() {}
 }


### PR DESCRIPTION
Follow-Up PR to https://github.com/contao/core-bundle/pull/184.

Now also contains the FrontendUser handling and does the loading process as well. In addition, `TL_REFERER_ID` has been replaced as well.

Tests still to be added.