### PR TITLE
[RTM] Added ScriptHandler method to generate random secret

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "simplepie/simplepie": "~1.3",
         "tecnick.com/tcpdf": "~6.0",
         "true/punycode": "~1.0",
-        "contao-components/all": "~4.0"
+        "contao-components/all": "~4.0",
+        "paragonie/random_compat": "~1.0"
     },
     "require-dev": {
         "composer/composer": "~1.0@dev",

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -42,6 +42,28 @@ class ScriptHandler
     }
 
     /**
+     * Sets environment variable for random secret on installation.
+     *
+     * @param Event $event The event object
+     */
+    public static function generateRandomSecret(Event $event)
+    {
+        $extra = $event->getComposer()->getPackage()->getExtra();
+
+        if (!isset($extra['incenteev-parameters']) || !isset($extra['incenteev-parameters']['file'])) {
+            return;
+        }
+
+        $file = $extra['incenteev-parameters']['file'];
+
+        if (is_file($file)) {
+            return;
+        }
+
+        putenv('CONTAO_RANDOM_SECRET=' . md5(uniqid(mt_rand(), true)));
+    }
+
+    /**
      * Executes a command.
      *
      * @param string $cmd   The command

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -21,6 +21,8 @@ use Symfony\Component\Process\Process;
  */
 class ScriptHandler
 {
+    const RANDOM_SECRET_NAME = 'CONTAO_RANDOM_SECRET';
+
     /**
      * Adds the Contao directories.
      *
@@ -54,7 +56,7 @@ class ScriptHandler
             return;
         }
 
-        putenv('CONTAO_RANDOM_SECRET=' . bin2hex(random_bytes(32)));
+        putenv(static::RANDOM_SECRET_NAME . '=' . bin2hex(random_bytes(32)));
     }
 
     /**
@@ -101,9 +103,11 @@ class ScriptHandler
             $result = false;
 
             foreach ($config as $v) {
-                if (is_array($v) && isset($v['file']) && !is_file($v['file'])) {
-                    $result = true;
+                if (is_array($v) && isset($v['file']) && is_file($v['file'])) {
+                    return false;
                 }
+
+                $result = true;
             }
 
             return $result;

--- a/tests/Composer/ScriptHandlerTest.php
+++ b/tests/Composer/ScriptHandlerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Script\Event;
+use Contao\CoreBundle\Composer\ScriptHandler;
+use Contao\CoreBundle\Test\TestCase;
+
+/**
+ * Tests the ScriptHandler class.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class ScriptHandlerTest extends TestCase
+{
+    /**
+     * @var ScriptHandler
+     */
+    private $handler;
+
+    public function setUp()
+    {
+        $this->handler = new ScriptHandler();
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\\CoreBundle\\Composer\\ScriptHandler', $this->handler);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGeneratesRandomSecret()
+    {
+        $this->assertRandomSecretDoesNotExist();
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent(
+                [
+                    'incenteev-parameters' => [
+                        'file' => __DIR__ . '/../Fixtures/app/config/parameters.yml'
+                    ]
+                ]
+            )
+        );
+
+        $this->assertRandomSecretIsValid();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGeneratesRandomSecretArray()
+    {
+        $this->assertRandomSecretDoesNotExist();
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent(
+                [
+                    'incenteev-parameters' => [
+                        [
+                            'file' => __DIR__ . '/../Fixtures/app/config/parameters.yml'
+                        ],
+                        [
+                            'file' => __DIR__ . '/../Fixtures/app/config/test.yml'
+                        ]
+                    ]
+                ]
+            )
+        );
+
+        $this->assertRandomSecretIsValid();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGeneratesNoRandomSecretWithoutFileConfig()
+    {
+        $this->assertRandomSecretDoesNotExist();
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent([])
+        );
+
+        $this->assertRandomSecretDoesNotExist();
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent(
+                [
+                    'incenteev-parameters' => []
+                ]
+            )
+        );
+
+        $this->assertRandomSecretDoesNotExist();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGeneratesNoRandomSecretIfFileExists()
+    {
+        $this->assertRandomSecretDoesNotExist();
+
+        touch(__DIR__ . '/../Fixtures/app/config/parameters.yml');
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent(
+                [
+                    'incenteev-parameters' => [
+                        'file' => __DIR__ . '/../Fixtures/app/config/parameters.yml'
+                    ]
+                ]
+            )
+        );
+
+        unlink(__DIR__ . '/../Fixtures/app/config/parameters.yml');
+
+        $this->assertRandomSecretDoesNotExist();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGeneratesNoRandomSecretIfFileExistsArray()
+    {
+        $this->assertRandomSecretDoesNotExist();
+
+        touch(__DIR__ . '/../Fixtures/app/config/parameters.yml');
+
+        $this->handler->generateRandomSecret(
+            $this->getComposerEvent(
+                [
+                    'incenteev-parameters' => [
+                        [
+                            'file' => __DIR__ . '/../Fixtures/app/config/parameters.yml'
+                        ],
+                        [
+                            'file' => __DIR__ . '/../Fixtures/app/config/test.yml'
+                        ]
+                    ]
+                ]
+            )
+        );
+
+        unlink(__DIR__ . '/../Fixtures/app/config/parameters.yml');
+
+        $this->assertRandomSecretDoesNotExist();
+    }
+
+    /**
+     * Asserts that the random secret environment variable is not set.
+     */
+    private function assertRandomSecretDoesNotExist()
+    {
+        $this->assertEmpty(getenv(ScriptHandler::RANDOM_SECRET_NAME));
+    }
+
+    /**
+     * Asserts that the random secret environment variable is set and valid.
+     */
+    private function assertRandomSecretIsValid()
+    {
+        $this->assertNotFalse(getenv(ScriptHandler::RANDOM_SECRET_NAME));
+        $this->assertGreaterThanOrEqual(64, strlen(getenv(ScriptHandler::RANDOM_SECRET_NAME)));
+    }
+
+    /**
+     * @param array $extra
+     *
+     * @return Event
+     */
+    private function getComposerEvent(array $extra = [])
+    {
+        $package = $this->mockPackage($extra);
+
+        return new Event('', $this->mockComposer($package), $this->mockIO());
+    }
+
+    /**
+     * @param PackageInterface $package
+     *
+     * @return Composer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockComposer(PackageInterface $package)
+    {
+        $config          = $this->getMock('Composer\\Config');
+        $downloadManager = $this->getMock('Composer\\Downloader\\DownloadManager', [], [], '', false);
+        $composer        = $this->getMock('Composer\\Composer', ['getConfig', 'getDownloadManager', 'getPackage']);
+
+        $composer
+            ->expects($this->any())
+            ->method('getConfig')
+            ->willReturn($config)
+        ;
+
+        $composer
+            ->expects($this->any())
+            ->method('getDownloadManager')
+            ->willReturn($downloadManager)
+        ;
+
+        $composer
+            ->expects($this->any())
+            ->method('getPackage')
+            ->willReturn($package)
+        ;
+
+        return $composer;
+    }
+
+    /**
+     * @return IOInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockIO()
+    {
+        $io = $this->getMock('Composer\\IO\\IOInterface');
+
+        $io
+            ->expects($this->any())
+            ->method('isVerbose')
+            ->willReturn(true)
+        ;
+
+        $io
+            ->expects($this->any())
+            ->method('isVeryVerbose')
+            ->willReturn(true)
+        ;
+
+        return $io;
+    }
+
+    /**
+     * @param array $extras
+     *
+     * @return PackageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockPackage(array $extras = [])
+    {
+        $package = $this->getMock('Composer\\Package\\PackageInterface');
+
+        $package
+            ->expects($this->any())
+            ->method('getTargetDir')
+            ->willReturn('')
+        ;
+
+        $package
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn('foo/bar')
+        ;
+
+        $package
+            ->expects($this->any())
+            ->method('getPrettyName')
+            ->willReturn('foo/bar')
+        ;
+
+        $package
+            ->expects(empty($extras) ? $this->any() : $this->atLeastOnce())
+            ->method('getExtra')
+            ->willReturn($extras)
+        ;
+
+        return $package;
+    }
+}

--- a/tests/Fixtures/app/config/.gitignore
+++ b/tests/Fixtures/app/config/.gitignore
@@ -1,0 +1,1 @@
+# Dummy file


### PR DESCRIPTION
This adds the necessary script handler to generate the random secret for https://github.com/contao/core-bundle/issues/302

The random secret must only be generated if the `parameters.yml` file does not exist. This is because the `IncentiveeParametersHandler` will update/overwrite existing parameters if a respective environment variable is available.

Using this method means the user is not asked for a random secret on installation, but it can obviously still be changed in the `parameters.yml`.