### PR TITLE
[RTM] Added a fully unit tested MergeHttpHeadersListener

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -30,11 +30,6 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 class MergeHttpHeadersListener
 {
     /**
-     * @var array
-     */
-    private $routeNames;
-
-    /**
      * @var ContaoFrameworkInterface
      */
     private $contaoFramework;
@@ -54,16 +49,11 @@ class MergeHttpHeadersListener
     /**
      * Constructor.
      *
-     * @param array                    $routeNames
      * @param ContaoFrameworkInterface $contaoFramework
      */
-    public function __construct(
-        array $routeNames,
-        ContaoFrameworkInterface $contaoFramework
-    ) {
-        $this->routeNames = $routeNames;
+    public function __construct(ContaoFrameworkInterface $contaoFramework)
+    {
         $this->contaoFramework = $contaoFramework;
-
         $this->setHeaders(headers_list());
     }
 
@@ -123,15 +113,6 @@ class MergeHttpHeadersListener
     public function onKernelResponse(FilterResponseEvent $event)
     {
         if (!$this->contaoFramework->isInitialized()) {
-
-            return;
-        }
-
-        $request = $event->getRequest();
-
-        if (!$request->attributes->has('_route')
-            || !in_array($request->attributes->get('_route'), $this->routeNames)
-        ) {
 
             return;
         }

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -40,6 +40,11 @@ class MergeHttpHeadersListener
     private $contaoFramework;
 
     /**
+     * Remove old headers or not
+     * @var boolean
+     */
+    private $removeOldHeaders = true;
+
     /**
      * Headers
      * @var array
@@ -81,6 +86,27 @@ class MergeHttpHeadersListener
     {
         $this->headers = $headers;
     }
+
+    /**
+     * Gets whether old headers should be removed using header_remove()
+     * or not.
+     *
+     * @return boolean
+     */
+    public function getRemoveOldHeaders()
+    {
+        return $this->removeOldHeaders;
+    }
+
+    /**
+     * Sets whether old headers should be removed using header_remove()
+     * or not.
+     *
+     * @param boolean $removeOldHeaders
+     */
+    public function setRemoveOldHeaders($removeOldHeaders)
+    {
+        $this->removeOldHeaders = (bool) $removeOldHeaders;
     }
 
     /**
@@ -120,6 +146,11 @@ class MergeHttpHeadersListener
     {
         foreach ($this->getHeaders() as $header) {
             list($name, $content) = explode(':', $header, 2);
+
+            if ($this->removeOldHeaders) {
+                header_remove($name);
+            }
+
             $content = trim($content);
 
             if ($response->headers->has($name)) {

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -103,9 +103,15 @@ class MergeHttpHeadersListener
      * or not.
      *
      * @param boolean $removeOldHeaders
+     *
+     * @throws \InvalidArgumentException
      */
     public function setRemoveOldHeaders($removeOldHeaders)
     {
+        if (false === $removeOldHeaders && 'cli' !== PHP_SAPI) {
+            throw new \InvalidArgumentException('You cannot disable removing old
+            headers when not on CLI SAPI.');
+        }
         $this->removeOldHeaders = (bool) $removeOldHeaders;
     }
 

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -33,21 +33,54 @@ class MergeHttpHeadersListener
      * @var array
      */
     private $routeNames;
+
     /**
      * @var ContaoFrameworkInterface
      */
     private $contaoFramework;
 
     /**
+    /**
+     * Headers
+     * @var array
+     */
+    private $headers = [];
+
+    /**
      * Constructor.
      *
-     * @param array $routeNames
+     * @param array                    $routeNames
      * @param ContaoFrameworkInterface $contaoFramework
      */
-    public function __construct(array $routeNames, ContaoFrameworkInterface $contaoFramework)
-    {
+    public function __construct(
+        array $routeNames,
+        ContaoFrameworkInterface $contaoFramework
+    ) {
         $this->routeNames = $routeNames;
         $this->contaoFramework = $contaoFramework;
+
+        $this->setHeaders(headers_list());
+    }
+
+    /**
+     * Gets the headers.
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Sets the headers.
+     *
+     * @param array $headers
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
+    }
     }
 
     /**
@@ -85,13 +118,7 @@ class MergeHttpHeadersListener
      */
     private function mergeHttpHeaders(Response $response)
     {
-        if ('cli' === PHP_SAPI && function_exists('xdebug_get_headers')) {
-            $headers = xdebug_get_headers();
-        } else {
-            $headers = headers_list();
-        }
-
-        foreach ($headers as $header) {
+        foreach ($this->getHeaders() as $header) {
             list($name, $content) = explode(':', $header, 2);
             $content = trim($content);
 

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\ContaoFrameworkInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Merges HTTP headers sent using PHP's header() method into the Symfony
+ * Response so they are available for other listeners following later in the
+ * application flow and relying on headers to be part of the response object.
+ *
+ * Although this could be useful in many applications we think that this should
+ * not be supported in general and only serves as a layer to support legacy
+ * code and therefore it's restricted to the Contao framework and part of the
+ * Contao Core Bundle.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class MergeHttpHeadersListener
+{
+    /**
+     * @var array
+     */
+    private $routeNames;
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $contaoFramework;
+
+    /**
+     * Constructor.
+     *
+     * @param array $routeNames
+     * @param ContaoFrameworkInterface $contaoFramework
+     */
+    public function __construct(array $routeNames, ContaoFrameworkInterface $contaoFramework)
+    {
+        $this->routeNames = $routeNames;
+        $this->contaoFramework = $contaoFramework;
+    }
+
+    /**
+     * Sets the default locale based on the request or session.
+     *
+     * @param GetResponseEvent $event The event object
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$this->contaoFramework->isInitialized()) {
+
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$request->attributes->has('_route')
+            || !in_array($request->attributes->get('_route'), $this->routeNames)
+        ) {
+
+            return;
+        }
+
+        $event->setResponse($this->mergeHttpHeaders($event->getResponse()));
+    }
+
+    /**
+     * Merge the http headers. If one of the headers is already present in the
+     * response, it will not be merged as the response object has a higher
+     * priority.
+     *
+     * @param Response $response
+     *
+     * @return Response
+     */
+    private function mergeHttpHeaders(Response $response)
+    {
+        if ('cli' === PHP_SAPI && function_exists('xdebug_get_headers')) {
+            $headers = xdebug_get_headers();
+        } else {
+            $headers = headers_list();
+        }
+
+        foreach ($headers as $header) {
+            list($name, $content) = explode(':', $header, 2);
+            $content = trim($content);
+
+            if ($response->headers->has($name)) {
+                continue;
+            }
+
+            $response->headers->set($name, $content);
+        }
+
+        return $response;
+    }
+}

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -35,12 +35,6 @@ class MergeHttpHeadersListener
     private $contaoFramework;
 
     /**
-     * Remove old headers or not
-     * @var boolean
-     */
-    private $removeOldHeaders = true;
-
-    /**
      * Headers
      * @var array
      */
@@ -78,34 +72,6 @@ class MergeHttpHeadersListener
     }
 
     /**
-     * Gets whether old headers should be removed using header_remove()
-     * or not.
-     *
-     * @return boolean
-     */
-    public function getRemoveOldHeaders()
-    {
-        return $this->removeOldHeaders;
-    }
-
-    /**
-     * Sets whether old headers should be removed using header_remove()
-     * or not.
-     *
-     * @param boolean $removeOldHeaders
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function setRemoveOldHeaders($removeOldHeaders)
-    {
-        if (false === $removeOldHeaders && 'cli' !== PHP_SAPI) {
-            throw new \InvalidArgumentException('You cannot disable removing old
-            headers when not on CLI SAPI.');
-        }
-        $this->removeOldHeaders = (bool) $removeOldHeaders;
-    }
-
-    /**
      * Sets the default locale based on the request or session.
      *
      * @param GetResponseEvent $event The event object
@@ -134,7 +100,7 @@ class MergeHttpHeadersListener
         foreach ($this->getHeaders() as $header) {
             list($name, $content) = explode(':', $header, 2);
 
-            if ($this->removeOldHeaders) {
+            if ('cli' !== PHP_SAPI) {
                 header_remove($name);
             }
 

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -153,11 +153,7 @@ class MergeHttpHeadersListener
 
             $content = trim($content);
 
-            if ($response->headers->has($name)) {
-                continue;
-            }
-
-            $response->headers->set($name, $content);
+            $response->headers->set($name, $content, false);
         }
 
         return $response;

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -68,6 +68,14 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 
+    contao.listener.merge_http_headers:
+        class: Contao\CoreBundle\EventListener\MergeHttpHeadersListener
+        arguments:
+            - "%contao.merge_http_headers_routes%"
+            - "@contao.framework"
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 256 }
+
     contao.listener.output_from_cache:
         class: Contao\CoreBundle\EventListener\OutputFromCacheListener
         arguments:

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -1,3 +1,12 @@
+parameters:
+    contao:
+        merge_http_headers_routes:
+            - contao_root
+            - contao_catch_all
+            - contao_frontend
+            - contao_frontend_cron
+            - contao_frontend_share
+
 ##
 # Listener priorities
 #

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -1,12 +1,3 @@
-parameters:
-    contao:
-        merge_http_headers_routes:
-            - contao_root
-            - contao_catch_all
-            - contao_frontend
-            - contao_frontend_cron
-            - contao_frontend_share
-
 ##
 # Listener priorities
 #
@@ -80,7 +71,6 @@ services:
     contao.listener.merge_http_headers:
         class: Contao\CoreBundle\EventListener\MergeHttpHeadersListener
         arguments:
-            - "%contao.merge_http_headers_routes%"
             - "@contao.framework"
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 256 }

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -56,6 +56,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener([], $framework);
         $listener->setHeaders(['FOOBAR: foobar']);
+        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -82,6 +83,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener([], $framework);
         $listener->setHeaders(['FOOBAR: foobar']);
+        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -110,6 +112,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener(['other_route'], $framework);
         $listener->setHeaders(['FOOBAR: content']);
+        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -138,6 +141,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
         $listener->setHeaders(['FOOBAR: content']);
+        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -169,6 +173,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
         $listener->setHeaders(['FOOBAR: new-content']);
+        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -56,7 +56,6 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: foobar']);
-        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -84,7 +83,6 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: content']);
-        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -114,7 +112,6 @@ class MergeHttpHeadersListenerTest extends TestCase
         /** @var ContaoFrameworkInterface $framework */
         $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: new-content']);
-        $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -32,7 +32,7 @@ class MergeHttpHeadersListenerTest extends TestCase
     {
         /** @var ContaoFrameworkInterface $framework */
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
-        $listener = new MergeHttpHeadersListener([], $framework);
+        $listener = new MergeHttpHeadersListener($framework);
 
         $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\MergeHttpHeadersListener', $listener);
     }
@@ -54,64 +54,8 @@ class MergeHttpHeadersListenerTest extends TestCase
         $framework->expects($this->once())->method('isInitialized')->willReturn(false);
 
         /** @var ContaoFrameworkInterface $framework */
-        $listener = new MergeHttpHeadersListener([], $framework);
+        $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: foobar']);
-        $listener->setRemoveOldHeaders(false);
-
-        $listener->onKernelResponse($responseEvent);
-        $response = $responseEvent->getResponse();
-        $this->assertFalse($response->headers->has('FOOBAR'));
-        $this->assertNull($response->headers->get('FOOBAR'));
-    }
-
-    /**
-     * Tests that the listener is skipped if the request has no route.
-     */
-    public function testListenerIsSkippedIfRequestHasNoRoute()
-    {
-        $request = new Request();
-        $responseEvent = new FilterResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::MASTER_REQUEST,
-            new Response()
-        );
-
-        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
-        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-
-        /** @var ContaoFrameworkInterface $framework */
-        $listener = new MergeHttpHeadersListener([], $framework);
-        $listener->setHeaders(['FOOBAR: foobar']);
-        $listener->setRemoveOldHeaders(false);
-
-        $listener->onKernelResponse($responseEvent);
-        $response = $responseEvent->getResponse();
-        $this->assertFalse($response->headers->has('FOOBAR'));
-        $this->assertNull($response->headers->get('FOOBAR'));
-    }
-
-    /**
-     * Tests that the listener is skipped if the request has a route which is the
-     * listener shall not handle.
-     */
-    public function testListenerIsSkippedIfRequestHasRouteTheListenerShouldNotHandle()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'foobar_route');
-        $responseEvent = new FilterResponseEvent(
-            $this->mockKernel(),
-            $request,
-            HttpKernelInterface::MASTER_REQUEST,
-            new Response()
-        );
-
-        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
-        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-
-        /** @var ContaoFrameworkInterface $framework */
-        $listener = new MergeHttpHeadersListener(['other_route'], $framework);
-        $listener->setHeaders(['FOOBAR: content']);
         $listener->setRemoveOldHeaders(false);
 
         $listener->onKernelResponse($responseEvent);
@@ -127,7 +71,6 @@ class MergeHttpHeadersListenerTest extends TestCase
     public function testHeadersAreMerged()
     {
         $request = new Request();
-        $request->attributes->set('_route', 'foobar_route');
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
             $request,
@@ -139,7 +82,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
 
         /** @var ContaoFrameworkInterface $framework */
-        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+        $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: content']);
         $listener->setRemoveOldHeaders(false);
 
@@ -158,7 +101,6 @@ class MergeHttpHeadersListenerTest extends TestCase
         $request = new Request();
         $response = new Response();
         $response->headers->set('FOOBAR', 'content');
-        $request->attributes->set('_route', 'foobar_route');
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
             $request,
@@ -170,7 +112,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
 
         /** @var ContaoFrameworkInterface $framework */
-        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+        $listener = new MergeHttpHeadersListener($framework);
         $listener->setHeaders(['FOOBAR: new-content']);
         $listener->setRemoveOldHeaders(false);
 

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\Test\EventListener;
 
+use Contao\CoreBundle\ContaoFrameworkInterface;
 use Contao\CoreBundle\EventListener\MergeHttpHeadersListener;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,24 +26,11 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 class MergeHttpHeadersListenerTest extends TestCase
 {
     /**
-     * Test for xdebug_get_headers() function. If this doesn't exist,
-     * the tests are nonsense as on CLI the headers_list() function does not
-     * return any headers sent using header().
-     *
-     */
-    protected function setUp()
-    {
-        if (!function_exists('xdebug_get_headers')) {
-            $this->markTestSkipped('To test header() merging you need to have
-            xdebug enabled');
-        }
-    }
-
-    /**
      * Tests the object instantiation.
      */
     public function testInstantiation()
     {
+        /** @var ContaoFrameworkInterface $framework */
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $listener = new MergeHttpHeadersListener([], $framework);
 
@@ -50,12 +38,8 @@ class MergeHttpHeadersListenerTest extends TestCase
     }
 
     /**
-     * Tests that the listener is skipped if the framework was not initialized
-     *
-     * Must run in separate process because of header()
-     *
-     * @runInSeparateProcess
-     **/
+     * Tests that the listener is skipped if the framework was not initialized.
+     */
     public function testListenerIsSkippedIfFrameworkNotInitialized()
     {
         $request = new Request();
@@ -68,9 +52,10 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $framework->expects($this->once())->method('isInitialized')->willReturn(false);
-        $listener = new MergeHttpHeadersListener([], $framework);
 
-        header('FOOBAR: foobar');
+        /** @var ContaoFrameworkInterface $framework */
+        $listener = new MergeHttpHeadersListener([], $framework);
+        $listener->setHeaders(['FOOBAR: foobar']);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -79,12 +64,8 @@ class MergeHttpHeadersListenerTest extends TestCase
     }
 
     /**
-     * Tests that the listener is skipped if the request has no route
-     *
-     * Must run in separate process because of header()
-     *
-     * @runInSeparateProcess
-     **/
+     * Tests that the listener is skipped if the request has no route.
+     */
     public function testListenerIsSkippedIfRequestHasNoRoute()
     {
         $request = new Request();
@@ -97,9 +78,10 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-        $listener = new MergeHttpHeadersListener([], $framework);
 
-        header('FOOBAR: content');
+        /** @var ContaoFrameworkInterface $framework */
+        $listener = new MergeHttpHeadersListener([], $framework);
+        $listener->setHeaders(['FOOBAR: foobar']);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -110,11 +92,7 @@ class MergeHttpHeadersListenerTest extends TestCase
     /**
      * Tests that the listener is skipped if the request has a route which is the
      * listener shall not handle.
-     *
-     * Must run in separate process because of header()
-     *
-     * @runInSeparateProcess
-     **/
+     */
     public function testListenerIsSkippedIfRequestHasRouteTheListenerShouldNotHandle()
     {
         $request = new Request();
@@ -128,9 +106,10 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-        $listener = new MergeHttpHeadersListener(['other_route'], $framework);
 
-        header('FOOBAR: content');
+        /** @var ContaoFrameworkInterface $framework */
+        $listener = new MergeHttpHeadersListener(['other_route'], $framework);
+        $listener->setHeaders(['FOOBAR: content']);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -140,12 +119,8 @@ class MergeHttpHeadersListenerTest extends TestCase
 
     /**
      * Tests that the headers sent using header() are actually merged into the
-     * response object
-     *
-     * Must run in separate process because of header()
-     *
-     * @runInSeparateProcess
-     **/
+     * response object.
+     */
     public function testHeadersAreMerged()
     {
         $request = new Request();
@@ -159,9 +134,10 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
 
-        header('FOOBAR: content');
+        /** @var ContaoFrameworkInterface $framework */
+        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+        $listener->setHeaders(['FOOBAR: content']);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
@@ -173,11 +149,7 @@ class MergeHttpHeadersListenerTest extends TestCase
      * Tests that if the response object already contains the header that shall
      * be sent using header(), it is not overridden. The response object always
      * has priority.
-     *
-     * Must run in separate process because of header()
-     *
-     * @runInSeparateProcess
-     **/
+     */
     public function testHeadersAreNotOverridenIfAlreadyPresentInResponse()
     {
         $request = new Request();
@@ -193,9 +165,10 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
         $framework->expects($this->once())->method('isInitialized')->willReturn(true);
-        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
 
-        header('FOOBAR: new-content');
+        /** @var ContaoFrameworkInterface $framework */
+        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+        $listener->setHeaders(['FOOBAR: new-content']);
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\EventListener\MergeHttpHeadersListener;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests the MergeHttpHeadersListenerTest class.
+ *
+ * @author Yanick Witschi <https:/github.com/toflar>
+ */
+class MergeHttpHeadersListenerTest extends TestCase
+{
+    /**
+     * Test for xdebug_get_headers() function. If this doesn't exist,
+     * the tests are nonsense as on CLI the headers_list() function does not
+     * return any headers sent using header().
+     *
+     */
+    protected function setUp()
+    {
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('To test header() merging you need to have
+            xdebug enabled');
+        }
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $listener = new MergeHttpHeadersListener([], $framework);
+
+        $this->assertInstanceOf('Contao\\CoreBundle\\EventListener\\MergeHttpHeadersListener', $listener);
+    }
+
+    /**
+     * Tests that the listener is skipped if the framework was not initialized
+     *
+     * Must run in separate process because of header()
+     *
+     * @runInSeparateProcess
+     **/
+    public function testListenerIsSkippedIfFrameworkNotInitialized()
+    {
+        $request = new Request();
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $framework->expects($this->once())->method('isInitialized')->willReturn(false);
+        $listener = new MergeHttpHeadersListener([], $framework);
+
+        header('FOOBAR: foobar');
+
+        $listener->onKernelResponse($responseEvent);
+        $response = $responseEvent->getResponse();
+        $this->assertFalse($response->headers->has('FOOBAR'));
+        $this->assertNull($response->headers->get('FOOBAR'));
+    }
+
+    /**
+     * Tests that the listener is skipped if the request has no route
+     *
+     * Must run in separate process because of header()
+     *
+     * @runInSeparateProcess
+     **/
+    public function testListenerIsSkippedIfRequestHasNoRoute()
+    {
+        $request = new Request();
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
+        $listener = new MergeHttpHeadersListener([], $framework);
+
+        header('FOOBAR: content');
+
+        $listener->onKernelResponse($responseEvent);
+        $response = $responseEvent->getResponse();
+        $this->assertFalse($response->headers->has('FOOBAR'));
+        $this->assertNull($response->headers->get('FOOBAR'));
+    }
+
+    /**
+     * Tests that the listener is skipped if the request has a route which is the
+     * listener shall not handle.
+     *
+     * Must run in separate process because of header()
+     *
+     * @runInSeparateProcess
+     **/
+    public function testListenerIsSkippedIfRequestHasRouteTheListenerShouldNotHandle()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'foobar_route');
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
+        $listener = new MergeHttpHeadersListener(['other_route'], $framework);
+
+        header('FOOBAR: content');
+
+        $listener->onKernelResponse($responseEvent);
+        $response = $responseEvent->getResponse();
+        $this->assertFalse($response->headers->has('FOOBAR'));
+        $this->assertNull($response->headers->get('FOOBAR'));
+    }
+
+    /**
+     * Tests that the headers sent using header() are actually merged into the
+     * response object
+     *
+     * Must run in separate process because of header()
+     *
+     * @runInSeparateProcess
+     **/
+    public function testHeadersAreMerged()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'foobar_route');
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
+        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+
+        header('FOOBAR: content');
+
+        $listener->onKernelResponse($responseEvent);
+        $response = $responseEvent->getResponse();
+        $this->assertTrue($response->headers->has('FOOBAR'));
+        $this->assertSame('content', $response->headers->get('FOOBAR'));
+    }
+
+    /**
+     * Tests that if the response object already contains the header that shall
+     * be sent using header(), it is not overridden. The response object always
+     * has priority.
+     *
+     * Must run in separate process because of header()
+     *
+     * @runInSeparateProcess
+     **/
+    public function testHeadersAreNotOverridenIfAlreadyPresentInResponse()
+    {
+        $request = new Request();
+        $response = new Response();
+        $response->headers->set('FOOBAR', 'content');
+        $request->attributes->set('_route', 'foobar_route');
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+
+        $framework =  $this->getMock('Contao\\CoreBundle\\ContaoFrameworkInterface');
+        $framework->expects($this->once())->method('isInitialized')->willReturn(true);
+        $listener = new MergeHttpHeadersListener(['foobar_route'], $framework);
+
+        header('FOOBAR: new-content');
+
+        $listener->onKernelResponse($responseEvent);
+        $response = $responseEvent->getResponse();
+        $this->assertTrue($response->headers->has('FOOBAR'));
+        $this->assertSame('content', $response->headers->get('FOOBAR'));
+    }
+}

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -151,8 +151,7 @@ class MergeHttpHeadersListenerTest extends TestCase
 
     /**
      * Tests that if the response object already contains the header that shall
-     * be sent using header(), it is not overridden. The response object always
-     * has priority.
+     * be sent using header(), it is not overridden. It should get merged.
      */
     public function testHeadersAreNotOverridenIfAlreadyPresentInResponse()
     {
@@ -177,7 +176,12 @@ class MergeHttpHeadersListenerTest extends TestCase
 
         $listener->onKernelResponse($responseEvent);
         $response = $responseEvent->getResponse();
+
         $this->assertTrue($response->headers->has('FOOBAR'));
-        $this->assertSame('content', $response->headers->get('FOOBAR'));
+
+        $allHeaders = $response->headers->get('FOOBAR', null, false);
+
+        $this->assertSame('content', $allHeaders[0]);
+        $this->assertSame('new-content', $allHeaders[1]);
     }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/contao/core-bundle/pull/331. We still have a lot of "legacy" code that cannot properly send HTTP headers. The way to go currently is still using `header()`. However, those ones are not respected in a lot of Symfony Bundles that listen on `kernel.response` and read the `Response` object for headers and do more stuff accordingly. This PR provides a listener that merges the sent HTTP headers into the SF response object unless they were already present (so it's not possible to overwrite the ones in the response).

RFC: 

* [x] `listener.yml` and config is obviously still missing.
* [x] Is it correct not to replace already existing headers in the response object?
* [x] What about the status code? I cannot really use `http_response_code()` because how do I know whether the one in the `Response` object is correct or the one set using `header()`?