### PR TITLE
[RTM] Locale handling

### DIFF
--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -293,20 +293,14 @@ class InitializeSystemListener extends ScopeAwareListener
      */
     private function setDefaultLanguage(Request $request = null)
     {
-        if (!$this->session->has('TL_LANGUAGE')) {
-            $langs = $request ? $request->getLanguages() : [];
-            array_push($langs, 'en'); // see #6533
+        $language = 'en';
 
-            foreach ($langs as $lang) {
-                if (is_dir(__DIR__ . '/../../src/Resources/contao/languages/' . str_replace('-', '_', $lang))) {
-                    $this->session->set('TL_LANGUAGE', $lang);
-                    break;
-                }
-            }
+        if (null !== $request) {
+            $language = str_replace('_', '-', $request->getLocale());
         }
 
-        $GLOBALS['TL_LANGUAGE']  = $this->session->get('TL_LANGUAGE');
-        $_SESSION['TL_LANGUAGE'] = $this->session->get('TL_LANGUAGE'); // backwards compatibility
+        $GLOBALS['TL_LANGUAGE']  = $language;
+        $_SESSION['TL_LANGUAGE'] = $language; // backwards compatibility
     }
 
     /**

--- a/src/EventListener/InitializeSystemListener.php
+++ b/src/EventListener/InitializeSystemListener.php
@@ -299,7 +299,7 @@ class InitializeSystemListener extends ScopeAwareListener
             $language = str_replace('_', '-', $request->getLocale());
         }
 
-        $GLOBALS['TL_LANGUAGE']  = $language;
+        $GLOBALS['TL_LANGUAGE']  = $language; // backwards compatibility
         $_SESSION['TL_LANGUAGE'] = $language; // backwards compatibility
     }
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -59,18 +59,15 @@ class LocaleListener extends ScopeAwareListener
         $request = $event->getRequest();
         $session = $request->getSession();
 
-        if ($locale = $request->attributes->get('_locale')) {
-            $locale = $this->formatLocaleID($locale);
-            $request->attributes->set('_locale', $locale);
-            $session->set('_locale', $locale);
-        } elseif ($locale = $session->get('_locale')) {
-            $request->attributes->set('_locale', $locale);
+        if ($request->attributes->has('_locale')) {
+            $locale = $this->formatLocaleID($request->attributes->get('_locale'));
+        } elseif (null !== $session && $session->has('_locale')) {
+            $locale = $session->get('_locale');
         } else {
             $locale = $this->getPreferredLocale($request);
-
-            $request->attributes->set('_locale', $locale);
-            $session->set('_locale', $locale);
         }
+
+        $this->saveLocale($request, $locale);
     }
 
     /**
@@ -127,5 +124,15 @@ class LocaleListener extends ScopeAwareListener
         }
 
         return $locale;
+    }
+
+
+    private function saveLocale(Request $request, $locale)
+    {
+        $request->attributes->set('_locale', $locale);
+
+        if ($request->hasSession()) {
+            $request->getSession()->set('_locale', $locale);
+        }
     }
 }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -60,7 +60,9 @@ class LocaleListener extends ScopeAwareListener
         $session = $request->getSession();
 
         if ($locale = $request->attributes->get('_locale')) {
-            $session->set('_locale', str_replace('-', '_', strtolower($locale)));
+            $locale = str_replace('-', '_', strtolower($locale));
+            $request->attributes->set('_locale', $locale);
+            $session->set('_locale', $locale);
         } elseif ($locale = $session->get('_locale')) {
             $request->attributes->set('_locale', $locale);
         } else {

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -60,7 +60,7 @@ class LocaleListener extends ScopeAwareListener
         $session = $request->getSession();
 
         if ($locale = $request->attributes->get('_locale')) {
-            $locale = str_replace('-', '_', strtolower($locale));
+            $locale = $this->formatLocaleID($locale);
             $request->attributes->set('_locale', $locale);
             $session->set('_locale', $locale);
         } elseif ($locale = $session->get('_locale')) {
@@ -103,5 +103,29 @@ class LocaleListener extends ScopeAwareListener
         array_unshift($languages, $this->defaultLocale);
 
         return $request->getPreferredLanguage(array_unique($languages));
+    }
+
+    /**
+     * Format a string to represent a locale ID.
+     *
+     * @param $locale
+     *
+     * @return string
+     */
+    private function formatLocaleID($locale)
+    {
+        $values = preg_split('/-|_/', $locale);
+
+        if (count($values) > 2 || strlen($values[0]) > 2 || (isset($values[1]) && strlen($values[1]) > 2)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not a supported locale.', $locale));
+        }
+
+        $locale = strtolower($values[0]);
+
+        if (isset($values[1])) {
+            $locale .= '_' . strtoupper($values[1]);
+        }
+
+        return $locale;
     }
 }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Config\ResourceFinder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+
+/**
+ * Makes sure the locale is available in request and persisted in the session.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class LocaleListener extends ScopeAwareListener
+{
+    /**
+     * @var ResourceFinder
+     */
+    private $resourceFinder;
+
+    /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
+     * Constructor.
+     *
+     * @param ResourceFinder $resourceFinder
+     * @param string         $defaultLocale The default locale
+     */
+    public function __construct(ResourceFinder $resourceFinder, $defaultLocale)
+    {
+        $this->resourceFinder = $resourceFinder;
+        $this->defaultLocale  = $defaultLocale;
+    }
+
+    /**
+     * Set the default locale based on the request or session.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$this->isContaoScope()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $request->getSession();
+
+        if ($locale = $request->attributes->get('_locale')) {
+            $session->set('_locale', str_replace('-', '_', strtolower($locale)));
+        } elseif ($locale = $session->get('_locale')) {
+            $request->attributes->set('_locale', $locale);
+        } else {
+            $locale = $this->getPreferredLocale($request);
+
+            $request->attributes->set('_locale', $locale);
+            $session->set('_locale', $locale);
+        }
+    }
+
+    /**
+     * Gets the preferred locale ID from browser Accept-Language headers.
+     *
+     * @param Request $request The request object
+     *
+     * @return string The preferred locale ID
+     */
+    private function getPreferredLocale(Request $request)
+    {
+        $languages = array_values(
+            array_map(
+                function(SplFileInfo $file) {
+                    return $file->getFilename();
+                },
+                iterator_to_array($this->resourceFinder->findIn('languages')->depth(0)->directories())
+            )
+        );
+
+        // The default locale must be the first supported language (also see contao/core#6533)
+        array_unshift($languages, $this->defaultLocale);
+
+        return $request->getPreferredLanguage(array_unique($languages));
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -68,8 +68,8 @@ services:
     contao.listener.locale:
         class: Contao\CoreBundle\EventListener\LocaleListener
         arguments:
-            - '@contao.resource_finder'
             - '%kernel.default_locale%'
+            - '%kernel.root_dir%'
         arguments:
             - "@service_container"
         tags:

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -5,10 +5,14 @@
 # Symfony route listener (defaults to 32).
 #
 # - 30: ContainerScopeListener
-# - 28: RefererIdListener
-# - 26: InitializeSystemListener
-# - 24: ToggleViewListener
-# - 22: OutputFromCacheListener
+# - 20: RefererIdListener
+#
+# The priorites of the following listeners must be lower than the one of the
+# Symfony locale listener (defaults to 16).
+#
+# - 10: InitializeSystemListener
+# - 5:  ToggleViewListener
+# - 5:  OutputFromCacheListener
 #
 # Session listener
 #
@@ -59,7 +63,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 26 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 10 }
             - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }
 
     contao.listener.output_from_cache:
@@ -67,7 +71,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 22 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
 
     contao.listener.pretty_error_screens:
         class: Contao\CoreBundle\EventListener\PrettyErrorScreenListener
@@ -85,7 +89,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 28 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 
     contao.listener.response_exception:
         class: Contao\CoreBundle\EventListener\ResponseExceptionListener
@@ -105,7 +109,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 24 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
 
     contao.listener.user_session:
         class: Contao\CoreBundle\EventListener\UserSessionListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -6,6 +6,7 @@
 #
 # - 30: ContainerScopeListener
 # - 20: RefererIdListener
+# - 20: LocaleListener
 #
 # The priorites of the following listeners must be lower than the one of the
 # Symfony locale listener (defaults to 16).
@@ -65,6 +66,16 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 10 }
             - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }
+
+    contao.listener.locale:
+        class: Contao\CoreBundle\EventListener\LocaleListener
+        arguments:
+            - '@contao.resource_finder'
+            - '%kernel.default_locale%'
+        arguments:
+            - "@service_container"
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 
     contao.listener.output_from_cache:
         class: Contao\CoreBundle\EventListener\OutputFromCacheListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -11,9 +11,9 @@
 # The priorites of the following listeners must be lower than the one of the
 # Symfony locale listener (defaults to 16).
 #
-# - 10: InitializeSystemListener
-# - 5:  ToggleViewListener
-# - 5:  OutputFromCacheListener
+# - 10:   InitializeSystemListener
+# - -15:  ToggleViewListener
+# - -20:  OutputFromCacheListener
 #
 # Session listener
 #
@@ -82,7 +82,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -20 }
 
     contao.listener.pretty_error_screens:
         class: Contao\CoreBundle\EventListener\PrettyErrorScreenListener
@@ -120,7 +120,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -15 }
 
     contao.listener.user_session:
         class: Contao\CoreBundle\EventListener\UserSessionListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -11,9 +11,7 @@
 # The priorites of the following listeners must be lower than the one of the
 # Symfony locale listener (defaults to 16).
 #
-# - 10:   InitializeSystemListener
-# - -15:  ToggleViewListener
-# - -20:  OutputFromCacheListener
+# - 10: InitializeSystemListener
 #
 # Session listener
 #
@@ -82,7 +80,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -20 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     contao.listener.pretty_error_screens:
         class: Contao\CoreBundle\EventListener\PrettyErrorScreenListener
@@ -120,7 +118,7 @@ services:
         calls:
             - [setContainer, ["@service_container"]]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -15 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     contao.listener.user_session:
         class: Contao\CoreBundle\EventListener\UserSessionListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -67,11 +67,12 @@ services:
 
     contao.listener.locale:
         class: Contao\CoreBundle\EventListener\LocaleListener
+        factory: [Contao\CoreBundle\EventListener\LocaleListener, createWithLocales]
         arguments:
             - '%kernel.default_locale%'
             - '%kernel.root_dir%'
-        arguments:
-            - "@service_container"
+        calls:
+            - ['setContainer', ["@service_container"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 

--- a/src/Resources/contao/classes/BackendUser.php
+++ b/src/Resources/contao/classes/BackendUser.php
@@ -345,6 +345,9 @@ class BackendUser extends \User
 	 */
 	protected function setUserFromDb()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
 		$this->intId = $this->id;
 
 		// Unserialize values
@@ -357,7 +360,10 @@ class BackendUser extends \User
 		}
 
 		$GLOBALS['TL_USERNAME'] = $this->username;
-		$GLOBALS['TL_LANGUAGE'] = str_replace('_', '-', $this->language);
+		$GLOBALS['TL_LANGUAGE'] = str_replace('_', '-', $this->language); // backwards compatibility
+
+		$kernel->getContainer()->get('request_stack')->getCurrentRequest()->setLocale($this->language);
+		$kernel->getContainer()->get('translator')->setLocale($this->language);
 
 		\Config::set('showHelp', $this->showHelp);
 		\Config::set('useRTE', $this->useRTE);

--- a/src/Resources/contao/classes/FrontendUser.php
+++ b/src/Resources/contao/classes/FrontendUser.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to manage front end users.
@@ -259,6 +261,9 @@ class FrontendUser extends \User
 	 */
 	protected function setUserFromDb()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
 		$this->intId = $this->id;
 
 		// Unserialize values
@@ -273,7 +278,11 @@ class FrontendUser extends \User
 		// Set language
 		if ($this->language != '')
 		{
-			$GLOBALS['TL_LANGUAGE'] = str_replace('_', '-', $this->language);
+			// FIXME: is the frontend user language ever used?
+			$kernel->getContainer()->get('request_stack')->getCurrentRequest()->setLocale($this->language);
+			$kernel->getContainer()->get('translator')->setLocale($this->language);
+
+			$GLOBALS['TL_LANGUAGE'] = str_replace('_', '-', $this->language); // backwards compatibility
 		}
 
 		$GLOBALS['TL_USERNAME'] = $this->username;

--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -62,8 +62,15 @@ class PageRegular extends \Frontend
 	 */
 	protected function prepare($objPage)
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
 		$GLOBALS['TL_KEYWORDS'] = '';
 		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
+
+		$locale  = str_replace('-', '_', $objPage->language);
+		$kernel->getContainer()->get('request_stack')->getCurrentRequest()->setLocale($locale);
+		$kernel->getContainer()->get('translator')->setLocale($locale);
 
 		\System::loadLanguageFile('default');
 

--- a/tests/EventListener/LocaleListenerTest.php
+++ b/tests/EventListener/LocaleListenerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\EventListener\LocaleListener;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests the LocaleListener class.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class LocaleListenerTest extends TestCase
+{
+    /**
+     * @var LocaleListener
+     */
+    private $listener;
+
+    public function setUp()
+    {
+        $this->listener = new LocaleListener('en', $this->getRootDir() . '/app');
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\LocaleListener', $this->listener);
+    }
+
+    /**
+     * @dataProvider localeTestData
+     *
+     * @param string $input
+     * @param string $expected
+     */
+    public function testWithRequestAttribute($input, $expected)
+    {
+        $kernel  = $this->mockKernel();
+        $session = $this->mockSession();
+        $request = Request::create('/');
+        $event   = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $kernel->getContainer()->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
+        $request->setSession($session);
+        $this->listener->setContainer($kernel->getContainer());
+
+        $request->attributes->set('_locale', $input);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals($expected, $request->attributes->get('_locale'));
+        $this->assertEquals($expected, $session->get('_locale'));
+    }
+
+    /**
+     * @dataProvider localeTestData
+     *
+     * @param string $input
+     * @param string $expected
+     */
+    public function testWithSessionValue($input, $expected)
+    {
+        $kernel  = $this->mockKernel();
+        $session = $this->mockSession();
+        $request = Request::create('/');
+        $event   = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $kernel->getContainer()->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
+        $request->setSession($session);
+        $this->listener->setContainer($kernel->getContainer());
+
+        // The session values is already formatted, so we're passing in $expected here
+        $session->set('_locale', $expected);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals($expected, $request->attributes->get('_locale'));
+        $this->assertEquals($expected, $session->get('_locale'));
+    }
+
+    public function testFindsFallback()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testWithoutContainer()
+    {
+        $kernel  = $this->mockKernel();
+        $session = $this->mockSession();
+        $request = Request::create('/');
+        $event   = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $request->setSession($session);
+
+        $request->attributes->set('_locale', 'zh-TW');
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals('zh-TW', $request->attributes->get('_locale'));
+        $this->assertFalse($session->has('_locale'));
+    }
+
+    public function testWithoutContaoScope()
+    {
+        $kernel  = $this->mockKernel();
+        $session = $this->mockSession();
+        $request = Request::create('/');
+        $event   = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $request->setSession($session);
+        $this->listener->setContainer($kernel->getContainer());
+
+        $request->attributes->set('_locale', 'zh-TW');
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals('zh-TW', $request->attributes->get('_locale'));
+        $this->assertFalse($session->has('_locale'));
+    }
+
+    /**
+     * @dataProvider localeTestData
+     *
+     * @param string $input
+     * @param string $expected
+     */
+    public function testWithoutSession($input, $expected)
+    {
+        $kernel  = $this->mockKernel();
+        $request = Request::create('/');
+        $event   = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $this->assertNull($request->getSession());
+
+        $kernel->getContainer()->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
+        $request->attributes->set('_locale', $input);
+
+        $this->listener->setContainer($kernel->getContainer());
+        $this->listener->onKernelRequest($event);
+
+        $this->assertEquals($expected, $request->attributes->get('_locale'));
+    }
+
+    public function localeTestData()
+    {
+        return [
+            ['en', 'en'],
+            ['de', 'de'],
+            ['de-CH', 'de_CH'],
+            ['de_CH', 'de_CH'],
+            ['zh-tw', 'zh_TW']
+        ];
+    }
+}


### PR DESCRIPTION
Because there will be no quick solution to #233, this pull request implements the most simple solution:

1. Use `kernel.request` event to convert our route locale (e.g. `de-CH`) to a locale ID (`de_CH`).
2. Set request and translator locale when page or user is loaded
3. Use new locale in `InitializeSystemListener`

#### TODO
 - [ ] Should we replace `$GLOBALS['TL_LANGUAGE']` everywhere (in legacy code)?