### PR TITLE
Fix buffered query result

### DIFF
--- a/src/Cache/ContaoCacheWarmer.php
+++ b/src/Cache/ContaoCacheWarmer.php
@@ -332,7 +332,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     private function isCompleteInstallation()
     {
         try {
-            $this->connection->exec("SELECT COUNT(*) FROM tl_page");
+            $this->connection->prepare("SELECT COUNT(*) FROM tl_page")->fetchAll();
         } catch (TableNotFoundException $e) {
             return false;
         }


### PR DESCRIPTION
@aschempp and me received an error message when using `app/console cache:warmup`

```
[Doctrine\DBAL\Exception\DriverException]
An exception occurred while executing 'SELECT tl_page.* FROM tl_page WHERE tl_page.type='root'':
SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.
```