### PR TITLE
[RTM] Solution for event listeners

### DIFF
--- a/src/Resources/contao/library/Contao/System.php
+++ b/src/Resources/contao/library/Contao/System.php
@@ -152,7 +152,18 @@ abstract class System
 
 		if ($blnForce || !isset($this->arrObjects[$strKey]))
 		{
-			$this->arrObjects[$strKey] = (in_array('getInstance', get_class_methods($strClass))) ? call_user_func(array($strClass, 'getInstance')) : new $strClass();
+			if (static::getContainer()->has($strClass))
+			{
+				$this->arrObjects[$strKey] = self::getContainer()->get($strClass);
+			}
+			elseif (in_array('getInstance', get_class_methods($strClass)))
+			{
+				$this->arrObjects[$strKey] = call_user_func(array($strClass, 'getInstance'));
+			}
+			else
+			{
+				$this->arrObjects[$strKey] = new $strClass();
+			}
 		}
 	}
 
@@ -172,7 +183,18 @@ abstract class System
 
 		if ($blnForce || !isset(static::$arrStaticObjects[$strKey]))
 		{
-			static::$arrStaticObjects[$strKey] = (in_array('getInstance', get_class_methods($strClass))) ? call_user_func(array($strClass, 'getInstance')) : new $strClass();
+			if (static::getContainer()->has($strClass))
+			{
+				static::$arrStaticObjects[$strKey] = self::getContainer()->get($strClass);
+			}
+			elseif (in_array('getInstance', get_class_methods($strClass)))
+			{
+				static::$arrStaticObjects[$strKey] = call_user_func(array($strClass, 'getInstance'));
+			}
+			else
+			{
+				static::$arrStaticObjects[$strKey] = new $strClass();
+			}
 		}
 
 		return static::$arrStaticObjects[$strKey];


### PR DESCRIPTION
The solution is so simple, I can't believe we did not come up with it earlier:
`System::import()` and `System::importStatic()` simply allow to pass a service name as class name.

**Example for hooks:**
```php
// config.php
$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = ['app.event_listener.foo', 'replaceInsertTags'];

// foo service
public function replaceInsertTags(/** ... */) {
    // just a regular function with the original arguments
}
```

This solves all issues with passing by reference etc. It also automatically enables event listener for callbacks in `DC_Table` as well as any third-party extensions that use the *correct* way of calling a hook.


**Other effects / advantages:**
In unit tests, I can now set a service called `Database` into the mock container. Which means that mocked services can be used for everyone who does `System::importStatic()`. I think this will be a great advantage to unit test legacy stuff.

Replaces #204