### PR TITLE
Follow symlinks when searching for installed files

### DIFF
--- a/src/Command/SymlinksCommand.php
+++ b/src/Command/SymlinksCommand.php
@@ -175,7 +175,7 @@ class SymlinksCommand extends AbstractLockedCommand
      */
     private function findIn($path)
     {
-        return Finder::create()->ignoreDotFiles(false)->filter($this->getFilterClosure())->in($path);
+        return Finder::create()->ignoreDotFiles(false)->filter($this->getFilterClosure())->followLinks()->in($path);
     }
 
     /**


### PR DESCRIPTION
I used my draft of the composer plugin to install legacy packages into system modules. However, the .htaccess files were not found due to this missing flag. I can't think of any side effects with enabling this "by default".