### PR TITLE
Do not show maintenance message in debug mode

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -40,8 +40,10 @@ class FrontendIndex extends \Frontend
 		// No back end user logged in
 		if (!$_SESSION['DISABLE_CACHE'])
 		{
+            global $kernel;
+
 			// Maintenance mode (see #4561 and #6353)
-			if (\Config::get('maintenanceMode'))
+			if (\Config::get('maintenanceMode') && !$kernel->isDebug())
 			{
 				throw new ServiceUnavailableException('This site is currently down for maintenance. Please come back later.');
 			}

--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -40,7 +40,7 @@ class FrontendIndex extends \Frontend
 		// No back end user logged in
 		if (!$_SESSION['DISABLE_CACHE'])
 		{
-            global $kernel;
+			global $kernel;
 
 			// Maintenance mode (see #4561 and #6353)
 			if (\Config::get('maintenanceMode') && !$kernel->isDebug())


### PR DESCRIPTION
I think it does make sense to show the real website if the visitor is successfully using the `app_dev.php` entry point (either on localhost or using authentication).
