### PR TITLE
[RFC] Use the kernel.terminate event for the command scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.1.0-RC1 (2015-XX-XX)
 
+ * Use the `kernel.terminate` event for the command scheduler (see #244).
  * Support news and event links in the front end preview (see contao/core#7504).
 
 ### 4.1.0-beta1 (2015-10-21)

--- a/src/EventListener/CommandSchedulerListener.php
+++ b/src/EventListener/CommandSchedulerListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\Config;
+use Contao\CoreBundle\Controller\FrontendController;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Registers the Contao front end and back end session bags.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class CommandSchedulerListener
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $framework;
+
+    /**
+     * Constructor.
+     *
+     * @param ContaoFrameworkInterface $framework The Contao framework service
+     */
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * Runs the command scheduler.
+     */
+    public function onKernelTerminate()
+    {
+        if (!$this->framework->isInitialized()) {
+            return;
+        }
+
+        /** @var Config $config */
+        $config = $this->framework->getAdapter('Contao\Config');
+
+        if ($config->get('disableCron')) {
+            return;
+        }
+
+        $controller = new FrontendController();
+        $controller->setContainer($this->container);
+        $controller->cronAction();
+    }
+}

--- a/src/EventListener/CommandSchedulerListener.php
+++ b/src/EventListener/CommandSchedulerListener.php
@@ -11,9 +11,8 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\Config;
-use Contao\CoreBundle\Controller\FrontendController;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Contao\FrontendCron;
 
 /**
  * Triggers the Contao command scheduler after the response has been sent.
@@ -22,8 +21,6 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  */
 class CommandSchedulerListener
 {
-    use ContainerAwareTrait;
-
     /**
      * @var ContaoFrameworkInterface
      */
@@ -55,8 +52,8 @@ class CommandSchedulerListener
             return;
         }
 
-        $controller = new FrontendController();
-        $controller->setContainer($this->container);
-        $controller->cronAction();
+        /** @var FrontendCron $controller */
+        $controller = $this->framework->createInstance('Contao\FrontendCron');
+        $controller->run();
     }
 }

--- a/src/EventListener/CommandSchedulerListener.php
+++ b/src/EventListener/CommandSchedulerListener.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
- * Registers the Contao front end and back end session bags.
+ * Triggers the Contao command scheduler after the response has been sent.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -44,8 +44,6 @@ services:
         class: Contao\CoreBundle\EventListener\CommandSchedulerListener
         arguments:
             - "@contao.framework"
-        calls:
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
 

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -40,6 +40,15 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
 
+    contao.listener.command_scheduler:
+        class: Contao\CoreBundle\EventListener\CommandSchedulerListener
+        arguments:
+            - "@contao.framework"
+        calls:
+            - ["setContainer", ["@service_container"]]
+        tags:
+            - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
+
     contao.listener.container_scope:
         class: Contao\CoreBundle\EventListener\ContainerScopeListener
         arguments:

--- a/src/Resources/contao/controllers/BackendIndex.php
+++ b/src/Resources/contao/controllers/BackendIndex.php
@@ -102,7 +102,6 @@ class BackendIndex extends \Backend
 		$objTemplate->username = $GLOBALS['TL_LANG']['tl_user']['username'][0];
 		$objTemplate->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$objTemplate->feLink = $GLOBALS['TL_LANG']['MSC']['feLink'];
-		$objTemplate->disableCron = \Config::get('disableCron');
 		$objTemplate->default = $GLOBALS['TL_LANG']['MSC']['default'];
 
 		return $objTemplate->getResponse();

--- a/src/Resources/contao/controllers/FrontendCron.php
+++ b/src/Resources/contao/controllers/FrontendCron.php
@@ -29,8 +29,15 @@ class FrontendCron extends \Frontend
 		parent::__construct();
 
 		// See #4099
-		define('BE_USER_LOGGED_IN', false);
-		define('FE_USER_LOGGED_IN', false);
+		if (!defined('BE_USER_LOGGED_IN'))
+		{
+			define('BE_USER_LOGGED_IN', false);
+		}
+
+		if (!defined('FE_USER_LOGGED_IN'))
+		{
+			define('FE_USER_LOGGED_IN', false);
+		}
 	}
 
 

--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -749,12 +749,6 @@ abstract class Controller extends \System
 			}
 		}
 
-		// Command scheduler
-		if (!\Config::get('disableCron'))
-		{
-			$strScripts .= "\n" . \Template::generateInlineScript('setTimeout(function(){var e=function(e,t){try{var n=new XMLHttpRequest}catch(r){return}n.open("GET",e,!0),n.onreadystatechange=function(){this.readyState==4&&this.status==200&&typeof t=="function"&&t(this.responseText)},n.send()};e("system/cron/cron.txt",function(n){parseInt(n||0)<Math.round(+(new Date)/1e3)-' . \Frontend::getCronTimeout() . '&&e("_contao/cron")})},5e3);') . "\n";
-		}
-
 		$arrReplace['[[TL_BODY]]'] = $strScripts;
 		$strScripts = '';
 

--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -471,8 +471,6 @@ class PageRegular extends \Frontend
 		$this->Template->language = $GLOBALS['TL_LANGUAGE'];
 		$this->Template->charset = \Config::get('characterSet');
 		$this->Template->base = \Environment::get('base');
-		$this->Template->disableCron = \Config::get('disableCron');
-		$this->Template->cronTimeout = $this->getCronTimeout();
 		$this->Template->isRTL = false;
 	}
 

--- a/src/Resources/contao/templates/backend/be_login.html5
+++ b/src/Resources/contao/templates/backend/be_login.html5
@@ -94,19 +94,5 @@
     });
   </script>
 
-  <?php if (!$this->disableCron): ?>
-    <script>
-      new Request({
-        url:'system/cron/cron.txt',
-        onComplete: function(txt) {
-          if (!txt) txt = 0;
-          if (parseInt(txt) < (Date.now()/1000 - 300)) {
-            new Request({url:'<?= $this->route('contao_frontend_cron') ?>'}).send();
-          }
-        }
-      }).send();
-    </script>
-  <?php endif; ?>
-
 </body>
 </html>

--- a/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/tests/EventListener/CommandSchedulerListenerTest.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\EventListener\CommandSchedulerListener;
 use Contao\CoreBundle\Test\TestCase;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Tests the CommandSchedulerListener class.
@@ -85,18 +84,15 @@ class CommandSchedulerListenerTest extends TestCase
      */
     public function testWithContaoFramework()
     {
-        /** @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject $container */
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
-
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->willReturn($this->mockContaoFramework())
-        ;
-
         $this->framework
             ->expects($this->once())
             ->method('getAdapter')
+        ;
+
+        $this->framework
+            ->expects($this->any())
+            ->method('createInstance')
+            ->willReturn($this->getMock('Contao\FrontendCron', ['run']))
         ;
 
         $this->framework
@@ -106,7 +102,6 @@ class CommandSchedulerListenerTest extends TestCase
         ;
 
         $listener = new CommandSchedulerListener($this->framework);
-        $listener->setContainer($container);
         $listener->onKernelTerminate();
     }
 }

--- a/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/tests/EventListener/CommandSchedulerListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\EventListener\CommandSchedulerListener;
+use Contao\CoreBundle\Test\TestCase;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Tests the CommandSchedulerListener class.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class CommandSchedulerListenerTest extends TestCase
+{
+    /**
+     * @var ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $framework;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->framework = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\ContaoFramework')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->framework
+            ->expects($this->any())
+            ->method('getAdapter')
+            ->willReturn($this->mockConfigAdapter())
+        ;
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $listener = new CommandSchedulerListener($this->framework);
+
+        $this->assertInstanceOf('Contao\CoreBundle\EventListener\CommandSchedulerListener', $listener);
+    }
+
+    /**
+     * Tests that the listener does nothing if the Contao framework is not booted.
+     */
+    public function testWithoutContaoFramework()
+    {
+        $this->framework
+            ->expects($this->any())
+            ->method('isInitialized')
+            ->willReturn(false)
+        ;
+
+        $this->framework
+            ->expects($this->never())
+            ->method('getAdapter')
+        ;
+
+        $listener = new CommandSchedulerListener($this->framework);
+        $listener->onKernelTerminate();
+    }
+
+    /**
+     * Tests that the listener does use the response if the Contao framework is booted.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testWithContaoFramework()
+    {
+        /** @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject $container */
+        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+
+        $container
+            ->expects($this->any())
+            ->method('get')
+            ->willReturn($this->mockContaoFramework())
+        ;
+
+        $this->framework
+            ->expects($this->once())
+            ->method('getAdapter')
+        ;
+
+        $this->framework
+            ->expects($this->any())
+            ->method('isInitialized')
+            ->willReturn(true)
+        ;
+
+        $listener = new CommandSchedulerListener($this->framework);
+        $listener->setContainer($container);
+        $listener->onKernelTerminate();
+    }
+}


### PR DESCRIPTION
This is the follow-up ticket for #244. It includes the necessary changes to trigger the command scheduler upon the `kernel.terminate` event instead of using an Ajax request.

@contao/developers Please review.