### PR TITLE
Correctly use the driver to check for enabled lock

### DIFF
--- a/src/Resources/contao/classes/Maintenance.php
+++ b/src/Resources/contao/classes/Maintenance.php
@@ -43,14 +43,19 @@ class Maintenance extends \Backend implements \executable
 		$objTemplate->headline = $GLOBALS['TL_LANG']['tl_maintenance']['maintenanceMode'];
 		$objTemplate->isActive = $this->isActive();
 
-		$container = \System::getContainer();
-		$isLocked = file_exists($container->getParameter('kernel.root_dir') . '/cache/lock');
+		try
+		{
+			$driver   = \System::getContainer()->get('lexik_maintenance.driver.factory')->getDriver();
+			$isLocked = $driver->isExists();
+		}
+		catch (\Exception $e)
+		{
+			return '';
+		}
 
 		// Toggle the maintenance mode
 		if (\Input::post('FORM_SUBMIT') == 'tl_maintenance_mode')
 		{
-			$driver = $this->getContainer()->get('lexik_maintenance.driver.factory')->getDriver();
-
 			if ($isLocked)
 			{
 				$driver->unlock();

--- a/src/Resources/contao/classes/Messages.php
+++ b/src/Resources/contao/classes/Messages.php
@@ -42,9 +42,16 @@ class Messages extends \Backend
 	 */
 	public function maintenanceCheck()
 	{
-		if (file_exists(\System::getContainer()->getParameter('kernel.root_dir') . '/cache/lock'))
+		try
 		{
-			return '<p class="tl_error"><a href="contao/main.php?do=maintenance">' . $GLOBALS['TL_LANG']['MSC']['maintenanceEnabled'] . '</a></p>';
+			if (\System::getContainer()->get('lexik_maintenance.driver.factory')->getDriver()->isExists())
+			{
+				return '<p class="tl_error"><a href="contao/main.php?do=maintenance">' . $GLOBALS['TL_LANG']['MSC']['maintenanceEnabled'] . '</a></p>';
+			}
+		}
+		catch (\Exception $e)
+		{
+			// If the driver does not exist, we simply don't show a message
 		}
 
 		return '';


### PR DESCRIPTION
The app config can be adjusted to use another driver, so we should not check for the file directly.