### PR TITLE
[RTM] Fix symlinks command

### DIFF
--- a/src/Command/SymlinksCommand.php
+++ b/src/Command/SymlinksCommand.php
@@ -212,11 +212,11 @@ class SymlinksCommand extends LockedCommand implements ContainerAwareInterface
      */
     private function validateSymlink($source, $target, $rootDir)
     {
-        if ($source == '') {
+        if ($source === '') {
             throw new \InvalidArgumentException('The symlink source must not be empty.');
         }
 
-        if ($target == '') {
+        if ($target === '') {
             throw new \InvalidArgumentException('The symlink target must not be empty.');
         }
 

--- a/src/Command/SymlinksCommand.php
+++ b/src/Command/SymlinksCommand.php
@@ -159,7 +159,13 @@ class SymlinksCommand extends LockedCommand implements ContainerAwareInterface
     {
         /** @var SplFileInfo $file */
         foreach ($finder as $file) {
-            $path = $prepend . '/' . $file->getRelativePath();
+            $path = $prepend;
+
+            // Don't add a trailing slash, when relativePath is ''
+            if (strlen($file->getRelativePath())) {
+                $path .= '/' . $file->getRelativePath();
+            }
+
             $this->symlink(str_repeat('../', substr_count($path, '/') + 1) . $path, "web/$path", $rootDir, $output);
         }
     }

--- a/src/Command/SymlinksCommand.php
+++ b/src/Command/SymlinksCommand.php
@@ -212,11 +212,11 @@ class SymlinksCommand extends LockedCommand implements ContainerAwareInterface
      */
     private function validateSymlink($source, $target, $rootDir)
     {
-        if ($source === '') {
+        if ('' === $source) {
             throw new \InvalidArgumentException('The symlink source must not be empty.');
         }
 
-        if ($target === '') {
+        if ('' === $target) {
             throw new \InvalidArgumentException('The symlink target must not be empty.');
         }
 


### PR DESCRIPTION
This commit fixes an issue with the symlink command (`php app/console contao:symlinks`) to symlink the `files`-directory (upload directory).

**Before (e.g. `$uploadPath = 'files'`):**
`files` gets a `/` added and the result is `../../files` and ends up with

```bash
[Symfony\Component\Filesystem\Exception\IOException]                                                                                              
  Failed to create symbolic link from "../../files/" to "/var/www/dev/contao-4/standard-edition-develop/web/files/".
```

**After (same `$uploadPath`):**
```bash
Added web/files as symlink to ../files.
Added system/themes/flexible as symlink to ../../vendor/contao/core-bundle/src/Resources/contao/themes/flexible.
Added web/assets as symlink to ../assets.
Added web/system/themes as symlink to ../../system/themes.
Added system/logs as symlink to ../app/logs.
```
Secondary, I changed some code style within the same file.