### PR TITLE
Fixed Contao considering case in file search and the whole path

### DIFF
--- a/src/Resources/contao/widgets/FileSelector.php
+++ b/src/Resources/contao/widgets/FileSelector.php
@@ -405,7 +405,7 @@ class FileSelector extends \Widget
 
 				if ($for != '')
 				{
-					if (!preg_match('/' . str_replace('/', '\\/', $for) . '/', $folders[$f] . '/' . $v))
+					if (!preg_match('/' . str_replace('/', '\\/', $for) . '/', $folders[$f] . '/i' . $v))
 					{
 						--$countFiles;
 					}
@@ -485,14 +485,15 @@ class FileSelector extends \Widget
 
 			for ($h=0, $c=count($files); $h<$c; $h++)
 			{
+				$currentFile = str_replace(TL_ROOT . '/', '', $files[$h]);
+
 				// Ignore files not matching the search criteria
-				if ($for != '' && !preg_match('/' . str_replace('/', '\\/', $for) . '/', $files[$h]))
+				if ($for != '' && !preg_match('/' . str_replace('/', '\\/', $for) . '/i', $currentFile))
 				{
 					continue;
 				}
 
 				$thumbnail = '';
-				$currentFile = str_replace(TL_ROOT . '/', '', $files[$h]);
 				$currentEncoded = $this->urlEncode($currentFile);
 
 				$objFile = new \File($currentFile);


### PR DESCRIPTION
Two fixes here:

* When I search for `dsc` it did not find `61891_DSC.jpg` because the `preg_match` was case-sensitive.
* The `preg_match` was executed on the absolute path instead of the relative path.
