### PR TITLE
Database schema: Specified key was too long

### DIFF
--- a/src/Resources/contao/dca/tl_files.php
+++ b/src/Resources/contao/dca/tl_files.php
@@ -148,7 +148,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		'path' => array
 		(
 			'eval'                    => array('unique'=>true),
-			'sql'                     => "varchar(1022) NOT NULL default ''",
+			'sql'                     => "varchar(333) NOT NULL default ''",
 		),
 		'extension' => array
 		(


### PR DESCRIPTION
During a fresh install on `contao/install` while creating the tables:

```
An exception occurred while executing 'CREATE TABLE `tl_files` (
`id` int(10) unsigned NOT NULL auto_increment,
`pid` binary(16) NULL,
`tstamp` int(10) unsigned NOT NULL default '0',
`uuid` binary(16) NULL,
`type` varchar(16) NOT NULL default '',
`path` varchar(1022) NOT NULL default '',
`extension` varchar(16) NOT NULL default '',
`hash` varchar(32) NOT NULL default '',
`found` char(1) NOT NULL default '1',
`name` varchar(255) NOT NULL default '',
`importantPartX` int(10) NOT NULL default '0',
`importantPartY` int(10) NOT NULL default '0',
`importantPartWidth` int(10) NOT NULL default '0',
`importantPartHeight` int(10) NOT NULL default '0',
`meta` blob NULL,
PRIMARY KEY (`id`),
KEY `pid` (`pid`),
UNIQUE KEY `uuid` (`uuid`),
KEY `path` (`path`),
KEY `extension` (`extension`)
) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE utf8_general_ci;':

SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000 bytes
```

It would acutally work with `varchar(333)` - max key length = 1000 bytes, UTF-8 character uses 3 bytes, so max length of the `varchar` is 333 (see 5fbe4a9).

What's the reason to use `varchar(1022)` for the field `path` ?