### PR TITLE
[RTM] Use Monolog to log PHP errors and exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@
 
 # Tests
 /tests/Fixtures/app/cache/contao/
-/tests/Fixtures/assets/*/
+/tests/Fixtures/assets/*
+!/tests/Fixtures/assets/.gitignore
 /tests/Fixtures/system/cache/
 /tests/Fixtures/system/config/
 /tests/Fixtures/system/logs/
-/tests/Fixtures/system/themes/*/
+/tests/Fixtures/system/themes/*
+!/tests/Fixtures/system/themes/.gitignore
 /tests/Fixtures/system/tmp/
 /tests/Fixtures/web/
 

--- a/src/ContaoFramework.php
+++ b/src/ContaoFramework.php
@@ -269,10 +269,6 @@ class ContaoFramework implements ContaoFrameworkInterface
         error_reporting($this->errorLevel);
 
         $this->includeHelpers();
-
-        // TODO: use Monolog to log errors
-        $this->iniSet('error_log', $this->rootDir . '/system/logs/error.log');
-
         $this->includeBasicClasses();
 
         // Set the container

--- a/src/EventListener/PrettyErrorScreenListener.php
+++ b/src/EventListener/PrettyErrorScreenListener.php
@@ -274,13 +274,13 @@ class PrettyErrorScreenListener
                 'errorOccurred' => 'An error occurred while executing this script. Something does not work properly. '
                     . 'Additionally an error occurred while trying to display the error message.',
                 'howToFix' => 'How can I fix the issue?',
-                'errorFixOne' => 'Open the <code>app/logs/prod.log</code> file and find the associated error '
-                    . 'message (usually the last one).',
+                'errorFixOne' => 'Search the <code>app/logs</code> folder for the current log file and find the '
+                    . 'associated error message (usually the last one).',
                 'more' => 'Tell me more, please',
                 'errorExplain' => 'The script execution stopped, because something does not work properly. The '
                     . 'actual error message is hidden by this notice for security reasons and can be '
-                    . 'found in the <code>app/logs/prod.log</code> file (see above). If you do not '
-                    . 'understand the error message or do not know how to fix the problem, search the '
+                    . 'found in the current log file (see above). If you do not understand the error message or do '
+                    . 'not know how to fix the problem, search the '
                     . '<a href="https://contao.org/faq.html">Contao FAQs</a> or visit the '
                     . '<a href="https://contao.org/support.html">Contao support page</a>.',
             ],

--- a/src/EventListener/PrettyErrorScreenListener.php
+++ b/src/EventListener/PrettyErrorScreenListener.php
@@ -71,10 +71,10 @@ class PrettyErrorScreenListener
     /**
      * Constructor.
      *
-     * @param bool              $prettyErrorScreens True to render the error screens
-     * @param \Twig_Environment $twig               The twig environment
-     * @param ConfigAdapter     $config             The config adapter
-     * @param LoggerInterface   $logger             An optional logger service
+     * @param bool                 $prettyErrorScreens True to render the error screens
+     * @param \Twig_Environment    $twig               The twig environment
+     * @param ConfigAdapter        $config             The config adapter
+     * @param LoggerInterface|null $logger             An optional logger service
      */
     public function __construct(
         $prettyErrorScreens,

--- a/src/EventListener/PrettyErrorScreenListener.php
+++ b/src/EventListener/PrettyErrorScreenListener.php
@@ -74,13 +74,13 @@ class PrettyErrorScreenListener
      * @param bool              $prettyErrorScreens True to render the error screens
      * @param \Twig_Environment $twig               The twig environment
      * @param ConfigAdapter     $config             The config adapter
-     * @param LoggerInterface   $logger             The logger service
+     * @param LoggerInterface   $logger             An optional logger service
      */
     public function __construct(
         $prettyErrorScreens,
         \Twig_Environment $twig,
         ConfigAdapter $config,
-        LoggerInterface $logger
+        LoggerInterface $logger = null
     ) {
         $this->prettyErrorScreens = $prettyErrorScreens;
         $this->twig = $twig;
@@ -345,6 +345,10 @@ class PrettyErrorScreenListener
      */
     private function logException(\Exception $exception)
     {
+        if (null === $this->logger) {
+            return;
+        }
+
         $this->logger->critical('An exception occurred.', ['exception' => $exception]);
     }
 }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -83,7 +83,7 @@ services:
             - "%contao.pretty_error_screens%"
             - "@twig"
             - "@contao.adapter.config"
-            - "@monolog.logger"
+            - "@logger"
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 32 }
 

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -83,6 +83,7 @@ services:
             - "%contao.pretty_error_screens%"
             - "@twig"
             - "@contao.adapter.config"
+            - "@monolog.logger"
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 32 }
 

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -386,7 +386,6 @@ $GLOBALS['TL_CRON'] = array
 	),
 	'daily' => array
 	(
-		array('Automator', 'rotateLogs'),
 		array('Automator', 'purgeTempFolder'),
 		array('Automator', 'checkForUpdates')
 	),

--- a/src/Resources/contao/helper/functions.php
+++ b/src/Resources/contao/helper/functions.php
@@ -15,9 +15,9 @@
  * @param string $strMessage
  * @param string $strLog
  */
-function log_message($strMessage, $strLog='error.log')
+function log_message($strMessage, $strLog='prod.log')
 {
-	error_log(sprintf("[%s] %s\n", date('d-M-Y H:i:s'), $strMessage), 3, TL_ROOT . '/system/logs/' . $strLog);
+	error_log(sprintf("[%s] %s\n", date('d-M-Y H:i:s'), $strMessage), 3, TL_ROOT . '/app/logs/' . $strLog);
 }
 
 

--- a/src/Resources/contao/helper/functions.php
+++ b/src/Resources/contao/helper/functions.php
@@ -14,9 +14,19 @@
  *
  * @param string $strMessage
  * @param string $strLog
+ *
+ * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
+ *             Use the logger service instead.
  */
-function log_message($strMessage, $strLog='prod.log')
+function log_message($strMessage, $strLog=null)
 {
+	trigger_error('Using log_message() has been deprecated and will no longer work in Contao 5.0. Use the logger service instead.', E_USER_DEPRECATED);
+
+	if ($strLog === null)
+	{
+		$strLog = 'prod-' . date('Y-m-d') . '.log';
+	}
+
 	error_log(sprintf("[%s] %s\n", date('d-M-Y H:i:s'), $strMessage), 3, TL_ROOT . '/app/logs/' . $strLog);
 }
 

--- a/src/Resources/contao/languages/en/exception.xlf
+++ b/src/Resources/contao/languages/en/exception.xlf
@@ -21,7 +21,7 @@
         <source>An error occurred while executing this script. Something does not work properly.</source>
       </trans-unit>
       <trans-unit id="XPT.errorFixOne">
-        <source>Serach the &lt;code&gt;app/logs&lt;/code&gt; folder for the current log file and find the associated error message (usually the last one).</source>
+        <source>Search the &lt;code&gt;app/logs&lt;/code&gt; folder for the current log file and find the associated error message (usually the last one).</source>
       </trans-unit>
       <trans-unit id="XPT.errorExplain">
         <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the current log file (see above). If you do not understand the error message or do not know how to fix the problem, search the &lt;a href="https://contao.org/faq.html" target="_blank"&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href="https://contao.org/support.html" target="_blank"&gt;Contao support page&lt;/a&gt;.</source>

--- a/src/Resources/contao/languages/en/exception.xlf
+++ b/src/Resources/contao/languages/en/exception.xlf
@@ -21,10 +21,10 @@
         <source>An error occurred while executing this script. Something does not work properly.</source>
       </trans-unit>
       <trans-unit id="XPT.errorFixOne">
-        <source>Open the &lt;code&gt;app/logs/prod.log&lt;/code&gt; file and find the associated error message (usually the last one).</source>
+        <source>Serach the &lt;code&gt;app/logs&lt;/code&gt; folder for the current log file and find the associated error message (usually the last one).</source>
       </trans-unit>
       <trans-unit id="XPT.errorExplain">
-        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the &lt;code&gt;app/logs/prod.log&lt;/code&gt; file (see above). If you do not understand the error message or do not know how to fix the problem, search the &lt;a href="https://contao.org/faq.html" target="_blank"&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href="https://contao.org/support.html" target="_blank"&gt;Contao support page&lt;/a&gt;.</source>
+        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the current log file (see above). If you do not understand the error message or do not know how to fix the problem, search the &lt;a href="https://contao.org/faq.html" target="_blank"&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href="https://contao.org/support.html" target="_blank"&gt;Contao support page&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPT.requestToken">
         <source>Invalid request token</source>

--- a/src/Resources/contao/languages/en/exception.xlf
+++ b/src/Resources/contao/languages/en/exception.xlf
@@ -21,10 +21,10 @@
         <source>An error occurred while executing this script. Something does not work properly.</source>
       </trans-unit>
       <trans-unit id="XPT.errorFixOne">
-        <source>Open the &lt;code&gt;app/logs/error.log&lt;/code&gt; file and find the associated error message (usually the last one).</source>
+        <source>Open the &lt;code&gt;app/logs/prod.log&lt;/code&gt; file and find the associated error message (usually the last one).</source>
       </trans-unit>
       <trans-unit id="XPT.errorExplain">
-        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the &lt;code&gt;app/logs/error.log&lt;/code&gt; file (see above). If you do not understand the error message or do not know how to fix the problem, search the &lt;a href="https://contao.org/faq.html" target="_blank"&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href="https://contao.org/support.html" target="_blank"&gt;Contao support page&lt;/a&gt;.</source>
+        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the &lt;code&gt;app/logs/prod.log&lt;/code&gt; file (see above). If you do not understand the error message or do not know how to fix the problem, search the &lt;a href="https://contao.org/faq.html" target="_blank"&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href="https://contao.org/support.html" target="_blank"&gt;Contao support page&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPT.requestToken">
         <source>Invalid request token</source>

--- a/src/Resources/contao/library/Contao/Automator.php
+++ b/src/Resources/contao/library/Contao/Automator.php
@@ -459,14 +459,19 @@ class Automator extends \System
 
 	/**
 	 * Rotate the log files
+	 *
+	 * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
+	 *             Use the logger service instead, which rotates its log files automatically.
 	 */
 	public function rotateLogs()
 	{
-		$arrFiles = preg_grep('/\.log$/', scan(TL_ROOT . '/app/logs'));
+		trigger_error('Using Automator::rotateLogs() has been deprecated and will no longer work in Contao 5.0. Use the logger service instead, which rotates its log files automatically.', E_USER_DEPRECATED);
+
+		$arrFiles = preg_grep('/\.log$/', scan(TL_ROOT . '/system/logs'));
 
 		foreach ($arrFiles as $strFile)
 		{
-			$objFile = new \File('app/logs/' . $strFile . '.9');
+			$objFile = new \File('system/logs/' . $strFile . '.9');
 
 			// Delete the oldest file
 			if ($objFile->exists())
@@ -477,18 +482,18 @@ class Automator extends \System
 			// Rotate the files (e.g. error.log.4 becomes error.log.5)
 			for ($i=8; $i>0; $i--)
 			{
-				$strGzName = 'app/logs/' . $strFile . '.' . $i;
+				$strGzName = 'system/logs/' . $strFile . '.' . $i;
 
 				if (file_exists(TL_ROOT . '/' . $strGzName))
 				{
 					$objFile = new \File($strGzName);
-					$objFile->renameTo('app/logs/' . $strFile . '.' . ($i+1));
+					$objFile->renameTo('system/logs/' . $strFile . '.' . ($i+1));
 				}
 			}
 
 			// Add .1 to the latest file
-			$objFile = new \File('app/logs/' . $strFile);
-			$objFile->renameTo('app/logs/' . $strFile . '.1');
+			$objFile = new \File('system/logs/' . $strFile);
+			$objFile->renameTo('system/logs/' . $strFile . '.1');
 		}
 	}
 }

--- a/src/Resources/contao/library/Contao/Automator.php
+++ b/src/Resources/contao/library/Contao/Automator.php
@@ -462,11 +462,11 @@ class Automator extends \System
 	 */
 	public function rotateLogs()
 	{
-		$arrFiles = preg_grep('/\.log$/', scan(TL_ROOT . '/system/logs'));
+		$arrFiles = preg_grep('/\.log$/', scan(TL_ROOT . '/app/logs'));
 
 		foreach ($arrFiles as $strFile)
 		{
-			$objFile = new \File('system/logs/' . $strFile . '.9');
+			$objFile = new \File('app/logs/' . $strFile . '.9');
 
 			// Delete the oldest file
 			if ($objFile->exists())
@@ -477,18 +477,18 @@ class Automator extends \System
 			// Rotate the files (e.g. error.log.4 becomes error.log.5)
 			for ($i=8; $i>0; $i--)
 			{
-				$strGzName = 'system/logs/' . $strFile . '.' . $i;
+				$strGzName = 'app/logs/' . $strFile . '.' . $i;
 
 				if (file_exists(TL_ROOT . '/' . $strGzName))
 				{
 					$objFile = new \File($strGzName);
-					$objFile->renameTo('system/logs/' . $strFile . '.' . ($i+1));
+					$objFile->renameTo('app/logs/' . $strFile . '.' . ($i+1));
 				}
 			}
 
 			// Add .1 to the latest file
-			$objFile = new \File('system/logs/' . $strFile);
-			$objFile->renameTo('system/logs/' . $strFile . '.1');
+			$objFile = new \File('app/logs/' . $strFile);
+			$objFile->renameTo('app/logs/' . $strFile . '.1');
 		}
 	}
 }

--- a/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -221,8 +221,9 @@ class PrettyErrorScreenListenerTest extends TestCase
             })
         ;
 
-        /** @var LoggerInterface $logger */
+        /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
         $logger = $this->getMock('Psr\\Log\\LoggerInterface');
+        $logger->expects($this->once())->method('critical');
 
         $listener = new PrettyErrorScreenListener(true, $twig, new ConfigAdapter(), $logger);
         $listener->onKernelException($event);

--- a/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\ServiceUnavailableException;
 use Contao\CoreBundle\Test\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -61,7 +62,10 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->getMock()
         ;
 
-        $this->listener = new PrettyErrorScreenListener(true, $twig, $this->mockConfig());
+        /** @var LoggerInterface $logger */
+        $logger = $this->getMock('Psr\\Log\\LoggerInterface');
+
+        $this->listener = new PrettyErrorScreenListener(true, $twig, $this->mockConfig(), $logger);
     }
 
     /**
@@ -217,7 +221,10 @@ class PrettyErrorScreenListenerTest extends TestCase
             })
         ;
 
-        $listener = new PrettyErrorScreenListener(true, $twig, new ConfigAdapter());
+        /** @var LoggerInterface $logger */
+        $logger = $this->getMock('Psr\\Log\\LoggerInterface');
+
+        $listener = new PrettyErrorScreenListener(true, $twig, new ConfigAdapter(), $logger);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());


### PR DESCRIPTION
This PR includes three fixes:

* Use Monolog to log PHP errors.
* Add log entries in the pretty error screen listener.
* Use `app/logs` instead of `system/logs`.

The PR also fixes #335.