### PR TITLE
[RTM] Use the RequestToken class to validate the Contao request token

### DIFF
--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -17,14 +17,13 @@ use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
 use Contao\CoreBundle\Exception\IncompleteInstallationException;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\Input;
+use Contao\RequestToken;
 use Contao\System;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Initializes the Contao framework.
@@ -47,11 +46,6 @@ class ContaoFramework implements ContaoFrameworkInterface
     private $router;
 
     /**
-     * @var CsrfTokenManagerInterface
-     */
-    private $tokenManager;
-
-    /**
      * @var SessionInterface
      */
     private $session;
@@ -60,11 +54,6 @@ class ContaoFramework implements ContaoFrameworkInterface
      * @var string
      */
     private $rootDir;
-
-    /**
-     * @var string
-     */
-    private $csrfTokenName;
 
     /**
      * @var int
@@ -105,28 +94,22 @@ class ContaoFramework implements ContaoFrameworkInterface
     /**
      * Constructor.
      *
-     * @param RequestStack              $requestStack  The request stack
-     * @param RouterInterface           $router        The router service
-     * @param SessionInterface          $session       The session service
-     * @param string                    $rootDir       The kernel root directory
-     * @param CsrfTokenManagerInterface $tokenManager  The token manager service
-     * @param string                    $csrfTokenName The name of the token
-     * @param int                       $errorLevel    The PHP error level
+     * @param RequestStack     $requestStack  The request stack
+     * @param RouterInterface  $router        The router service
+     * @param SessionInterface $session       The session service
+     * @param string           $rootDir       The kernel root directory
+     * @param int              $errorLevel    The PHP error level
      */
     public function __construct(
         RequestStack $requestStack,
         RouterInterface $router,
         SessionInterface $session,
         $rootDir,
-        CsrfTokenManagerInterface $tokenManager,
-        $csrfTokenName,
         $errorLevel
     ) {
         $this->router = $router;
         $this->session = $session;
         $this->rootDir = dirname($rootDir);
-        $this->tokenManager = $tokenManager;
-        $this->csrfTokenName = $csrfTokenName;
         $this->errorLevel = $errorLevel;
         $this->requestStack = $requestStack;
     }
@@ -434,16 +417,14 @@ class ContaoFramework implements ContaoFrameworkInterface
     {
         // Deprecated since Contao 4.0, to be removed in Contao 5.0
         if (!defined('REQUEST_TOKEN')) {
-            define('REQUEST_TOKEN', $this->tokenManager->getToken($this->csrfTokenName)->getValue());
+            define('REQUEST_TOKEN', RequestToken::get());
         }
 
         if (null === $this->request || 'POST' !== $this->request->getRealMethod()) {
             return;
         }
 
-        $token = new CsrfToken($this->csrfTokenName, $this->request->request->get('REQUEST_TOKEN'));
-
-        if ($this->tokenManager->isTokenValid($token)) {
+        if (RequestToken::validate($this->request->request->get('REQUEST_TOKEN'))) {
             return;
         }
 

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -94,11 +94,11 @@ class ContaoFramework implements ContaoFrameworkInterface
     /**
      * Constructor.
      *
-     * @param RequestStack     $requestStack  The request stack
-     * @param RouterInterface  $router        The router service
-     * @param SessionInterface $session       The session service
-     * @param string           $rootDir       The kernel root directory
-     * @param int              $errorLevel    The PHP error level
+     * @param RequestStack     $requestStack The request stack
+     * @param RouterInterface  $router       The router service
+     * @param SessionInterface $session      The session service
+     * @param string           $rootDir      The kernel root directory
+     * @param int              $errorLevel   The PHP error level
      */
     public function __construct(
         RequestStack $requestStack,

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,8 +15,6 @@ services:
             - "@router"
             - "@session"
             - "%kernel.root_dir%"
-            - "@security.csrf.token_manager"
-            - "%contao.csrf_token_name%"
             - "%contao.error_level%"
         calls:
             - ["setContainer", ["@service_container"]]

--- a/src/Resources/contao/library/Contao/RequestToken.php
+++ b/src/Resources/contao/library/Contao/RequestToken.php
@@ -53,9 +53,8 @@ class RequestToken
 	public static function get()
 	{
 		$container = \System::getContainer();
-		$name = $container->getParameter('contao.csrf_token_name');
 
-		return $container->get('security.csrf.token_manager')->getToken($name)->getValue();
+		return $container->get('security.csrf.token_manager')->getToken($container->getParameter('contao.csrf_token_name'))->getValue();
 	}
 
 
@@ -89,8 +88,7 @@ class RequestToken
 		}
 
 		$container = \System::getContainer();
-		$token = new CsrfToken($container->getParameter('contao.csrf_token_name'), $strToken);
 
-		return $container->get('security.csrf.token_manager')->isTokenValid($token);
+		return $container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), $strToken));
 	}
 }

--- a/tests/Fixtures/library/RequestToken.php
+++ b/tests/Fixtures/library/RequestToken.php
@@ -4,13 +4,18 @@ namespace Contao\Fixtures;
 
 class RequestToken
 {
-    public static function validate()
-    {
-        return true;
-    }
-
     public static function initialize()
     {
         // do nothing
+    }
+
+    public static function get()
+    {
+        return 'foobar';
+    }
+
+    public static function validate()
+    {
+        return true;
     }
 }

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -16,7 +16,6 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 /**
  * Tests the ContaoFramework class.

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -206,12 +206,6 @@ class ContaoFrameworkTest extends TestCase
                 $this->mockRouter('/contao/install'),
                 $this->mockSession(),
                 $this->getRootDir() . '/app',
-                new CsrfTokenManager(
-                    $this->getMock('Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface'),
-                    $this->getMock('Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface')
-                ),
-                'contao_csrf_token',
-                null,
                 error_reporting(),
             ])
             ->setMethods(['isInitialized'])
@@ -316,8 +310,7 @@ class ContaoFrameworkTest extends TestCase
 
         $framework = $this->mockContaoFramework(
             $container->get('request_stack'),
-            $this->mockRouter('/contao/install'),
-            $tokenManager
+            $this->mockRouter('/contao/install')
         );
 
         $framework->setContainer($container);
@@ -336,28 +329,6 @@ class ContaoFrameworkTest extends TestCase
         $this->assertEquals('', TL_REFERER_ID);
         $this->assertEquals('contao/install', TL_SCRIPT);
         $this->assertEquals('', TL_PATH);
-    }
-
-    /**
-     * Tests initializing the framework with an invalid request token.
-     *
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     * @expectedException \Contao\CoreBundle\Exception\InvalidRequestTokenException
-     */
-    public function testInvalidRequestToken()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->setMethod('POST');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/contao/install'));
-        $framework->setContainer($container);
-        $framework->initialize();
     }
 
     /**
@@ -407,7 +378,6 @@ class ContaoFrameworkTest extends TestCase
         $framework = $this->mockContaoFramework(
             $container->get('request_stack'),
             $this->mockRouter('/contao/install'),
-            null,
             $configAdapter
         );
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,8 +26,6 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Abstract TestCase class.
@@ -216,17 +214,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * Returns a ContaoFramework instance.
      *
-     * @param RequestStack                   $requestStack  The request stack
-     * @param RouterInterface                $router        The router object
-     * @param CsrfTokenManagerInterface|null $tokenManager  An optional token manager
-     * @param Adapter|null                   $configAdapter An optional config adapter
+     * @param RequestStack    $requestStack  The request stack
+     * @param RouterInterface $router        The router object
+     * @param Adapter|null    $configAdapter An optional config adapter
      *
      * @return ContaoFramework The object instance
      */
     public function mockContaoFramework(
         RequestStack $requestStack = null,
         RouterInterface $router = null,
-        CsrfTokenManagerInterface $tokenManager = null,
         Adapter $configAdapter = null
     ) {
         $container = $this->mockContainerWithContaoScopes();
@@ -237,13 +233,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         if (null === $router) {
             $router = $this->mockRouter('/index.html');
-        }
-
-        if (null === $tokenManager) {
-            $tokenManager = new CsrfTokenManager(
-                $this->getMock('Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface'),
-                $this->getMock('Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface')
-            );
         }
 
         if (null === $configAdapter) {
@@ -258,8 +247,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
                 $router,
                 $this->mockSession(),
                 $this->getRootDir() . '/app',
-                $tokenManager,
-                'contao_csrf_token',
                 error_reporting(),
             ])
             ->setMethods(['getAdapter'])


### PR DESCRIPTION
As discussed on Mumble, we should use the `RequestToken` class to validate the Contao request token to restore support for `disableRefererCheck`, `BYPASS_TOKEN_CHECK` and `requestTokenWhitelist`. This PR includes the necessary changes.

@contao/developers Please review.