### PR TITLE
[RTM] Allow to configure the image dir and if to cache images

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -51,7 +51,6 @@ class InstallCommand extends AbstractLockedCommand
      */
     private $ignoredDirs = [
         'assets/css',
-        'assets/images',
         'assets/js',
         'system/cache',
         'system/config',
@@ -123,6 +122,8 @@ class InstallCommand extends AbstractLockedCommand
         foreach ($this->ignoredDirs as $path) {
             $this->addIgnoredDir($this->rootDir . '/' . $path);
         }
+
+        $this->addIgnoredDir($this->rootDir . '/' . $this->getContainer()->getParameter('contao.image.target_path'));
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,21 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * Constructor.
+     *
+     * @param bool $debug If kernel debug mode is enabled
+     */
+    public function __construct($debug)
+    {
+        $this->debug = (bool) $debug;
+    }
+
+    /**
      * Generates the configuration tree builder.
      *
      * @return TreeBuilder The tree builder
@@ -54,6 +69,12 @@ class Configuration implements ConfigurationInterface
                         })
                         ->thenInvalid('%s')
                     ->end()
+                ->end()
+                ->booleanNode('image_cache')
+                    ->defaultValue(!$this->debug)
+                ->end()
+                ->scalarNode('image_dir')
+                    ->defaultValue('assets/images')
                 ->end()
                 ->scalarNode('csrf_token_name')
                     ->cannotBeEmpty()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -101,6 +101,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('image')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('bypass_cache')
                             ->defaultValue($this->debug)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -70,12 +71,6 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('%s')
                     ->end()
                 ->end()
-                ->booleanNode('image_cache')
-                    ->defaultValue(!$this->debug)
-                ->end()
-                ->scalarNode('image_dir')
-                    ->defaultValue('assets/images')
-                ->end()
                 ->scalarNode('csrf_token_name')
                     ->cannotBeEmpty()
                     ->defaultValue('contao_csrf_token')
@@ -91,6 +86,31 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addImageSection($rootNode);
+
         return $treeBuilder;
+    }
+
+    /**
+     * Configures the `contao.image` section.
+     *
+     * @param ArrayNodeDefinition $rootNode
+     */
+    private function addImageSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('image')
+                    ->children()
+                        ->booleanNode('bypass_cache')
+                            ->defaultValue($this->debug)
+                        ->end()
+                        ->scalarNode('target_dir')
+                            ->defaultValue('assets/images')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+        ;
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -106,7 +106,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('bypass_cache')
                             ->defaultValue($this->debug)
                         ->end()
-                        ->scalarNode('target_dir')
+                        ->scalarNode('target_path')
                             ->defaultValue('assets/images')
                         ->end()
                     ->end()

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -66,7 +66,6 @@ class ContaoCoreExtension extends ConfigurableExtension
 
         foreach ($this->files as $file) {
             $loader->load($file);
-            $container->addResource(new FileResource(__DIR__ . '/../Resources/config/' . $file));
         }
 
         $container->setParameter('contao.prepend_locale', $mergedConfig['prepend_locale']);

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -11,7 +11,6 @@
 namespace Contao\CoreBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
@@ -72,8 +71,8 @@ class ContaoCoreExtension extends ConfigurableExtension
         $container->setParameter('contao.encryption_key', $mergedConfig['encryption_key']);
         $container->setParameter('contao.url_suffix', $mergedConfig['url_suffix']);
         $container->setParameter('contao.upload_path', $mergedConfig['upload_path']);
-        $container->setParameter('contao.image_cache', $mergedConfig['image_cache']);
-        $container->setParameter('contao.image_dir', $mergedConfig['image_dir']);
+        $container->setParameter('contao.image.bypass_cache', $mergedConfig['image']['bypass_cache']);
+        $container->setParameter('contao.image.target_dir', $mergedConfig['image']['target_dir']);
         $container->setParameter('contao.csrf_token_name', $mergedConfig['csrf_token_name']);
         $container->setParameter('contao.pretty_error_screens', $mergedConfig['pretty_error_screens']);
         $container->setParameter('contao.error_level', $mergedConfig['error_level']);

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
@@ -45,6 +46,17 @@ class ContaoCoreExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        // Will add the resource to the container
+        parent::getConfiguration($config, $container);
+
+        return new Configuration($container->getParameter('kernel.debug'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader(
@@ -54,12 +66,15 @@ class ContaoCoreExtension extends ConfigurableExtension
 
         foreach ($this->files as $file) {
             $loader->load($file);
+            $container->addResource(new FileResource(__DIR__ . '/../Resources/config/' . $file));
         }
 
         $container->setParameter('contao.prepend_locale', $mergedConfig['prepend_locale']);
         $container->setParameter('contao.encryption_key', $mergedConfig['encryption_key']);
         $container->setParameter('contao.url_suffix', $mergedConfig['url_suffix']);
         $container->setParameter('contao.upload_path', $mergedConfig['upload_path']);
+        $container->setParameter('contao.image_cache', $mergedConfig['image_cache']);
+        $container->setParameter('contao.image_dir', $mergedConfig['image_dir']);
         $container->setParameter('contao.csrf_token_name', $mergedConfig['csrf_token_name']);
         $container->setParameter('contao.pretty_error_screens', $mergedConfig['pretty_error_screens']);
         $container->setParameter('contao.error_level', $mergedConfig['error_level']);

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -308,7 +308,7 @@ $GLOBALS['TL_PURGE'] = array
 		'images' => array
 		(
 			'callback' => array('Automator', 'purgeImageCache'),
-			'affected' => array('assets/images')
+			'affected' => array(System::getContainer()->getParameter('contao.image.target_path'))
 		),
 		'scripts' => array
 		(

--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -2101,7 +2101,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			// Remove potentially existing thumbnails (see #6641)
 			if (in_array(substr($this->strExtension, 1), $arrImageTypes))
 			{
-				foreach (glob(TL_ROOT . '/assets/images/*/' . $this->varValue . '-*' . $this->strExtension) as $strThumbnail)
+				foreach (glob(TL_ROOT . '/' . System::getContainer()->getParameter('contao.image.target_path') . '/*/' . $this->varValue . '-*' . $this->strExtension) as $strThumbnail)
 				{
 					$this->Files->delete(str_replace(TL_ROOT . '/', '', $strThumbnail));
 				}

--- a/src/Resources/contao/library/Contao/Automator.php
+++ b/src/Resources/contao/library/Contao/Automator.php
@@ -136,12 +136,14 @@ class Automator extends \System
 	 */
 	public function purgeImageCache()
 	{
+		$strTargetPath = System::getContainer()->getParameter('contao.image.target_path');
+
 		// Walk through the subfolders
-		foreach (scan(TL_ROOT . '/assets/images') as $dir)
+		foreach (scan(TL_ROOT . '/' . $strTargetPath) as $dir)
 		{
 			if (strncmp($dir, '.', 1) !== 0)
 			{
-				$objFolder = new \Folder('assets/images/' . $dir);
+				$objFolder = new \Folder($strTargetPath . '/' . $dir);
 				$objFolder->purge();
 			}
 		}

--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -14,7 +14,7 @@ namespace Contao;
 /**
  * Resizes images
  *
- * The class resizes images and stores them in the assets/images folder.
+ * The class resizes images and stores them in the image cache folder.
  *
  * Usage:
  *
@@ -386,7 +386,7 @@ class Image
 			. '-t' . $this->fileObj->mtime
 		), 0, 8);
 
-		return 'assets/images/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
+		return System::getContainer()->getParameter('contao.image_dir') . '/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
 	}
 
 
@@ -442,7 +442,7 @@ class Image
 		}
 
 		// Check whether the image exists already
-		if (!\Config::get('debugMode'))
+		if (System::getContainer()->getParameter('contao.image_cache'))
 		{
 			// Custom target (thanks to Tristan Lins) (see #4166)
 			if ($this->getTargetPath() && !$this->getForceOverride())
@@ -922,7 +922,7 @@ class Image
 
 
 	/**
-	 * Resize an image and store the resized version in the assets/images folder
+	 * Resize an image and store the resized version in the image cache folder
 	 *
 	 * @param string  $image        The image path
 	 * @param integer $width        The target width

--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -386,7 +386,7 @@ class Image
 			. '-t' . $this->fileObj->mtime
 		), 0, 8);
 
-		return System::getContainer()->getParameter('contao.image.target_dir') . '/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
+		return System::getContainer()->getParameter('contao.image.target_path') . '/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
 	}
 
 

--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -386,7 +386,7 @@ class Image
 			. '-t' . $this->fileObj->mtime
 		), 0, 8);
 
-		return System::getContainer()->getParameter('contao.image_dir') . '/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
+		return System::getContainer()->getParameter('contao.image.target_dir') . '/' . substr($strCacheKey, -1) . '/' . $this->fileObj->filename . '-' . $strCacheKey . '.' . $this->fileObj->extension;
 	}
 
 
@@ -442,7 +442,7 @@ class Image
 		}
 
 		// Check whether the image exists already
-		if (System::getContainer()->getParameter('contao.image_cache'))
+		if (!System::getContainer()->getParameter('contao.image.bypass_cache'))
 		{
 			// Custom target (thanks to Tristan Lins) (see #4166)
 			if ($this->getTargetPath() && !$this->getForceOverride())

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -63,6 +63,7 @@ class InstallCommandTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->setParameter('kernel.root_dir', $this->getRootDir() . '/app');
+        $container->setParameter('contao.image.target_path', 'assets/images');
         $command->setContainer($container);
 
         $code = $tester->execute([]);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\DependencyInjection;
+
+
+use Contao\CoreBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * Creates the core extension object.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->configuration = new Configuration(false);
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\CoreBundle\DependencyInjection\Configuration', $this->configuration);
+        $this->assertInstanceOf('Symfony\Component\Config\Definition\Builder\TreeBuilder', $this->configuration->getConfigTreeBuilder());
+    }
+
+    /**
+     * @dataProvider invalidUploadPathProvider
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testInvalidUploadPath($uploadPath)
+    {
+        $processor = new Processor();
+        $processor->processConfiguration($this->configuration, [
+            'contao' => [
+                'encryption_key' => 's3cr3t',
+                'upload_path' => $uploadPath,
+            ]
+        ]);
+    }
+
+    public function invalidUploadPathProvider()
+    {
+        return [
+            [''],
+            ['app'],
+            ['assets'],
+            ['contao'],
+            ['plugins'],
+            ['share'],
+            ['system'],
+            ['templates'],
+            ['vendor'],
+            ['web'],
+        ];
+    }
+}

--- a/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -13,6 +13,7 @@ namespace Contao\CoreBundle\Test\DependencyInjection;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * Tests the ContaoCoreExtension class.
@@ -49,7 +50,7 @@ class ContaoCoreExtensionTest extends TestCase
      */
     public function testLoad()
     {
-        $container = new ContainerBuilder();
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
 
         $params = [
             'contao' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -188,6 +188,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $container->setParameter('kernel.root_dir', $this->getRootDir());
         $container->setParameter('kernel.cache_dir', $this->getCacheDir());
         $container->setParameter('kernel.debug', false);
+        $container->setParameter('contao.image.bypass_cache', false);
+        $container->setParameter('contao.image.target_path', 'assets/images');
 
         $container->set(
             'contao.resource_finder',


### PR DESCRIPTION
This allows to define a custom image caching path in the application configuration.

Additionally, I can define per environment if I want images to be cached. My problem is that currently the dev environment does not cache images at all. I have > 50 images on one page, which makes using the dev controller almost unbearable.