### PR TITLE
[WIP] Added backwards compatibility for Database_Result etc.

### DIFF
--- a/src/Resources/contao/config/ide_compat.php
+++ b/src/Resources/contao/config/ide_compat.php
@@ -40,7 +40,6 @@ namespace {
 	class BackendFile extends \Contao\BackendFile {}
 	class BackendHelp extends \Contao\BackendHelp {}
 	class BackendIndex extends \Contao\BackendIndex {}
-	class BackendInstall extends \Contao\BackendInstall {}
 	class BackendMain extends \Contao\BackendMain {}
 	class BackendPage extends \Contao\BackendPage {}
 	class BackendPassword extends \Contao\BackendPassword {}
@@ -99,6 +98,8 @@ namespace {
 	class Config extends \Contao\Config {}
 	abstract class Controller extends \Contao\Controller {}
 	class Database extends \Contao\Database {}
+	class Database_Result extends \Contao\Database\Result {}
+	class Database_Statement extends \Contao\Database\Statement {}
 	class Date extends \Contao\Date {}
 	class Dbafs extends \Contao\Dbafs {}
 	class DcaExtractor extends \Contao\DcaExtractor {}

--- a/src/Resources/contao/library/Contao/ClassLoader.php
+++ b/src/Resources/contao/library/Contao/ClassLoader.php
@@ -182,6 +182,20 @@ class ClassLoader
 			}
 		}
 
+		if ($class == 'Database_Statement')
+		{
+			trigger_error('Class Database_Statement is deprecated, use \\Contao\\Database\\Statement instead', E_USER_DEPRECATED);
+
+			return 'Contao\\Database\\Statement';
+		}
+
+		if ($class == 'Database_Result')
+		{
+			trigger_error('Class Database_Result is deprecated, use \\Contao\\Database\\Result instead', E_USER_DEPRECATED);
+
+			return 'Contao\\Database\\Result';
+		}
+
 		return null;
 	}
 


### PR DESCRIPTION
Some (old) extensions still rely on classes like `Database_Result`, especially for method arguments. In Contao 3, the `class_alias` method was called directly in the class file, but this would not allow to trigger a deprecated warning.