### PR TITLE
[RTM] Use the Symfony session instead of $this->Session

### DIFF
--- a/src/EventListener/AbstractUserAwareListener.php
+++ b/src/EventListener/AbstractUserAwareListener.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Provides methods to test if there is a user.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+abstract class AbstractUserAwareListener extends AbstractScopeAwareListener
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    /**
+     * Sets the token storage object.
+     *
+     * @param TokenStorageInterface $tokenStorage The token storage object
+     */
+    public function setTokenStorage(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Checks if there is an authenticated user.
+     *
+     * @return bool True if there is an authenticated user
+     */
+    protected function hasUser()
+    {
+        $user = $this->tokenStorage->getToken();
+
+        if (null === $user) {
+            return false;
+        }
+
+        return (!$user instanceof AnonymousToken);
+    }
+}

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -13,8 +13,6 @@ namespace Contao\CoreBundle\EventListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Stores the referer in the session.
@@ -22,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * @author Yanick Witschi <https://github.com/toflar>
  * @author Leo Feyer <https://github.com/leofeyer>
  */
-class StoreRefererListener extends AbstractScopeAwareListener
+class StoreRefererListener extends AbstractUserAwareListener
 {
     /**
      * @var SessionInterface
@@ -30,20 +28,13 @@ class StoreRefererListener extends AbstractScopeAwareListener
     private $session;
 
     /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
-    /**
      * Constructor.
      *
-     * @param SessionInterface      $session      The session object
-     * @param TokenStorageInterface $tokenStorage The token storage object
+     * @param SessionInterface $session The session object
      */
-    public function __construct(SessionInterface $session, TokenStorageInterface $tokenStorage)
+    public function __construct(SessionInterface $session)
     {
-        $this->session      = $session;
-        $this->tokenStorage = $tokenStorage;
+        $this->session = $session;
     }
 
     /**
@@ -64,22 +55,6 @@ class StoreRefererListener extends AbstractScopeAwareListener
         } else {
             $this->storeFrontendReferer($request);
         }
-    }
-
-    /**
-     * Checks if there is an authenticated user.
-     *
-     * @return bool True if there is an authenticated user
-     */
-    private function hasUser()
-    {
-        $user = $this->tokenStorage->getToken();
-
-        if (null === $user) {
-            return false;
-        }
-
-        return (!$user instanceof AnonymousToken);
     }
 
     /**

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Stores the referer in the session.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class StoreRefererListener extends AbstractScopeAwareListener
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * Constructor.
+     *
+     * @param SessionInterface      $session      The session object
+     * @param TokenStorageInterface $tokenStorage The token storage object
+     */
+    public function __construct(SessionInterface $session, TokenStorageInterface $tokenStorage)
+    {
+        $this->session      = $session;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * Stores the referer in the session.
+     *
+     * @param FilterResponseEvent $event The event object
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$this->hasUser() || !$this->isContaoMasterRequest($event)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if ($this->isBackendScope()) {
+            $this->storeBackendReferer($request);
+        } else {
+            $this->storeFrontendReferer($request);
+        }
+    }
+
+    /**
+     * Checks if there is an authenticated user.
+     *
+     * @return bool True if there is an authenticated user
+     */
+    private function hasUser()
+    {
+        $user = $this->tokenStorage->getToken();
+
+        if (null === $user) {
+            return false;
+        }
+
+        return (!$user instanceof AnonymousToken);
+    }
+
+    /**
+     * Stores the back end referer.
+     *
+     * @param Request $request The request object
+     */
+    private function storeBackendReferer(Request $request)
+    {
+        if (!$this->canModifyBackendSession($request)) {
+            return;
+        }
+
+        $key       = $request->query->has('popup') ? 'popupReferer' : 'referer';
+        $refererId = $request->attributes->get('_contao_referer_id');
+        $referers  = $this->prepareBackendReferer($refererId, $this->session->get($key));
+        $ref       = $request->query->get('ref', '');
+
+        // Move current to last if the referer is in both the URL and the session
+        if ('' !== $ref && isset($referers[$ref])) {
+            $referers[$refererId]['last'] = $referers[$ref]['current'];
+        }
+
+        // Set new current referer
+        $referers[$refererId]['current'] = $this->getRelativeRequestUri($request);
+
+        $this->session->set($key, $referers);
+    }
+
+    /**
+     * Checks if the back end session can be modified.
+     *
+     * @param Request $request The request object
+     *
+     * @return bool True if the back end session can be modified
+     */
+    private function canModifyBackendSession(Request $request)
+    {
+        return !$request->query->has('act')
+            && !$request->query->has('key')
+            && !$request->query->has('token')
+            && !$request->query->has('state')
+            && 'feRedirect' !== $request->query->get('do')
+            && !$request->isXmlHttpRequest()
+        ;
+    }
+
+    /**
+     * Prepares the back end referer array.
+     *
+     * @param string     $refererId The referer ID
+     * @param array|null $referers  The old referer data
+     *
+     * @return array The back end referer URLs
+     */
+    private function prepareBackendReferer($refererId, array $referers = null)
+    {
+        if (!is_array($referers)) {
+            $referers = [];
+        }
+
+        if (!isset($referers[$refererId]) || !is_array($referers[$refererId])) {
+            $referers[$refererId] = ['last' => ''];
+        }
+
+        // Make sure we never have more than 25 different referer URLs
+        while (count($referers) >= 25) {
+            array_shift($referers);
+        }
+
+        return $referers;
+    }
+
+    /**
+     * Stores the front end referer.
+     *
+     * @param Request $request The request object
+     */
+    private function storeFrontendReferer(Request $request)
+    {
+        $refererOld = $this->session->get('referer');
+
+        if (!$this->canModifyFrontendSession($request, $refererOld)) {
+            return;
+        }
+
+        $refererNew = [
+            'last'    => (string) $refererOld['current'],
+            'current' => $this->getRelativeRequestUri($request),
+        ];
+
+        $this->session->set('referer', $refererNew);
+    }
+
+    /**
+     * Checks if the front end session can be modified.
+     *
+     * @param Request    $request The request object
+     * @param array|null $referer The referer array
+     *
+     * @return bool True if the front end session can be modified
+     */
+    private function canModifyFrontendSession(Request $request, array $referer = null)
+    {
+        return (null !== $referer)
+            && !$request->query->has('pdf')
+            && !$request->query->has('file')
+            && !$request->query->has('id')
+            && isset($referer['current'])
+            && $referer['current'] !== $this->getRelativeRequestUri($request)
+        ;
+    }
+
+    /**
+     * Returns the current request URI relative to the base path.
+     *
+     * @param Request $request The request object
+     *
+     * @return string The relative request URI
+     */
+    private function getRelativeRequestUri(Request $request)
+    {
+        return (string) substr($request->getRequestUri(), strlen($request->getBasePath()) + 1);
+    }
+}

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -120,10 +120,10 @@ class UserSessionListener extends AbstractScopeAwareListener
     {
         // Update the referer URL
         if ($this->canModifyBackendSession($request)) {
+            // FIXME: make a separate listener
             $key       = $request->query->has('popup') ? 'popupReferer' : 'referer';
             $refererId = $request->attributes->get('_contao_referer_id');
-            $bag       = $this->getSessionBag();
-            $referers  = $this->prepareBackendReferer($refererId, $bag->get($key));
+            $referers  = $this->prepareBackendReferer($refererId, $this->session->get($key));
             $ref       = $request->query->get('ref', '');
 
             // Move current to last if the referer is in both the URL and the session
@@ -134,7 +134,7 @@ class UserSessionListener extends AbstractScopeAwareListener
             // Set new current referer
             $referers[$refererId]['current'] = $this->getRelativeRequestUri($request);
 
-            $bag->set($key, $referers);
+            $this->session->set($key, $referers);
         }
 
         $this->storeSession();

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\BackendUser;
 use Contao\FrontendUser;
 use Doctrine\DBAL\Driver\Connection;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -17,15 +17,14 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Stores and restores the user session.
  *
  * @author Yanick Witschi <https://github.com/toflar>
+ * @author Leo Feyer <https://github.com/leofeyer>
  */
-class UserSessionListener extends AbstractScopeAwareListener
+class UserSessionListener extends AbstractUserAwareListener
 {
     /**
      * @var SessionInterface
@@ -38,22 +37,15 @@ class UserSessionListener extends AbstractScopeAwareListener
     private $connection;
 
     /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
-    /**
      * Constructor.
      *
-     * @param SessionInterface      $session      The session object
-     * @param Connection            $connection   The database connection
-     * @param TokenStorageInterface $tokenStorage The token storage object
+     * @param SessionInterface $session    The session object
+     * @param Connection       $connection The database connection
      */
-    public function __construct(SessionInterface $session, Connection $connection, TokenStorageInterface $tokenStorage)
+    public function __construct(SessionInterface $session, Connection $connection)
     {
-        $this->session      = $session;
-        $this->connection   = $connection;
-        $this->tokenStorage = $tokenStorage;
+        $this->session    = $session;
+        $this->connection = $connection;
     }
 
     /**
@@ -91,22 +83,6 @@ class UserSessionListener extends AbstractScopeAwareListener
             ->prepare('UPDATE ' . $user->getTable() . ' SET session=? WHERE id=?')
             ->execute([serialize($this->getSessionBag()->all()), $user->id])
         ;
-    }
-
-    /**
-     * Checks if there is an authenticated user.
-     *
-     * @return bool True if there is an authenticated user
-     */
-    private function hasUser()
-    {
-        $user = $this->tokenStorage->getToken();
-
-        if (null === $user) {
-            return false;
-        }
-
-        return (!$user instanceof AnonymousToken);
     }
 
     /**

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -123,10 +123,10 @@ services:
     contao.listener.store_referer:
         class: Contao\CoreBundle\EventListener\StoreRefererListener
         arguments:
-            - '@session'
-            - '@security.token_storage'
+            - "@session"
         calls:
             - [setContainer, ["@service_container"]]
+            - [setTokenStorage, ["@security.token_storage"]]
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
@@ -140,11 +140,11 @@ services:
     contao.listener.user_session:
         class: Contao\CoreBundle\EventListener\UserSessionListener
         arguments:
-            - '@session'
-            - '@doctrine.dbal.default_connection'
-            - '@security.token_storage'
+            - "@session"
+            - "@doctrine.dbal.default_connection"
         calls:
             - [setContainer, ["@service_container"]]
+            - [setTokenStorage, ["@security.token_storage"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -117,8 +117,18 @@ services:
             - "@session"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 64 }
-            # FIXME: remove
+            # FIXME: remove once #234 has been merged
             - { name: kernel.event_listener, event: console.command, method: onKernelRequest, priority: 64 }
+
+    contao.listener.store_referer:
+        class: Contao\CoreBundle\EventListener\StoreRefererListener
+        arguments:
+            - '@session'
+            - '@security.token_storage'
+        calls:
+            - [setContainer, ["@service_container"]]
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
     contao.listener.toggle_view:
         class: Contao\CoreBundle\EventListener\ToggleViewListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -117,6 +117,8 @@ services:
             - "@session"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 64 }
+            # FIXME: remove
+            - { name: kernel.event_listener, event: console.command, method: onKernelRequest, priority: 64 }
 
     contao.listener.toggle_view:
         class: Contao\CoreBundle\EventListener\ToggleViewListener

--- a/src/Resources/contao/classes/Ajax.php
+++ b/src/Resources/contao/classes/Ajax.php
@@ -78,23 +78,23 @@ class Ajax extends \Backend
 		/** @var KernelInterface $kernel */
 		global $kernel;
 
-		/** @var AttributeBagInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session')->getBag('contao_backend');
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		switch ($this->strAction)
 		{
 			// Toggle navigation menu
 			case 'toggleNavigation':
-				$bemod = $objSession->get('backend_modules');
+				$bemod = $objSessionBag->get('backend_modules');
 				$bemod[\Input::post('id')] = intval(\Input::post('state'));
-				$objSession->set('backend_modules', $bemod);
+				$objSessionBag->set('backend_modules', $bemod);
 				throw new NoContentResponseException();
 
 			// Load a navigation menu group
 			case 'loadNavigation':
-				$bemod = $objSession->get('backend_modules');
+				$bemod = $objSessionBag->get('backend_modules');
 				$bemod[\Input::post('id')] = intval(\Input::post('state'));
-				$objSession->set('backend_modules', $bemod);
+				$objSessionBag->set('backend_modules', $bemod);
 
 				$this->import('BackendUser', 'User');
 
@@ -118,9 +118,9 @@ class Ajax extends \Backend
 					$this->strAjaxName = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', \Input::post('name'));
 				}
 
-				$nodes = $objSession->get($this->strAjaxKey);
+				$nodes = $objSessionBag->get($this->strAjaxKey);
 				$nodes[$this->strAjaxId] = intval(\Input::post('state'));
-				$objSession->set($this->strAjaxKey, $nodes);
+				$objSessionBag->set($this->strAjaxKey, $nodes);
 				throw new NoContentResponseException();
 
 			// Load nodes of the file or page tree
@@ -137,16 +137,16 @@ class Ajax extends \Backend
 					$this->strAjaxName = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', \Input::post('name'));
 				}
 
-				$nodes = $objSession->get($this->strAjaxKey);
+				$nodes = $objSessionBag->get($this->strAjaxKey);
 				$nodes[$this->strAjaxId] = intval(\Input::post('state'));
-				$objSession->set($this->strAjaxKey, $nodes);
+				$objSessionBag->set($this->strAjaxKey, $nodes);
 				break;
 
 			// Toggle the visibility of a fieldset
 			case 'toggleFieldset':
-				$fs = $objSession->get('fieldset_states');
+				$fs = $objSessionBag->get('fieldset_states');
 				$fs[\Input::post('table')][\Input::post('id')] = intval(\Input::post('state'));
-				$objSession->set('fieldset_states', $fs);
+				$objSessionBag->set('fieldset_states', $fs);
 				throw new NoContentResponseException();
 
 			// Check whether the temporary directory is writeable
@@ -174,9 +174,9 @@ class Ajax extends \Backend
 
 			// Toggle checkbox groups
 			case 'toggleCheckboxGroup':
-				$state = $objSession->get('checkbox_groups');
+				$state = $objSessionBag->get('checkbox_groups');
 				$state[\Input::post('id')] = intval(\Input::post('state'));
-				$objSession->set('checkbox_groups', $state);
+				$objSessionBag->set('checkbox_groups', $state);
 				break;
 
 			// HOOK: pass unknown actions to callback functions

--- a/src/Resources/contao/classes/Ajax.php
+++ b/src/Resources/contao/classes/Ajax.php
@@ -13,7 +13,9 @@ namespace Contao;
 use Contao\CoreBundle\Exception\NoContentResponseException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 
 /**
@@ -73,20 +75,26 @@ class Ajax extends \Backend
 	 */
 	public function executePreActions()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var AttributeBagInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
 		switch ($this->strAction)
 		{
 			// Toggle navigation menu
 			case 'toggleNavigation':
-				$bemod = $this->Session->get('backend_modules');
+				$bemod = $objSession->get('backend_modules');
 				$bemod[\Input::post('id')] = intval(\Input::post('state'));
-				$this->Session->set('backend_modules', $bemod);
+				$objSession->set('backend_modules', $bemod);
 				throw new NoContentResponseException();
 
 			// Load a navigation menu group
 			case 'loadNavigation':
-				$bemod = $this->Session->get('backend_modules');
+				$bemod = $objSession->get('backend_modules');
 				$bemod[\Input::post('id')] = intval(\Input::post('state'));
-				$this->Session->set('backend_modules', $bemod);
+				$objSession->set('backend_modules', $bemod);
 
 				$this->import('BackendUser', 'User');
 
@@ -110,9 +118,9 @@ class Ajax extends \Backend
 					$this->strAjaxName = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', \Input::post('name'));
 				}
 
-				$nodes = $this->Session->get($this->strAjaxKey);
+				$nodes = $objSession->get($this->strAjaxKey);
 				$nodes[$this->strAjaxId] = intval(\Input::post('state'));
-				$this->Session->set($this->strAjaxKey, $nodes);
+				$objSession->set($this->strAjaxKey, $nodes);
 				throw new NoContentResponseException();
 
 			// Load nodes of the file or page tree
@@ -129,16 +137,16 @@ class Ajax extends \Backend
 					$this->strAjaxName = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', \Input::post('name'));
 				}
 
-				$nodes = $this->Session->get($this->strAjaxKey);
+				$nodes = $objSession->get($this->strAjaxKey);
 				$nodes[$this->strAjaxId] = intval(\Input::post('state'));
-				$this->Session->set($this->strAjaxKey, $nodes);
+				$objSession->set($this->strAjaxKey, $nodes);
 				break;
 
 			// Toggle the visibility of a fieldset
 			case 'toggleFieldset':
-				$fs = $this->Session->get('fieldset_states');
+				$fs = $objSession->get('fieldset_states');
 				$fs[\Input::post('table')][\Input::post('id')] = intval(\Input::post('state'));
-				$this->Session->set('fieldset_states', $fs);
+				$objSession->set('fieldset_states', $fs);
 				throw new NoContentResponseException();
 
 			// Check whether the temporary directory is writeable
@@ -166,9 +174,9 @@ class Ajax extends \Backend
 
 			// Toggle checkbox groups
 			case 'toggleCheckboxGroup':
-				$state = $this->Session->get('checkbox_groups');
+				$state = $objSession->get('checkbox_groups');
 				$state[\Input::post('id')] = intval(\Input::post('state'));
-				$this->Session->set('checkbox_groups', $state);
+				$objSession->set('checkbox_groups', $state);
 				break;
 
 			// HOOK: pass unknown actions to callback functions

--- a/src/Resources/contao/classes/Backend.php
+++ b/src/Resources/contao/classes/Backend.php
@@ -11,7 +11,9 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to manage back end controllers.
@@ -315,14 +317,20 @@ abstract class Backend extends \Controller
 			$this->redirect('contao/main.php?act=error');
 		}
 
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		$arrTables = (array) $arrModule['tables'];
 		$strTable = \Input::get('table') ?: $arrTables[0];
-		$id = (!\Input::get('act') && \Input::get('id')) ? \Input::get('id') : $this->Session->get('CURRENT_ID');
+		$id = (!\Input::get('act') && \Input::get('id')) ? \Input::get('id') : $objSession->get('CURRENT_ID');
 
 		// Store the current ID in the current session
-		if ($id != $this->Session->get('CURRENT_ID'))
+		if ($id != $objSession->get('CURRENT_ID'))
 		{
-			$this->Session->set('CURRENT_ID', $id);
+			$objSession->set('CURRENT_ID', $id);
 		}
 
 		define('CURRENT_ID', (\Input::get('table') ? $id : \Input::get('id')));

--- a/src/Resources/contao/classes/BackendUser.php
+++ b/src/Resources/contao/classes/BackendUser.php
@@ -465,17 +465,17 @@ class BackendUser extends \User
 		/** @var KernelInterface $kernel */
 		global $kernel;
 
-		/** @var AttributeBagInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session')->getBag('contao_backend');
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		$arrModules = array();
-		$session = $objSession->all();
+		$session = $objSessionBag->all();
 
 		// Toggle nodes
 		if (\Input::get('mtg'))
 		{
 			$session['backend_modules'][\Input::get('mtg')] = (isset($session['backend_modules'][\Input::get('mtg')]) && $session['backend_modules'][\Input::get('mtg')] == 0) ? 1 : 0;
-			$objSession->replace($session);
+			$objSessionBag->replace($session);
 			\Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*/i', '', \Environment::get('request')));
 		}
 

--- a/src/Resources/contao/classes/BackendUser.php
+++ b/src/Resources/contao/classes/BackendUser.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\RedirectResponseException;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -461,14 +462,20 @@ class BackendUser extends \User
 	 */
 	public function navigation($blnShowAll=false)
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var AttributeBagInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
 		$arrModules = array();
-		$session = $this->Session->all();
+		$session = $objSession->all();
 
 		// Toggle nodes
 		if (\Input::get('mtg'))
 		{
 			$session['backend_modules'][\Input::get('mtg')] = (isset($session['backend_modules'][\Input::get('mtg')]) && $session['backend_modules'][\Input::get('mtg')] == 0) ? 1 : 0;
-			$this->Session->replace($session);
+			$objSession->replace($session);
 			\Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*/i', '', \Environment::get('request')));
 		}
 

--- a/src/Resources/contao/classes/RebuildIndex.php
+++ b/src/Resources/contao/classes/RebuildIndex.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 
@@ -65,7 +66,13 @@ class RebuildIndex extends \Backend implements \executable
 			// Check the request token (see #4007)
 			if (!isset($_GET['rt']) || !\RequestToken::validate(\Input::get('rt')))
 			{
-				$this->Session->set('INVALID_TOKEN_URL', \Environment::get('request'));
+				/** @var KernelInterface $kernel */
+				global $kernel;
+
+				/** @var SessionInterface $objSession */
+				$objSession = $kernel->getContainer()->get('session');
+
+				$objSession->set('INVALID_TOKEN_URL', \Environment::get('request'));
 				$this->redirect('contao/confirm.php');
 			}
 

--- a/src/Resources/contao/classes/Theme.php
+++ b/src/Resources/contao/classes/Theme.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to handle themes.
@@ -40,6 +43,12 @@ class Theme extends \Backend
 
 		if (\Input::post('FORM_SUBMIT') == 'tl_theme_import')
 		{
+			/** @var KernelInterface $kernel */
+			global $kernel;
+
+			/** @var SessionInterface $objSession */
+			$objSession = $kernel->getContainer()->get('session');
+
 			if (!\Input::post('confirm'))
 			{
 				$arrUploaded = $objUploader->uploadTo('system/tmp');
@@ -75,7 +84,7 @@ class Theme extends \Backend
 			}
 			else
 			{
-				$arrFiles = explode(',', $this->Session->get('uploaded_themes'));
+				$arrFiles = explode(',', $objSession->get('uploaded_themes'));
 			}
 
 			// Check whether there are any files
@@ -105,7 +114,7 @@ class Theme extends \Backend
 			}
 			else
 			{
-				$this->Session->set('uploaded_themes', implode(',', $arrFiles));
+				$objSession->set('uploaded_themes', implode(',', $arrFiles));
 
 				return $this->compareThemeFiles($arrFiles, $arrDbFields);
 			}
@@ -641,7 +650,14 @@ class Theme extends \Backend
 		}
 
 		\System::setCookie('BE_PAGE_OFFSET', 0, 0);
-		$this->Session->remove('uploaded_themes');
+
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$objSession->remove('uploaded_themes');
 
 		// Redirect
 		$this->redirect(str_replace('&key=importTheme', '', \Environment::get('request')));

--- a/src/Resources/contao/controllers/BackendConfirm.php
+++ b/src/Resources/contao/controllers/BackendConfirm.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 
 /**
@@ -49,10 +51,16 @@ class BackendConfirm extends \Backend
 	 */
 	public function run()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Redirect to the back end home page
 		if (\Input::post('FORM_SUBMIT') == 'invalid_token_url')
 		{
-			list($strUrl) = explode('?', $this->Session->get('INVALID_TOKEN_URL'));
+			list($strUrl) = explode('?', $objSession->get('INVALID_TOKEN_URL'));
 			$this->redirect($strUrl);
 		}
 
@@ -60,7 +68,7 @@ class BackendConfirm extends \Backend
 		$objTemplate = new \BackendTemplate('be_confirm');
 
 		// Prepare the URL
-		$url = preg_replace('/(\?|&)rt=[^&]*/', '', $this->Session->get('INVALID_TOKEN_URL'));
+		$url = preg_replace('/(\?|&)rt=[^&]*/', '', $objSession->get('INVALID_TOKEN_URL'));
 		$objTemplate->href = ampersand($url . ((strpos($url, '?') !== false) ? '&rt=' : '?rt=') . REQUEST_TOKEN);
 
 		$vars = array();

--- a/src/Resources/contao/controllers/BackendFile.php
+++ b/src/Resources/contao/controllers/BackendFile.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 
 /**
@@ -54,6 +56,12 @@ class BackendFile extends \Backend
 	 */
 	public function run()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		/** @var \BackendTemplate|object $objTemplate */
 		$objTemplate = new \BackendTemplate('be_picker');
 		$objTemplate->main = '';
@@ -69,7 +77,7 @@ class BackendFile extends \Backend
 		$strField = \Input::get('field');
 
 		// Define the current ID
-		define('CURRENT_ID', (\Input::get('table') ? $this->Session->get('CURRENT_ID') : \Input::get('id')));
+		define('CURRENT_ID', (\Input::get('table') ? $objSession->get('CURRENT_ID') : \Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
@@ -99,7 +107,7 @@ class BackendFile extends \Backend
 			$this->objAjax->executePostActions($objDca);
 		}
 
-		$this->Session->set('filePickerRef', \Environment::get('request'));
+		$objSession->set('filePickerRef', \Environment::get('request'));
 		$arrValues = array_filter(explode(',', \Input::get('value')));
 
 		// Convert UUIDs to binary
@@ -144,7 +152,7 @@ class BackendFile extends \Backend
 		$objTemplate->addSearch = false;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->action = ampersand(\Environment::get('request'));
-		$objTemplate->value = $this->Session->get('file_selector_search');
+		$objTemplate->value = $objSession->get('file_selector_search');
 		$objTemplate->manager = $GLOBALS['TL_LANG']['MSC']['fileManager'];
 		$objTemplate->managerHref = 'contao/main.php?do=files&amp;popup=1';
 		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_files']['list']['sorting']['breadcrumb'];

--- a/src/Resources/contao/controllers/BackendMain.php
+++ b/src/Resources/contao/controllers/BackendMain.php
@@ -210,11 +210,14 @@ class BackendMain extends \Backend
 			$this->Template->title = $this->Template->headline;
 		}
 
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// File picker reference
-		if (\Input::get('popup') && \Input::get('act') != 'show' && (\Input::get('do') == 'page' || \Input::get('do') == 'files') && $this->Session->get('filePickerRef'))
+		if (\Input::get('popup') && \Input::get('act') != 'show' && (\Input::get('do') == 'page' || \Input::get('do') == 'files') && $objSession->get('filePickerRef'))
 		{
-			$this->Template->managerHref = $this->Session->get('filePickerRef');
-			$this->Template->manager = (strpos($this->Session->get('filePickerRef'), 'contao/page?') !== false) ? $GLOBALS['TL_LANG']['MSC']['pagePickerHome'] : $GLOBALS['TL_LANG']['MSC']['filePickerHome'];
+			$this->Template->managerHref = $objSession->get('filePickerRef');
+			$this->Template->manager = (strpos($objSession->get('filePickerRef'), 'contao/page?') !== false) ? $GLOBALS['TL_LANG']['MSC']['pagePickerHome'] : $GLOBALS['TL_LANG']['MSC']['filePickerHome'];
 		}
 
 		$this->Template->theme = \Backend::getTheme();

--- a/src/Resources/contao/controllers/BackendPage.php
+++ b/src/Resources/contao/controllers/BackendPage.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 
 /**
@@ -54,6 +56,12 @@ class BackendPage extends \Backend
 	 */
 	public function run()
 	{
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		/** @var \BackendTemplate|object $objTemplate */
 		$objTemplate = new \BackendTemplate('be_picker');
 		$objTemplate->main = '';
@@ -69,7 +77,7 @@ class BackendPage extends \Backend
 		$strField = \Input::get('field');
 
 		// Define the current ID
-		define('CURRENT_ID', (\Input::get('table') ? $this->Session->get('CURRENT_ID') : \Input::get('id')));
+		define('CURRENT_ID', (\Input::get('table') ? $objSession->get('CURRENT_ID') : \Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
@@ -99,7 +107,7 @@ class BackendPage extends \Backend
 			$this->objAjax->executePostActions($objDca);
 		}
 
-		$this->Session->set('filePickerRef', \Environment::get('request'));
+		$objSession->set('filePickerRef', \Environment::get('request'));
 		$arrValues = array_filter(explode(',', \Input::get('value')));
 
 		// Call the load_callback
@@ -134,7 +142,7 @@ class BackendPage extends \Backend
 		$objTemplate->addSearch = true;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->action = ampersand(\Environment::get('request'));
-		$objTemplate->value = $this->Session->get('page_selector_search');
+		$objTemplate->value = $objSession->get('page_selector_search');
 		$objTemplate->manager = $GLOBALS['TL_LANG']['MSC']['pageManager'];
 		$objTemplate->managerHref = 'contao/main.php?do=page&amp;popup=1';
 		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'];

--- a/src/Resources/contao/controllers/BackendPage.php
+++ b/src/Resources/contao/controllers/BackendPage.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -133,6 +134,9 @@ class BackendPage extends \Backend
 		/** @var \PageSelector $objPageTree */
 		$objPageTree = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$strTable]['fields'][$strField], $strField, $arrValues, $strField, $strTable, $objDca));
 
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $objSession->getBag('contao_backend');
+
 		$objTemplate->main = $objPageTree->generate();
 		$objTemplate->theme = \Backend::getTheme();
 		$objTemplate->base = \Environment::get('base');
@@ -142,7 +146,7 @@ class BackendPage extends \Backend
 		$objTemplate->addSearch = true;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->action = ampersand(\Environment::get('request'));
-		$objTemplate->value = $objSession->get('page_selector_search');
+		$objTemplate->value = $objSessionBag->get('page_selector_search');
 		$objTemplate->manager = $GLOBALS['TL_LANG']['MSC']['pageManager'];
 		$objTemplate->managerHref = 'contao/main.php?do=page&amp;popup=1';
 		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'];

--- a/src/Resources/contao/dca/tl_article.php
+++ b/src/Resources/contao/dca/tl_article.php
@@ -369,7 +369,13 @@ class tl_article extends Backend
 			return;
 		}
 
-		$session = $this->Session->all();
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$session = $objSession->all();
 
 		// Set the default page user and group
 		$GLOBALS['TL_DCA']['tl_page']['fields']['cuser']['default'] = intval(Config::get('defaultUser') ?: $this->User->id);
@@ -440,7 +446,7 @@ class tl_article extends Backend
 		$permission = 0;
 
 		// Overwrite the session
-		$this->Session->replace($session);
+		$objSession->replace($session);
 
 		// Check current action
 		if (Input::get('act') && Input::get('act') != 'paste')
@@ -858,7 +864,13 @@ class tl_article extends Backend
 		// Generate the aliases
 		if (Input::post('FORM_SUBMIT') == 'tl_select' && isset($_POST['alias']))
 		{
-			$session = $this->Session->all();
+			/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+			global $kernel;
+
+			/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+			$objSession = $kernel->getContainer()->get('session');
+
+			$session = $objSession->all();
 			$ids = $session['CURRENT']['IDS'];
 
 			foreach ($ids as $id)

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -839,15 +839,21 @@ class tl_content extends Backend
 	 */
 	public function checkPermission()
 	{
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Prevent deleting referenced elements (see #4898)
 		if (Input::get('act') == 'deleteAll')
 		{
 			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND type='alias'")
 									 ->execute();
 
-			$session = $this->Session->all();
+			$session = $objSession->all();
 			$session['CURRENT']['IDS'] = array_diff($session['CURRENT']['IDS'], $objCes->fetchEach('cteAlias'));
-			$this->Session->replace($session);
+			$objSession->replace($session);
 		}
 
 		if ($this->User->isAdmin)
@@ -897,9 +903,9 @@ class tl_content extends Backend
 				$objCes = $this->Database->prepare("SELECT id FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND pid=?")
 										 ->execute(CURRENT_ID);
 
-				$session = $this->Session->all();
+				$session = $objSession->all();
 				$session['CURRENT']['IDS'] = array_intersect($session['CURRENT']['IDS'], $objCes->fetchEach('id'));
-				$this->Session->replace($session);
+				$objSession->replace($session);
 				break;
 
 			case 'cut':

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -839,17 +839,17 @@ class tl_content extends Backend
 	 */
 	public function checkPermission()
 	{
-		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
-		global $kernel;
-
-		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session');
-
 		// Prevent deleting referenced elements (see #4898)
 		if (Input::get('act') == 'deleteAll')
 		{
 			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND type='alias'")
 									 ->execute();
+
+			/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+			global $kernel;
+
+			/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+			$objSession = $kernel->getContainer()->get('session');
 
 			$session = $objSession->all();
 			$session['CURRENT']['IDS'] = array_diff($session['CURRENT']['IDS'], $objCes->fetchEach('cteAlias'));

--- a/src/Resources/contao/dca/tl_files.php
+++ b/src/Resources/contao/dca/tl_files.php
@@ -283,7 +283,13 @@ class tl_files extends Backend
 			$GLOBALS['TL_DCA']['tl_files']['config']['notDeletable'] = true;
 		}
 
-		$session = $this->Session->all();
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$session = $objSession->all();
 
 		// Set allowed page IDs (edit multiple)
 		if (is_array($session['CURRENT']['IDS']))
@@ -333,7 +339,7 @@ class tl_files extends Backend
 		}
 
 		// Overwrite session
-		$this->Session->replace($session);
+		$objSession->replace($session);
 
 		// Check current action
 		if (Input::get('act') && Input::get('act') != 'paste')

--- a/src/Resources/contao/dca/tl_form.php
+++ b/src/Resources/contao/dca/tl_form.php
@@ -299,12 +299,6 @@ class tl_form extends Backend
 			return;
 		}
 
-		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
-		global $kernel;
-
-		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session');
-
 		// Set root IDs
 		if (!is_array($this->User->forms) || empty($this->User->forms))
 		{
@@ -322,6 +316,12 @@ class tl_form extends Backend
 		{
 			$GLOBALS['TL_DCA']['tl_form']['config']['closed'] = true;
 		}
+
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
 
 		// Check current action
 		switch (Input::get('act'))

--- a/src/Resources/contao/dca/tl_form.php
+++ b/src/Resources/contao/dca/tl_form.php
@@ -299,6 +299,12 @@ class tl_form extends Backend
 			return;
 		}
 
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Set root IDs
 		if (!is_array($this->User->forms) || empty($this->User->forms))
 		{
@@ -329,7 +335,7 @@ class tl_form extends Backend
 				// Dynamically add the record to the user profile
 				if (!in_array(Input::get('id'), $root))
 				{
-					$arrNew = $this->Session->get('new_records');
+					$arrNew = $objSession->get('new_records');
 
 					if (is_array($arrNew['tl_form']) && in_array(Input::get('id'), $arrNew['tl_form']))
 					{
@@ -391,7 +397,7 @@ class tl_form extends Backend
 			case 'editAll':
 			case 'deleteAll':
 			case 'overrideAll':
-				$session = $this->Session->all();
+				$session = $objSession->all();
 				if (Input::get('act') == 'deleteAll' && !$this->User->hasAccess('delete', 'formp'))
 				{
 					$session['CURRENT']['IDS'] = array();
@@ -400,7 +406,7 @@ class tl_form extends Backend
 				{
 					$session['CURRENT']['IDS'] = array_intersect($session['CURRENT']['IDS'], $root);
 				}
-				$this->Session->replace($session);
+				$objSession->replace($session);
 				break;
 
 			default:

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -536,9 +536,15 @@ class tl_form_field extends Backend
 					$this->redirect('contao/main.php?act=error');
 				}
 
-				$session = $this->Session->all();
+				/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+				global $kernel;
+
+				/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+				$objSession = $kernel->getContainer()->get('session');
+
+				$session = $objSession->all();
 				$session['CURRENT']['IDS'] = array_intersect($session['CURRENT']['IDS'], $objForm->fetchEach('id'));
-				$this->Session->replace($session);
+				$objSession->replace($session);
 				break;
 
 			default:

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -661,7 +661,13 @@ class tl_page extends Backend
 			return;
 		}
 
-		$session = $this->Session->all();
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$session = $objSession->all();
 
 		// Set the default page user and group
 		$GLOBALS['TL_DCA']['tl_page']['fields']['cuser']['default'] = intval(Config::get('defaultUser') ?: $this->User->id);
@@ -730,7 +736,7 @@ class tl_page extends Backend
 		}
 
 		// Overwrite session
-		$this->Session->replace($session);
+		$objSession->replace($session);
 
 		// Check permissions to save and create new
 		if (Input::get('act') == 'edit')
@@ -1062,7 +1068,13 @@ class tl_page extends Backend
 			return;
 		}
 
-		$new_records = $this->Session->get('new_records');
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$new_records = $objSession->get('new_records');
 
 		// Not a new page
 		if (!$new_records || (is_array($new_records[$dc->table]) && !in_array($dc->id, $new_records[$dc->table])))
@@ -1537,7 +1549,13 @@ class tl_page extends Backend
 		// Generate the aliases
 		if (Input::post('FORM_SUBMIT') == 'tl_select' && isset($_POST['alias']))
 		{
-			$session = $this->Session->all();
+			/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+			global $kernel;
+
+			/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+			$objSession = $kernel->getContainer()->get('session');
+
+			$session = $objSession->all();
 			$ids = $session['CURRENT']['IDS'];
 
 			foreach ($ids as $id)

--- a/src/Resources/contao/dca/tl_style.php
+++ b/src/Resources/contao/dca/tl_style.php
@@ -662,7 +662,7 @@ class tl_style extends Backend
 		global $kernel;
 
 		/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
-		$objSessionBag = $kernel->getContainer()->get('session');
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		$key = 'tl_style_' . CURRENT_ID;
 		$filter = $objSessionBag->get('filter');

--- a/src/Resources/contao/dca/tl_style.php
+++ b/src/Resources/contao/dca/tl_style.php
@@ -658,8 +658,14 @@ class tl_style extends Backend
 			return $varValue;
 		}
 
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session');
+
 		$key = 'tl_style_' . CURRENT_ID;
-		$filter = $this->Session->get('filter');
+		$filter = $objSessionBag->get('filter');
 
 		// Return the current category
 		if (strlen($filter[$key]['category']))
@@ -689,7 +695,13 @@ class tl_style extends Backend
 	 */
 	public function updateStyleSheet()
 	{
-		$session = $this->Session->get('style_sheet_updater');
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$session = $objSession->get('style_sheet_updater');
 
 		if (!is_array($session) || empty($session))
 		{
@@ -703,7 +715,7 @@ class tl_style extends Backend
 			$this->StyleSheets->updateStyleSheet($id);
 		}
 
-		$this->Session->set('style_sheet_updater', null);
+		$objSession->set('style_sheet_updater', null);
 	}
 
 
@@ -722,10 +734,16 @@ class tl_style extends Backend
 			return;
 		}
 
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Store the ID in the session
-		$session = $this->Session->get('style_sheet_updater');
+		$session = $objSession->get('style_sheet_updater');
 		$session[] = CURRENT_ID;
-		$this->Session->set('style_sheet_updater', array_unique($session));
+		$objSession->set('style_sheet_updater', array_unique($session));
 	}
 
 

--- a/src/Resources/contao/dca/tl_style_sheet.php
+++ b/src/Resources/contao/dca/tl_style_sheet.php
@@ -255,7 +255,13 @@ class tl_style_sheet extends Backend
 	 */
 	public function updateStyleSheet()
 	{
-		$session = $this->Session->get('style_sheet_updater');
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$session = $objSession->get('style_sheet_updater');
 
 		if (!is_array($session) || empty($session))
 		{
@@ -269,7 +275,7 @@ class tl_style_sheet extends Backend
 			$this->StyleSheets->updateStyleSheet($id);
 		}
 
-		$this->Session->set('style_sheet_updater', null);
+		$objSession->set('style_sheet_updater', null);
 	}
 
 
@@ -295,10 +301,16 @@ class tl_style_sheet extends Backend
 			return;
 		}
 
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Store the ID in the session
-		$session = $this->Session->get('style_sheet_updater');
+		$session = $objSession->get('style_sheet_updater');
 		$session[] = $id;
-		$this->Session->set('style_sheet_updater', array_unique($session));
+		$objSession->set('style_sheet_updater', array_unique($session));
 	}
 
 

--- a/src/Resources/contao/dca/tl_templates.php
+++ b/src/Resources/contao/dca/tl_templates.php
@@ -152,7 +152,7 @@ class tl_templates extends Backend
 		global $kernel;
 
 		/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
-		$objSessionBag = $kernel->getContainer()->get('session');
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		// Set a new node
 		if (isset($_GET['node']))

--- a/src/Resources/contao/dca/tl_templates.php
+++ b/src/Resources/contao/dca/tl_templates.php
@@ -148,6 +148,12 @@ class tl_templates extends Backend
 	 */
 	public function addBreadcrumb()
 	{
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session');
+
 		// Set a new node
 		if (isset($_GET['node']))
 		{
@@ -157,11 +163,11 @@ class tl_templates extends Backend
 				throw new RuntimeException('Insecure path ' . Input::get('node', true));
 			}
 
-			$this->Session->set('tl_templates_node', Input::get('node', true));
+			$objSessionBag->set('tl_templates_node', Input::get('node', true));
 			$this->redirect(preg_replace('/(&|\?)node=[^&]*/', '', Environment::get('request')));
 		}
 
-		$strNode = $this->Session->get('tl_templates_node');
+		$strNode = $objSessionBag->get('tl_templates_node');
 
 		if ($strNode == '')
 		{
@@ -177,7 +183,7 @@ class tl_templates extends Backend
 		// Currently selected folder does not exist
 		if (!is_dir(TL_ROOT . '/' . $strNode))
 		{
-			$this->Session->set('tl_templates_node', '');
+			$objSessionBag->set('tl_templates_node', '');
 
 			return;
 		}

--- a/src/Resources/contao/dca/tl_theme.php
+++ b/src/Resources/contao/dca/tl_theme.php
@@ -297,13 +297,19 @@ class tl_theme extends Backend
 	 */
 	public function updateStyleSheet()
 	{
-		if ($this->Session->get('style_sheet_update_all'))
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		if ($objSession->get('style_sheet_update_all'))
 		{
 			$this->import('StyleSheets');
 			$this->StyleSheets->updateStyleSheets();
 		}
 
-		$this->Session->set('style_sheet_update_all', null);
+		$objSession->set('style_sheet_update_all', null);
 	}
 
 
@@ -315,7 +321,13 @@ class tl_theme extends Backend
 	 */
 	public function scheduleUpdate()
 	{
-		$this->Session->set('style_sheet_update_all', true);
+		/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+		global $kernel;
+
+		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$objSession->set('style_sheet_update_all', true);
 	}
 
 

--- a/src/Resources/contao/dca/tl_user.php
+++ b/src/Resources/contao/dca/tl_user.php
@@ -500,10 +500,16 @@ class tl_user extends Backend
 			case 'editAll':
 			case 'deleteAll':
 			case 'overrideAll':
-				$session = $this->Session->all();
+				/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+				global $kernel;
+
+				/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
+				$objSession = $kernel->getContainer()->get('session');
+
+				$session = $objSession->all();
 				$objUser = $this->Database->execute("SELECT id FROM tl_user WHERE admin=1");
 				$session['CURRENT']['IDS'] = array_diff($session['CURRENT']['IDS'], $objUser->fetchEach('id'));
-				$this->Session->replace($session);
+				$objSession->replace($session);
 				break;
 		}
 	}
@@ -655,7 +661,13 @@ class tl_user extends Backend
 
 				if (in_array('purge_session', $arrPurge))
 				{
-					$this->Session->replace(array());
+					/** @var Symfony\Component\HttpKernel\KernelInterface $kernel */
+					global $kernel;
+
+					/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
+					$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
+					$objSessionBag->replace(array());
 					Message::addConfirmation($GLOBALS['TL_LANG']['tl_user']['sessionPurged']);
 				}
 

--- a/src/Resources/contao/dca/tl_user.php
+++ b/src/Resources/contao/dca/tl_user.php
@@ -667,7 +667,7 @@ class tl_user extends Backend
 					/** @var Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface $objSessionBag */
 					$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
-					$objSessionBag->replace(array());
+					$objSessionBag->clear();
 					Message::addConfirmation($GLOBALS['TL_LANG']['tl_user']['sessionPurged']);
 				}
 

--- a/src/Resources/contao/drivers/DC_File.php
+++ b/src/Resources/contao/drivers/DC_File.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to edit the local configuration file.
@@ -153,9 +156,15 @@ class DC_File extends \DataContainer implements \editable
 				}
 			}
 
+			/** @var KernelInterface $kernel */
+			global $kernel;
+
+			/** @var AttributeBagInterface $objSessionBag */
+			$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
 			// Render boxes
 			$class = 'tl_tbox';
-			$fs = $this->Session->get('fieldset_states');
+			$fs = $objSessionBag->get('fieldset_states');
 			$blnIsFirst = true;
 
 			foreach ($boxes as $k=>$v)

--- a/src/Resources/contao/forms/FormCaptcha.php
+++ b/src/Resources/contao/forms/FormCaptcha.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Class FormCaptcha
@@ -128,7 +131,13 @@ class FormCaptcha extends \Widget
 	 */
 	public function validate()
 	{
-		$arrCaptcha = $this->Session->get('captcha_' . $this->strId);
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$arrCaptcha = $objSession->get('captcha_' . $this->strId);
 
 		if (!is_array($arrCaptcha) || !strlen($arrCaptcha['key']) || !strlen($arrCaptcha['sum']) || \Input::post($arrCaptcha['key']) != $arrCaptcha['sum'] || $arrCaptcha['time'] > (time() - 3))
 		{
@@ -136,7 +145,7 @@ class FormCaptcha extends \Widget
 			$this->addError($GLOBALS['TL_LANG']['ERR']['captcha']);
 		}
 
-		$this->Session->set('captcha_' . $this->strId, '');
+		$objSession->set('captcha_' . $this->strId, '');
 	}
 
 
@@ -153,7 +162,13 @@ class FormCaptcha extends \Widget
 		$question = $GLOBALS['TL_LANG']['SEC']['question' . rand(1, 3)];
 		$question = sprintf($question, $int1, $int2);
 
-		$this->Session->set('captcha_' . $this->strId, array
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		$objSession->set('captcha_' . $this->strId, array
 		(
 			'sum' => $int1 + $int2,
 			'key' => $this->strCaptchaKey,

--- a/src/Resources/contao/library/Contao/Session.php
+++ b/src/Resources/contao/library/Contao/Session.php
@@ -73,8 +73,6 @@ class Session
 	 */
 	public static function getInstance()
 	{
-		trigger_error('Using Session::getInstance() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
-
 		if (static::$objInstance === null)
 		{
 			static::$objInstance = new static();
@@ -93,6 +91,8 @@ class Session
 	 */
 	public function get($strKey)
 	{
+		trigger_error('Using Session::get() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		/** @var AttributeBagInterface $bag */
 		$bag = $this->session->getBag($this->getSessionBagKey());
 
@@ -108,6 +108,8 @@ class Session
 	 */
 	public function set($strKey, $varValue)
 	{
+		trigger_error('Using Session::set() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		/** @var AttributeBagInterface $bag */
 		$bag = $this->session->getBag($this->getSessionBagKey());
 
@@ -122,6 +124,8 @@ class Session
 	 */
 	public function remove($strKey)
 	{
+		trigger_error('Using Session::remove() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		/** @var AttributeBagInterface $bag */
 		$bag = $this->session->getBag($this->getSessionBagKey());
 
@@ -136,6 +140,8 @@ class Session
 	 */
 	public function getData()
 	{
+		trigger_error('Using Session::getData() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		/** @var AttributeBagInterface $bag */
 		$bag = $this->session->getBag($this->getSessionBagKey());
 
@@ -152,6 +158,8 @@ class Session
 	 */
 	public function setData($arrData)
 	{
+		trigger_error('Using Session::setData() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		if (!is_array($arrData))
 		{
 			throw new \Exception('Array required to set session data');
@@ -173,6 +181,8 @@ class Session
 	 */
 	public function appendData($varData)
 	{
+		trigger_error('Using Session::appendData() has been deprecated and will no longer work in Contao 5.0. Use the Symfony session via the container instead.', E_USER_DEPRECATED);
+
 		if (is_object($varData))
 		{
 			$varData = get_object_vars($varData);

--- a/src/Resources/contao/library/Contao/System.php
+++ b/src/Resources/contao/library/Contao/System.php
@@ -12,9 +12,8 @@ namespace Contao;
 
 use Contao\CoreBundle\Config\Loader\PhpFileLoader;
 use Contao\CoreBundle\Config\Loader\XliffFileLoader;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 
@@ -46,7 +45,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * @property \Database\Updater                         $Updater     The database updater object
  * @property \Messages                                 $Messages    The messages object
  * @property \News                                     $News        The news object
- * @property AttributeBagInterface                     $Session     The session object
+ * @property \Session                                  $Session     The session object
  * @property \StyleSheets                              $StyleSheets The style sheets object
  * @property \BackendTemplate|\FrontendTemplate|object $Template    The template object
  * @property \BackendUser|\FrontendUser                $User        The user object
@@ -144,19 +143,7 @@ abstract class System
 
 		if ($blnForce || !isset($this->arrObjects[$strKey]))
 		{
-			if ($strKey == 'Session')
-			{
-				/** @var KernelInterface $kernel */
-				global $kernel;
-
-				$strMode = $kernel->getContainer()->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND) ? 'backend' : 'frontend';
-
-				$this->arrObjects[$strKey] = $kernel->getContainer()->get('session')->getBag('contao_' . $strMode);
-			}
-			else
-			{
-				$this->arrObjects[$strKey] = (in_array('getInstance', get_class_methods($strClass))) ? call_user_func(array($strClass, 'getInstance')) : new $strClass();
-			}
+			$this->arrObjects[$strKey] = (in_array('getInstance', get_class_methods($strClass))) ? call_user_func(array($strClass, 'getInstance')) : new $strClass();
 		}
 	}
 
@@ -231,10 +218,8 @@ abstract class System
 		/** @var KernelInterface $kernel */
 		global $kernel;
 
-		$strMode = $kernel->getContainer()->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND) ? 'backend' : 'frontend';
-
-		/** @var AttributeBagInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session')->getBag('contao_' . $strMode);
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
 
 		$ref = \Input::get('ref');
 		$key = \Input::get('popup') ? 'popupReferer' : 'referer';

--- a/src/Resources/contao/modules/ModulePassword.php
+++ b/src/Resources/contao/modules/ModulePassword.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Front end module "lost password".
@@ -211,15 +214,21 @@ class ModulePassword extends \Module
 		$objWidget->rowClassConfirm = 'row_1 odd';
 		$this->Template->rowLast = 'row_2 row_last even';
 
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Validate the field
-		if (strlen(\Input::post('FORM_SUBMIT')) && \Input::post('FORM_SUBMIT') == $this->Session->get('setPasswordToken'))
+		if (strlen(\Input::post('FORM_SUBMIT')) && \Input::post('FORM_SUBMIT') == $objSession->get('setPasswordToken'))
 		{
 			$objWidget->validate();
 
 			// Set the new password and redirect
 			if (!$objWidget->hasErrors())
 			{
-				$this->Session->set('setPasswordToken', '');
+				$objSession->set('setPasswordToken', '');
 				array_pop($_SESSION['TL_CONFIRM']);
 
 				$objMember->activation = '';
@@ -257,7 +266,7 @@ class ModulePassword extends \Module
 		}
 
 		$strToken = md5(uniqid(mt_rand(), true));
-		$this->Session->set('setPasswordToken', $strToken);
+		$objSession->set('setPasswordToken', $strToken);
 
 		$this->Template->formId = $strToken;
 		$this->Template->fields = $objWidget->parse();

--- a/src/Resources/contao/widgets/CheckBox.php
+++ b/src/Resources/contao/widgets/CheckBox.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to handle check boxes.
@@ -92,13 +95,19 @@ class CheckBox extends \Widget
 			$this->arrAttributes['required'] = 'required';
 		}
 
-		$state = $this->Session->get('checkbox_groups');
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
+		$state = $objSessionBag->get('checkbox_groups');
 
 		// Toggle the checkbox group
 		if (\Input::get('cbc'))
 		{
 			$state[\Input::get('cbc')] = (isset($state[\Input::get('cbc')]) && $state[\Input::get('cbc')] == 1) ? 0 : 1;
-			$this->Session->set('checkbox_groups', $state);
+			$objSessionBag->set('checkbox_groups', $state);
 
 			$this->redirect(preg_replace('/(&(amp;)?|\?)cbc=[^& ]*/i', '', \Environment::get('request')));
 		}

--- a/src/Resources/contao/widgets/FileSelector.php
+++ b/src/Resources/contao/widgets/FileSelector.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to handle input field "file tree".
@@ -55,14 +58,20 @@ class FileSelector extends \Widget
 		$this->import('BackendUser', 'User');
 		$this->convertValuesToPaths();
 
-		$strNode = $this->Session->get('tl_files_picker');
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
+		$strNode = $objSessionBag->get('tl_files_picker');
 
 		// Unset the node if it is not within the path (see #5899)
 		if ($strNode != '' && $this->path != '')
 		{
 			if (strncmp($strNode . '/', $this->path . '/', strlen($this->path) + 1) !== 0)
 			{
-				$this->Session->remove('tl_files_picker');
+				$objSessionBag->remove('tl_files_picker');
 			}
 		}
 
@@ -221,7 +230,14 @@ class FileSelector extends \Widget
 		}
 
 		static $session;
-		$session = $this->Session->all();
+
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
+
+		$session = $objSessionBag->all();
 
 		$flag = substr($this->strField, 0, 2);
 		$node = 'tree_' . $this->strTable . '_' . $this->strField;
@@ -231,7 +247,7 @@ class FileSelector extends \Widget
 		if (\Input::get($flag.'tg'))
 		{
 			$session[$node][\Input::get($flag.'tg')] = (isset($session[$node][\Input::get($flag.'tg')]) && $session[$node][\Input::get($flag.'tg')] == 1) ? 0 : 1;
-			$this->Session->replace($session);
+			$objSessionBag->replace($session);
 			$this->redirect(preg_replace('/(&(amp;)?|\?)'.$flag.'tg=[^& ]*/i', '', \Environment::get('request')));
 		}
 

--- a/src/Resources/contao/widgets/PageSelector.php
+++ b/src/Resources/contao/widgets/PageSelector.php
@@ -149,17 +149,17 @@ class PageSelector extends \Widget
 		}
 		else
 		{
-            /** @var AttributeBagInterface $objBag */
-			$objBag = $objSession->getBag('contao_backend');
+            /** @var AttributeBagInterface $objSessionBag */
+			$objSessionBag = $objSession->getBag('contao_backend');
 
-			$strNode = $objBag->get('tl_page_picker');
+			$strNode = $objSessionBag->get('tl_page_picker');
 
 			// Unset the node if it is not within the predefined node set (see #5899)
 			if ($strNode > 0 && is_array($this->rootNodes))
 			{
 				if (!in_array($strNode, $this->Database->getChildRecords($this->rootNodes, 'tl_page')))
 				{
-					$objBag->remove('tl_page_picker');
+					$objSessionBag->remove('tl_page_picker');
 				}
 			}
 
@@ -317,10 +317,10 @@ class PageSelector extends \Widget
 		/** @var SessionInterface $objSession */
 		$objSession = $kernel->getContainer()->get('session');
 
-		/** @var AttributeBagInterface $objBag */
-		$objBag = $objSession->getBag('contao_backend');
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $objSession->getBag('contao_backend');
 
-		$session = $objBag->all();
+		$session = $objSessionBag->all();
 
 		$flag = substr($this->strField, 0, 2);
 		$node = 'tree_' . $this->strTable . '_' . $this->strField;
@@ -330,7 +330,7 @@ class PageSelector extends \Widget
 		if (\Input::get($flag.'tg'))
 		{
 			$session[$node][\Input::get($flag.'tg')] = (isset($session[$node][\Input::get($flag.'tg')]) && $session[$node][\Input::get($flag.'tg')] == 1) ? 0 : 1;
-			$objBag->replace($session);
+			$objSessionBag->replace($session);
 			$this->redirect(preg_replace('/(&(amp;)?|\?)'.$flag.'tg=[^& ]*/i', '', \Environment::get('request')));
 		}
 

--- a/src/Resources/contao/widgets/PageSelector.php
+++ b/src/Resources/contao/widgets/PageSelector.php
@@ -149,7 +149,7 @@ class PageSelector extends \Widget
 		}
 		else
 		{
-            /** @var AttributeBagInterface $objSessionBag */
+			/** @var AttributeBagInterface $objSessionBag */
 			$objSessionBag = $objSession->getBag('contao_backend');
 
 			$strNode = $objSessionBag->get('tl_page_picker');

--- a/src/Resources/contao/widgets/PageSelector.php
+++ b/src/Resources/contao/widgets/PageSelector.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 
@@ -69,19 +68,19 @@ class PageSelector extends \Widget
 		/** @var KernelInterface $kernel */
 		global $kernel;
 
-		/** @var SessionInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session');
+		/** @var AttributeBagInterface $objSessionBag */
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		// Store the keyword
 		if (\Input::post('FORM_SUBMIT') == 'item_selector')
 		{
-			$objSession->set('page_selector_search', \Input::post('keyword'));
+			$objSessionBag->set('page_selector_search', \Input::post('keyword'));
 			$this->reload();
 		}
 
 		$tree = '';
 		$this->getPathNodes();
-		$for = $objSession->get('page_selector_search');
+		$for = $objSessionBag->get('page_selector_search');
 		$arrIds = array();
 
 		// Search for a specific page
@@ -149,9 +148,6 @@ class PageSelector extends \Widget
 		}
 		else
 		{
-			/** @var AttributeBagInterface $objSessionBag */
-			$objSessionBag = $objSession->getBag('contao_backend');
-
 			$strNode = $objSessionBag->get('tl_page_picker');
 
 			// Unset the node if it is not within the predefined node set (see #5899)
@@ -314,11 +310,8 @@ class PageSelector extends \Widget
 		/** @var KernelInterface $kernel */
 		global $kernel;
 
-		/** @var SessionInterface $objSession */
-		$objSession = $kernel->getContainer()->get('session');
-
 		/** @var AttributeBagInterface $objSessionBag */
-		$objSessionBag = $objSession->getBag('contao_backend');
+		$objSessionBag = $kernel->getContainer()->get('session')->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
 
@@ -404,7 +397,7 @@ class PageSelector extends \Widget
 		$return .= '</div><div style="clear:both"></div></li>';
 
 		// Begin a new submenu
-		if (!empty($childs) && ($blnIsOpen || $objSession->get('page_selector_search') != ''))
+		if (!empty($childs) && ($blnIsOpen || $objSessionBag->get('page_selector_search') != ''))
 		{
 			$return .= '<li class="parent" id="'.$node.'_'.$id.'"><ul class="level_'.$level.'">';
 

--- a/src/Resources/contao/widgets/PageSelector.php
+++ b/src/Resources/contao/widgets/PageSelector.php
@@ -10,6 +10,10 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * Provide methods to handle input field "page tree".
@@ -62,16 +66,22 @@ class PageSelector extends \Widget
 	{
 		$this->import('BackendUser', 'User');
 
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
 		// Store the keyword
 		if (\Input::post('FORM_SUBMIT') == 'item_selector')
 		{
-			$this->Session->set('page_selector_search', \Input::post('keyword'));
+			$objSession->set('page_selector_search', \Input::post('keyword'));
 			$this->reload();
 		}
 
 		$tree = '';
 		$this->getPathNodes();
-		$for = $this->Session->get('page_selector_search');
+		$for = $objSession->get('page_selector_search');
 		$arrIds = array();
 
 		// Search for a specific page
@@ -139,14 +149,17 @@ class PageSelector extends \Widget
 		}
 		else
 		{
-			$strNode = $this->Session->get('tl_page_picker');
+            /** @var AttributeBagInterface $objBag */
+			$objBag = $objSession->getBag('contao_backend');
+
+			$strNode = $objBag->get('tl_page_picker');
 
 			// Unset the node if it is not within the predefined node set (see #5899)
 			if ($strNode > 0 && is_array($this->rootNodes))
 			{
 				if (!in_array($strNode, $this->Database->getChildRecords($this->rootNodes, 'tl_page')))
 				{
-					$this->Session->remove('tl_page_picker');
+					$objBag->remove('tl_page_picker');
 				}
 			}
 
@@ -297,7 +310,17 @@ class PageSelector extends \Widget
 	protected function renderPagetree($id, $intMargin, $protectedPage=false, $blnNoRecursion=false)
 	{
 		static $session;
-		$session = $this->Session->all();
+
+		/** @var KernelInterface $kernel */
+		global $kernel;
+
+		/** @var SessionInterface $objSession */
+		$objSession = $kernel->getContainer()->get('session');
+
+		/** @var AttributeBagInterface $objBag */
+		$objBag = $objSession->getBag('contao_backend');
+
+		$session = $objBag->all();
 
 		$flag = substr($this->strField, 0, 2);
 		$node = 'tree_' . $this->strTable . '_' . $this->strField;
@@ -307,7 +330,7 @@ class PageSelector extends \Widget
 		if (\Input::get($flag.'tg'))
 		{
 			$session[$node][\Input::get($flag.'tg')] = (isset($session[$node][\Input::get($flag.'tg')]) && $session[$node][\Input::get($flag.'tg')] == 1) ? 0 : 1;
-			$this->Session->replace($session);
+			$objBag->replace($session);
 			$this->redirect(preg_replace('/(&(amp;)?|\?)'.$flag.'tg=[^& ]*/i', '', \Environment::get('request')));
 		}
 
@@ -381,7 +404,7 @@ class PageSelector extends \Widget
 		$return .= '</div><div style="clear:both"></div></li>';
 
 		// Begin a new submenu
-		if (!empty($childs) && ($blnIsOpen || $this->Session->get('page_selector_search') != ''))
+		if (!empty($childs) && ($blnIsOpen || $objSession->get('page_selector_search') != ''))
 		{
 			$return .= '<li class="parent" id="'.$node.'_'.$id.'"><ul class="level_'.$level.'">';
 

--- a/src/Session/Attribute/ArrayAttributeBag.php
+++ b/src/Session/Attribute/ArrayAttributeBag.php
@@ -51,40 +51,4 @@ class ArrayAttributeBag extends AttributeBag implements \ArrayAccess
     {
         $this->remove($key);
     }
-
-    /**
-     * Adds an alias for $this->all().
-     *
-     * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
-     *             Use the all() method instead.
-     */
-    public function getData()
-    {
-        trigger_error(
-            'Using Session::getData() has been deprecated and will no longer work in Contao 5.0. '
-                . 'Use the all() method instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $this->all();
-    }
-
-    /**
-     * Adds an alias for $this->replace().
-     *
-     * @param array $attributes The attributes
-     *
-     * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
-     *             Use the replace() method instead.
-     */
-    public function setData(array $attributes)
-    {
-        trigger_error(
-            'Using Session::setData() has been deprecated and will no longer work in Contao 5.0. '
-                . 'Use the replace() method instead.',
-            E_USER_DEPRECATED
-        );
-
-        $this->replace($attributes);
-    }
 }

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -262,6 +262,9 @@ class StoreRefererListenerTest extends TestCase
             $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
         }
 
-        return new StoreRefererListener($session, $tokenStorage);
+        $listener = new StoreRefererListener($session);
+        $listener->setTokenStorage($tokenStorage);
+
+        return $listener;
     }
 }

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\EventListener\StoreRefererListener;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Tests the StoreRefererListener class.
+ *
+ * @author Yanick Witschi <https:/github.com/toflar>
+ */
+class StoreRefererListenerTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $listener = $this->getListener();
+
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\StoreRefererListener', $listener);
+    }
+
+    /**
+     * Tests that the referer is stored upon kernel.response.
+     *
+     * @param string  $scope           The container scope
+     * @param Request $request         The request object
+     * @param array   $currentReferer  The current referer
+     * @param array   $expectedReferer The expected referer
+     *
+     * @dataProvider refererStoredOnKernelResponseProvider
+     */
+    public function testRefererStoredOnKernelResponse($scope, Request $request, $currentReferer, $expectedReferer)
+    {
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $token        = $this->getMock('Contao\\CoreBundle\\Security\\Authentication\\ContaoToken', [], [], '', false);
+        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
+
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token)
+        ;
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope($scope);
+
+        $session = $this->mockSession();
+
+        // Set the current referer URLs
+        $session->set('referer', $currentReferer);
+
+        $listener = $this->getListener($session, $tokenStorage);
+        $listener->setContainer($container);
+        $listener->onKernelResponse($responseEvent);
+
+        $this->assertSame($expectedReferer, $session->get('referer'));
+    }
+
+    /**
+     * Tests that the session is not written when there is no user.
+     *
+     * @param AnonymousToken $noUserReturn The user token
+     *
+     * @dataProvider noUserProvider
+     */
+    public function testListenerSkipIfNoUserOnKernelResponse(AnonymousToken $noUserReturn = null)
+    {
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('set')
+        ;
+
+        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($noUserReturn)
+        ;
+
+        $listener = $this->getListener($session, $tokenStorage);
+        $listener->onKernelResponse($responseEvent);
+    }
+
+    /**
+     * Tests that the session is not written upon a sub request.
+     */
+    public function testListenerSkipUponSubRequestOnKernelResponse()
+    {
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+            new Response()
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('set')
+        ;
+
+        $listener = $this->getListener($session);
+        $listener->onKernelResponse($responseEvent);
+    }
+
+
+    /**
+     * Provides the data for the testRefererStoredOnKernelResponse() method.
+     *
+     * @return array The test data
+     */
+    public function refererStoredOnKernelResponseProvider()
+    {
+        $request = new Request();
+        $request->attributes->set('_contao_referer_id', 'dummyTestRefererId');
+        $request->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
+
+        $requestWithRefInUrl = new Request();
+        $requestWithRefInUrl->attributes->set('_contao_referer_id', 'dummyTestRefererId');
+        $requestWithRefInUrl->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
+        $requestWithRefInUrl->query->set('ref', 'dummyTestRefererId');
+
+        return [
+            'Test current referer null returns correct new referer for back end scope' => [
+                ContaoCoreBundle::SCOPE_BACKEND,
+                $request,
+                null,
+                [
+                    'dummyTestRefererId' => [
+                        'last'    => '',
+                        'current' => 'path/of/contao?having&query&string=1',
+                    ],
+                ],
+            ],
+            'Test referer returns correct new referer for back end scope' => [
+                ContaoCoreBundle::SCOPE_BACKEND,
+                $requestWithRefInUrl,
+                [
+                    'dummyTestRefererId' => [
+                        'last'    => '',
+                        'current' => 'hi/I/am/your_current_referer.html',
+                    ],
+                ],
+                [
+                    'dummyTestRefererId' => [
+                        'last'    => 'hi/I/am/your_current_referer.html',
+                        'current' => 'path/of/contao?having&query&string=1',
+                    ],
+                ],
+            ],
+            'Test current referer null returns null for front end scope' => [
+                ContaoCoreBundle::SCOPE_FRONTEND,
+                $request,
+                null,
+                null,
+            ],
+            'Test referer returns correct new referer for front end scope' => [
+                ContaoCoreBundle::SCOPE_FRONTEND,
+                $requestWithRefInUrl,
+                [
+                    'last'    => '',
+                    'current' => 'hi/I/am/your_current_referer.html',
+                ],
+                [
+                    'last'    => 'hi/I/am/your_current_referer.html',
+                    'current' => 'path/of/contao?having&query&string=1',
+                ],
+            ],
+            'Test referers are correctly added to the referers array (see #143)' => [
+                ContaoCoreBundle::SCOPE_BACKEND,
+                $requestWithRefInUrl,
+                [
+                    'dummyTestRefererId' => [
+                        'last'    => '',
+                        'current' => 'hi/I/am/your_current_referer.html',
+                    ],
+                    'dummyTestRefererId1' => [
+                        'last'    => '',
+                        'current' => 'hi/I/am/your_current_referer.html',
+                    ],
+                ],
+                [
+                    'dummyTestRefererId' => [
+                        'last'    => 'hi/I/am/your_current_referer.html',
+                        'current' => 'path/of/contao?having&query&string=1',
+                    ],
+                    'dummyTestRefererId1' => [
+                        'last'    => '',
+                        'current' => 'hi/I/am/your_current_referer.html',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Provides the data for the user-less tests.
+     *
+     * @return array The test data
+     */
+    public function noUserProvider()
+    {
+        $anonymousToken = new AnonymousToken('key', 'anon.');
+
+        return [
+            [null],
+            [$anonymousToken],
+        ];
+    }
+
+    /**
+     * Returns the session listener object.
+     *
+     * @param SessionInterface      $session      The session object
+     * @param TokenStorageInterface $tokenStorage The token storage object
+     *
+     * @return StoreRefererListener The referer listener object
+     */
+    private function getListener(SessionInterface $session = null, TokenStorageInterface $tokenStorage = null)
+    {
+        if (null === $session) {
+            $session = $this->mockSession();
+        }
+
+        if (null === $tokenStorage) {
+            $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
+        }
+
+        return new StoreRefererListener($session, $tokenStorage);
+    }
+}

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -208,9 +208,9 @@ class UserSessionListenerTest extends TestCase
     }
 
     /**
-     * Tests that the session bag is never requested when there is no master request.
+     * Tests that the session bag is not requested upon a sub request.
      */
-    public function testListenerSkipIfNoMasterRequestOnKernelRequest()
+    public function testListenerSkipUponSubRequestOnKernelRequest()
     {
         $responseEvent = new GetResponseEvent(
             $this->mockKernel(),
@@ -232,7 +232,7 @@ class UserSessionListenerTest extends TestCase
     /**
      * Tests that neither the session bag nor doctrine is requested when there is no user.
      *
-     * @param AnonymousToken $noUserReturn
+     * @param AnonymousToken $noUserReturn The user token
      *
      * @dataProvider noUserProvider
      */
@@ -277,9 +277,9 @@ class UserSessionListenerTest extends TestCase
     }
 
     /**
-     * Tests that neither the session bag nor doctrine is requested when there is no master request.
+     * Tests that neither the session bag nor doctrine is requested upon a sub request.
      */
-    public function testListenerSkipIfNoMasterRequestOnKernelResponse()
+    public function testListenerSkipUponSubRequestOnKernelResponse()
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -185,7 +185,7 @@ class UserSessionListenerTest extends TestCase
         $responseEvent = new GetResponseEvent(
             $this->mockKernel(),
             new Request(),
-            HttpKernelInterface::SUB_REQUEST
+            HttpKernelInterface::MASTER_REQUEST
         );
 
         $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
@@ -241,7 +241,7 @@ class UserSessionListenerTest extends TestCase
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
             new Request(),
-            HttpKernelInterface::SUB_REQUEST,
+            HttpKernelInterface::MASTER_REQUEST,
             new Response()
         );
 

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -42,161 +42,13 @@ class UserSessionListenerTest extends TestCase
     }
 
     /**
-     * Tests that the session bag is not requested when there is no user.
-     *
-     * @param AnonymousToken $noUserReturn The user token
-     *
-     * @dataProvider noUserProvider
-     */
-    public function testListenerSkipIfNoUserOnKernelRequest(AnonymousToken $noUserReturn = null)
-    {
-        $request = new Request();
-
-        $responseEvent = new GetResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::SUB_REQUEST
-        );
-
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
-
-        $session
-            ->expects($this->never())
-            ->method('getBag')
-        ;
-
-        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
-
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn($noUserReturn)
-        ;
-
-        $listener = $this->getListener($session, null, $tokenStorage);
-        $listener->onKernelRequest($responseEvent);
-    }
-
-    /**
-     * Tests that the session bag is never requested when there is no master request.
-     */
-    public function testListenerSkipIfNoMasterRequestOnKernelRequest()
-    {
-        $request = new Request();
-
-        $responseEvent = new GetResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::SUB_REQUEST
-        );
-
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
-
-        $session
-            ->expects($this->never())
-            ->method('getBag')
-        ;
-
-        $listener = $this->getListener($session);
-        $listener->onKernelRequest($responseEvent);
-    }
-
-    /**
-     * Tests that neither the session bag nor doctrine is requested when there is no user.
-     *
-     * @param AnonymousToken $noUserReturn
-     *
-     * @dataProvider noUserProvider
-     */
-    public function testListenerSkipIfNoUserOnKernelResponse(AnonymousToken $noUserReturn = null)
-    {
-        $request  = new Request();
-        $response = new Response();
-
-        $responseEvent = new FilterResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::SUB_REQUEST,
-            $response
-        );
-
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
-
-        $session
-            ->expects($this->never())
-            ->method('getBag')
-        ;
-
-        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
-
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn($noUserReturn)
-        ;
-
-        $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
-
-        $connection
-            ->expects($this->never())
-            ->method('prepare')
-        ;
-
-        $connection
-            ->expects($this->never())
-            ->method('execute')
-        ;
-
-        $listener = $this->getListener($session, $connection, $tokenStorage);
-        $listener->onKernelResponse($responseEvent);
-    }
-
-    /**
-     * Tests that neither the session bag nor doctrine is requested when there is no master request.
-     */
-    public function testListenerSkipIfNoMasterRequestOnKernelResponse()
-    {
-        $request  = new Request();
-        $response = new Response();
-
-        $responseEvent = new FilterResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::SUB_REQUEST,
-            $response
-        );
-
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
-
-        $session
-            ->expects($this->never())
-            ->method('getBag')
-        ;
-
-        $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
-
-        $connection
-            ->expects($this->never())
-            ->method('prepare')
-        ;
-
-        $connection
-            ->expects($this->never())
-            ->method('execute')
-        ;
-
-        $listener = $this->getListener($session, $connection);
-        $listener->onKernelResponse($responseEvent);
-    }
-
-    /**
-     * Tests that session values are replaced upon kernel.request.
+     * Tests that the session is replaced upon kernel.request.
      *
      * @param string $scope          The container scope
      * @param string $userClass      The user class
      * @param string $sessionBagName The session bag
      *
-     * @dataProvider scopeProvider
+     * @dataProvider scopeBagProvider
      */
     public function testSessionReplacedOnKernelRequest($scope, $userClass, $sessionBagName)
     {
@@ -205,11 +57,9 @@ class UserSessionListenerTest extends TestCase
             'lonesome' => 'looser',
         ];
 
-        $request = new Request();
-
         $responseEvent = new GetResponseEvent(
             $this->mockKernel(),
-            $request,
+            new Request(),
             HttpKernelInterface::MASTER_REQUEST
         );
 
@@ -256,45 +106,33 @@ class UserSessionListenerTest extends TestCase
     }
 
     /**
-     * Tests that the session values are replaced upon kernel.request.
+     * Tests that the session is stored upon kernel.response.
      *
-     * @param string  $scope           The container scope
-     * @param string  $sessionBagName  The session bag name
-     * @param Request $request         The request object
-     * @param array   $currentReferer  The current referer
-     * @param array   $expectedReferer The expected referer
+     * @param string $scope     The container scope
+     * @param string $userClass The user class
+     * @param string $userTable The table name
      *
-     * @dataProvider sessionStoredOnKernelResponseProvider
+     * @dataProvider scopeTableProvider
      */
-    public function testSessionStoredOnKernelResponse(
-        $scope,
-        $sessionBagName,
-        $userClass,
-        $userTable,
-        Request $request,
-        $refererKey,
-        $currentReferer,
-        $expectedReferer
-    ) {
-        $response = new Response();
-
+    public function testSessionStoredOnKernelResponse($scope, $userClass, $userTable)
+    {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
-            $request,
+            new Request(),
             HttpKernelInterface::MASTER_REQUEST,
-            $response
+            new Response()
         );
 
         $connection = $this->getMock('Doctrine\\DBAL\\Connection', ['prepare', 'execute'], [], '', false);
 
         $connection
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('prepare')
             ->willReturnSelf()
         ;
 
         $connection
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('execute')
         ;
 
@@ -330,125 +168,172 @@ class UserSessionListenerTest extends TestCase
 
         $session = $this->mockSession();
 
-        /* @var AttributeBagInterface $bag */
-        $bag = $session->getBag($sessionBagName);
-
-        // Set the current referer URLs
-        $bag->set($refererKey, $currentReferer);
-
         $listener = $this->getListener($session, $connection, $tokenStorage);
         $listener->setContainer($container);
         $listener->onKernelResponse($responseEvent);
-
-        $this->assertSame($expectedReferer, $bag->get($refererKey));
     }
 
     /**
-     * Provides the data for the kernel.response tests.
+     * Tests that the session bag is not requested when there is no user.
+     *
+     * @param AnonymousToken $noUserReturn The user token
+     *
+     * @dataProvider noUserProvider
+     */
+    public function testListenerSkipIfNoUserOnKernelRequest(AnonymousToken $noUserReturn = null)
+    {
+        $responseEvent = new GetResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('getBag')
+        ;
+
+        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($noUserReturn)
+        ;
+
+        $listener = $this->getListener($session, null, $tokenStorage);
+        $listener->onKernelRequest($responseEvent);
+    }
+
+    /**
+     * Tests that the session bag is never requested when there is no master request.
+     */
+    public function testListenerSkipIfNoMasterRequestOnKernelRequest()
+    {
+        $responseEvent = new GetResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('getBag')
+        ;
+
+        $listener = $this->getListener($session);
+        $listener->onKernelRequest($responseEvent);
+    }
+
+    /**
+     * Tests that neither the session bag nor doctrine is requested when there is no user.
+     *
+     * @param AnonymousToken $noUserReturn
+     *
+     * @dataProvider noUserProvider
+     */
+    public function testListenerSkipIfNoUserOnKernelResponse(AnonymousToken $noUserReturn = null)
+    {
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+            new Response()
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('getBag')
+        ;
+
+        $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($noUserReturn)
+        ;
+
+        $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
+
+        $connection
+            ->expects($this->never())
+            ->method('prepare')
+        ;
+
+        $connection
+            ->expects($this->never())
+            ->method('execute')
+        ;
+
+        $listener = $this->getListener($session, $connection, $tokenStorage);
+        $listener->onKernelResponse($responseEvent);
+    }
+
+    /**
+     * Tests that neither the session bag nor doctrine is requested when there is no master request.
+     */
+    public function testListenerSkipIfNoMasterRequestOnKernelResponse()
+    {
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+            new Response()
+        );
+
+        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session\\SessionInterface');
+
+        $session
+            ->expects($this->never())
+            ->method('getBag')
+        ;
+
+        $connection = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
+
+        $connection
+            ->expects($this->never())
+            ->method('prepare')
+        ;
+
+        $connection
+            ->expects($this->never())
+            ->method('execute')
+        ;
+
+        $listener = $this->getListener($session, $connection);
+        $listener->onKernelResponse($responseEvent);
+    }
+
+    /**
+     * Provides the data for the testSessionReplacedOnKernelRequest() method.
      *
      * @return array The test data
      */
-    public function sessionStoredOnKernelResponseProvider()
+    public function scopeBagProvider()
     {
-        $request = new Request();
-        $request->attributes->set('_contao_referer_id', 'dummyTestRefererId');
-        $request->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
-
-        $requestWithRefInUrl = new Request();
-        $requestWithRefInUrl->attributes->set('_contao_referer_id', 'dummyTestRefererId');
-        $requestWithRefInUrl->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
-        $requestWithRefInUrl->query->set('ref', 'dummyTestRefererId');
-
         return [
-            'Test current referer null returns correct new referer for back end scope' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
-                'contao_backend',
-                'Contao\\BackendUser',
-                'tl_user',
-                $request,
-                'referer',
-                null,
-                [
-                    'dummyTestRefererId' => [
-                        'last'    => '',
-                        'current' => 'path/of/contao?having&query&string=1',
-                    ],
-                ],
-            ],
-            'Test referer returns correct new referer for back end scope' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
-                'contao_backend',
-                'Contao\\BackendUser',
-                'tl_user',
-                $requestWithRefInUrl,
-                'referer',
-                [
-                    'dummyTestRefererId' => [
-                        'last'    => '',
-                        'current' => 'hi/I/am/your_current_referer.html',
-                    ],
-                ],
-                [
-                    'dummyTestRefererId' => [
-                        'last'    => 'hi/I/am/your_current_referer.html',
-                        'current' => 'path/of/contao?having&query&string=1',
-                    ],
-                ],
-            ],
-            'Test current referer null returns null for front end scope' => [
-                ContaoCoreBundle::SCOPE_FRONTEND,
-                'contao_frontend',
-                'Contao\\FrontendUser',
-                'tl_member',
-                $request,
-                'referer',
-                null,
-                null,
-            ],
-            'Test referer returns correct new referer for front end scope' => [
-                ContaoCoreBundle::SCOPE_FRONTEND,
-                'contao_frontend',
-                'Contao\\FrontendUser',
-                'tl_member',
-                $requestWithRefInUrl,
-                'referer',
-                [
-                    'last'    => '',
-                    'current' => 'hi/I/am/your_current_referer.html',
-                ],
-                [
-                    'last'    => 'hi/I/am/your_current_referer.html',
-                    'current' => 'path/of/contao?having&query&string=1',
-                ],
-            ],
-            'Test referers are correctly added to the referers array (see #143)' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
-                'contao_backend',
-                'Contao\\BackendUser',
-                'tl_url',
-                $requestWithRefInUrl,
-                'referer',
-                [
-                    'dummyTestRefererId' => [
-                        'last'    => '',
-                        'current' => 'hi/I/am/your_current_referer.html',
-                    ],
-                    'dummyTestRefererId1' => [
-                        'last'    => '',
-                        'current' => 'hi/I/am/your_current_referer.html',
-                    ],
-                ],
-                [
-                    'dummyTestRefererId' => [
-                        'last'    => 'hi/I/am/your_current_referer.html',
-                        'current' => 'path/of/contao?having&query&string=1',
-                    ],
-                    'dummyTestRefererId1' => [
-                        'last'    => '',
-                        'current' => 'hi/I/am/your_current_referer.html',
-                    ],
-                ],
-            ],
+            [ContaoCoreBundle::SCOPE_BACKEND, 'Contao\\BackendUser', 'contao_backend'],
+            [ContaoCoreBundle::SCOPE_FRONTEND, 'Contao\\FrontendUser', 'contao_frontend'],
+        ];
+    }
+
+    /**
+     * Provides the data for the testSessionStoredOnKernelResponse() method.
+     *
+     * @return array The test data
+     */
+    public function scopeTableProvider()
+    {
+        return [
+            [ContaoCoreBundle::SCOPE_BACKEND, 'Contao\\BackendUser', 'tl_user'],
+            [ContaoCoreBundle::SCOPE_FRONTEND, 'Contao\\FrontendUser', 'tl_member'],
         ];
     }
 
@@ -459,24 +344,9 @@ class UserSessionListenerTest extends TestCase
      */
     public function noUserProvider()
     {
-        $anonymousToken = new AnonymousToken('key', 'anon.');
-
         return [
             [null],
-            [$anonymousToken],
-        ];
-    }
-
-    /**
-     * Provides the data for the scope-based tests.
-     *
-     * @return array the test data
-     */
-    public function scopeProvider()
-    {
-        return [
-            [ContaoCoreBundle::SCOPE_BACKEND, 'Contao\\BackendUser', 'contao_backend'],
-            [ContaoCoreBundle::SCOPE_FRONTEND, 'Contao\\FrontendUser', 'contao_frontend'],
+            [new AnonymousToken('key', 'anon.')],
         ];
     }
 

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -376,6 +376,9 @@ class UserSessionListenerTest extends TestCase
             $tokenStorage = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface');
         }
 
-        return new UserSessionListener($session, $connection, $tokenStorage);
+        $listener = new UserSessionListener($session, $connection);
+        $listener->setTokenStorage($tokenStorage);
+
+        return $listener;
     }
 }

--- a/tests/Session/Attribute/ArrayAttributeBagTest.php
+++ b/tests/Session/Attribute/ArrayAttributeBagTest.php
@@ -81,20 +81,4 @@ class ArrayAttributeBagTest extends TestCase
 
         $this->assertFalse($bag->has('foo'));
     }
-
-    /**
-     * Tests the alias methods.
-     */
-    public function testLegacyMethods()
-    {
-        $errorReporting = error_reporting();
-        error_reporting(E_ALL & ~E_USER_DEPRECATED);
-
-        $bag = new ArrayAttributeBag('foobar_storageKey');
-        $bag->setData(['foo' => 'bar']);
-
-        $this->assertEquals(['foo' => 'bar'], $bag->getData());
-
-        error_reporting($errorReporting);
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,12 +15,12 @@ use Contao\CoreBundle\Adapter\ConfigAdapter;
 use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\InitializeSystemListener;
+use Contao\CoreBundle\Session\Attribute\ArrayAttributeBag;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -209,12 +209,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         $session = new Session(new MockArraySessionStorage());
 
-        $beBag = new AttributeBag('_contao_be_attributes');
+        $beBag = new ArrayAttributeBag('_contao_be_attributes');
         $beBag->setName('contao_backend');
 
         $session->registerBag($beBag);
 
-        $feBag = new AttributeBag('_contao_fe_attributes');
+        $feBag = new ArrayAttributeBag('_contao_fe_attributes');
         $feBag->setName('contao_frontend');
 
         $session->registerBag($feBag);


### PR DESCRIPTION
This PR replaces `$this->Session` with the Symfony session. It also attempts to store non-state data in the default session bag, which will not be persisted in the database.