### PR TITLE
PHP 5.4 compat: Do not use function result within empty().

### DIFF
--- a/src/Resources/contao/classes/FrontendTemplate.php
+++ b/src/Resources/contao/classes/FrontendTemplate.php
@@ -185,7 +185,7 @@ class FrontendTemplate extends \Template
 	 */
 	public function sections($key=null, $template=null)
 	{
-		if (empty(array_filter($this->sections)))
+		if (!array_filter($this->sections))
 		{
 			return;
 		}


### PR DESCRIPTION
Function result values MUST NOT be used within `empty()` checks as `empty()` needs to access values by reference (in order to check whether that reference points to something that exists).
PHP supports references to temporary values returned from functions from 5.5 on, as we are currently still supporting 5.4, we must not pass function results to `empty()`.

See also https://community.contao.org/de/showthread.php?58092-quot-Es-ist-ein-Fehler-aufgetreten-quot-nach-der-Templateeinbindung