### PR TITLE
Prevent recursion when creating symlinks

### DIFF
--- a/src/Command/SymlinksCommand.php
+++ b/src/Command/SymlinksCommand.php
@@ -156,10 +156,20 @@ class SymlinksCommand extends LockedCommand implements ContainerAwareInterface
      */
     private function createSymlinksFromFinder(Finder $finder, $prepend, $rootDir, OutputInterface $output)
     {
+        $processed = [];
+
+        $finder->sortByName();
+
         /** @var SplFileInfo $file */
         foreach ($finder as $file) {
+            if (!empty($processed) && preg_match('{^' . implode('|^', $processed) . '}', $file->getRelativePath())) {
+                continue;
+            }
+
             $path = rtrim($prepend . '/' . $file->getRelativePath(), '/');
             $this->symlink($path, "web/$path", $rootDir, $output);
+
+            $processed[] = $file->getRelativePath();
         }
     }
 

--- a/tests/Fixtures/system/modules/foobar/assets/subfolder/.htaccess
+++ b/tests/Fixtures/system/modules/foobar/assets/subfolder/.htaccess
@@ -1,0 +1,2 @@
+# Grant access
+Require all granted


### PR DESCRIPTION
Otherwise a .htaccess file in a subfolder of an already published folder would generate an exception. This is for example the case with Isotope eCommerce (see https://github.com/isotope/core/tree/master/system/modules/isotope)