### PR TITLE
Fix DcaExtractor when no database.sql file was found

### DIFF
--- a/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -430,21 +430,21 @@ class DcaExtractor extends \Controller
 
 			if (!isset(static::$arrSql[$this->strTable]))
 			{
+				$arrSql = array();
+
 				try
 				{
 					/** @var SplFileInfo[] $files */
 					$files = \System::getContainer()->get('contao.resource_locator')->locate('config/database.sql', null, false);
+
+					foreach ($files as $file)
+					{
+						$arrSql = array_merge_recursive($arrSql, \SqlFileParser::parse($file));
+					}
 				}
 				catch (\InvalidArgumentException $e)
 				{
-					return;
-				}
-
-				$arrSql = array();
-
-				foreach ($files as $file)
-				{
-					$arrSql = array_merge_recursive($arrSql, \SqlFileParser::parse($file));
+					// Set static::$arrSql to an empty array if no database.sql files are found
 				}
 
 				static::$arrSql = $arrSql;


### PR DESCRIPTION
`$blnFromFile` is set to true when one filed in the DCA does not contain an SQL definition. Then the extractor tried to load files and failed, resulting in the DCA file details not being parsed either.