### PR TITLE
Fix composer abandoned hint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "patchwork/utf8": "~1.2",
         "phpspec/php-diff": "~1.0",
         "simplepie/simplepie": "~1.3",
-        "tecnick.com/tcpdf": "~6.0",
+        "tecnickcom/tcpdf": "~6.0",
         "true/punycode": "~1.0",
         "contao-components/all": "~4.0"
     },


### PR DESCRIPTION
`Package tecnick.com/tcpdf is abandoned, you should avoid using it. Use tecnickcom/tcpdf instead.`