### PR TITLE
Mark release branch as 4.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "4.0.x-dev"
+            "dev-develop": "4.1.x-dev",
+            "dev-release/4.0.0": "4.0.x-dev"
         }
     },
     "prefer-stable": true,


### PR DESCRIPTION
This should be added to both `release/4.0.0` as well as `develop` branch as well as all the other bundles.