### PR TITLE
[RFC] Extracting the request token handling from the framework

### DIFF
--- a/src/EventListener/RequestTokenListener.php
+++ b/src/EventListener/RequestTokenListener.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
+use Contao\CoreBundle\Exception\InvalidRequestTokenException;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+/**
+ * Validates Contao request tokens.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class RequestTokenListener
+{
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $framework;
+
+    /**
+     * @var array
+     */
+    private $routeNames;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var CsrfTokenManagerInterface
+     */
+    private $tokenManager;
+
+    /**
+     * @var string
+     */
+    private $csrfTokenName;
+
+    /**
+     * Constructor.
+     *
+     * @param ContaoFrameworkInterface  $framework
+     * @param array                     $routeNames
+     * @param RouterInterface           $router
+     * @param CsrfTokenManagerInterface $tokenManager
+     * @param string                    $csrfTokenName
+     */
+    public function __construct(
+        ContaoFrameworkInterface $framework,
+        array $routeNames,
+        RouterInterface $router,
+        CsrfTokenManagerInterface $tokenManager,
+        $csrfTokenName
+    ) {
+        $this->framework = $framework;
+        $this->routeNames = $routeNames;
+        $this->router = $router;
+        $this->tokenManager = $tokenManager;
+        $this->csrfTokenName = $csrfTokenName;
+    }
+
+    /**
+     * Handle the request token.
+     *
+     * @param GetResponseEvent $event
+     *
+     * @throws AjaxRedirectResponseException|InvalidRequestTokenException If the token is invalid
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$this->framework->isInitialized()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (null === $request
+            || 'POST' !== $request->getRealMethod()
+            || !$request->attributes->has('_route')
+            || !in_array($request->attributes->get('_route'), $this->routeNames)
+        ) {
+            return;
+        }
+
+        $this->setConstant();
+
+        $token = new CsrfToken($this->csrfTokenName, $request->request->get('REQUEST_TOKEN'));
+
+        if ($this->tokenManager->isTokenValid($token)) {
+            return;
+        }
+
+        if ($request->isXmlHttpRequest()) {
+            // @todo is contao_backend really the right solution here?
+            throw new AjaxRedirectResponseException($this->router->generate('contao_backend'));
+        }
+
+        throw new InvalidRequestTokenException('Invalid request token. Please reload the page and try again.');
+    }
+
+    /**
+     * Sets the REQUEST_TOKEN constant
+     */
+    private function setConstant()
+    {
+        // Deprecated since Contao 4.0, to be removed in Contao 5.0
+        if (!defined('REQUEST_TOKEN')) {
+            define('REQUEST_TOKEN', $this->tokenManager->getToken($this->csrfTokenName)->getValue());
+        }
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -109,6 +109,17 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 64 }
 
+    contao.listener.request_token:
+        class: Contao\CoreBundle\EventListener\RequestTokenListener
+        arguments:
+            - "@contao.framework"
+            - "%contao.request_token.routes%"
+            - "@router"
+            - "@security.csrf.token_manager"
+            - "%contao.csrf_token_name%"
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
     contao.listener.session:
         class: Contao\CoreBundle\EventListener\SessionListener
         arguments:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,8 +15,6 @@ services:
             - "@router"
             - "@session"
             - "%kernel.root_dir%"
-            - "@security.csrf.token_manager"
-            - "%contao.csrf_token_name%"
             - "%contao.error_level%"
         calls:
             - ["setContainer", ["@service_container"]]


### PR DESCRIPTION
Here's the first draft. Open questions:

* See my `@todo`. This was copied from the original source but shouldn't this target route be different?
* Same question as we had several times: Am I allowed to change the constructor of `ContaoFramework`? We really need to make a decision here once and for all.
* Is the naming for `contao.request_token.routes` okay?
* Where should the default settings for `contao.request_token.routes` go?
* Does the listener have to have any special priority?
* Isn't removing the request handling from the `ContaoFramework` a BC break? It automatically checked in Contao 4 but doesn't in Contao 4.1 anymore unless you enable it for your route...

And of course the unit tests are missing but I'll add them once we got the questions sorted.