### PR TITLE
[WIP] Use config param upload_path upon installation #393

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -92,11 +92,22 @@ class InstallCommand extends AbstractLockedCommand
      */
     private function addEmptyDirs()
     {
-        $this->emptyDirs[] = $this->getContainer()->getParameter('contao.upload_path');
-
-        foreach ($this->emptyDirs as $path) {
+        foreach ($this->getEmptyDirs() as $path) {
             $this->addEmptyDir($this->rootDir . '/' . $path);
         }
+    }
+
+    /**
+     * Get static and config based empty dirs
+     *
+     * @return array $emptyDirs
+     */
+    private function getEmptyDirs()
+    {
+        $emptyDirs = $this->emptyDirs;
+        $emptyDirs[] = $this->getContainer()->getParameter('contao.upload_path');
+
+        return $emptyDirs;
     }
 
     /**

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -40,7 +40,6 @@ class InstallCommand extends AbstractLockedCommand
      * @var array
      */
     private $emptyDirs = [
-        'files',
         'system',
         'templates',
         'web/system',
@@ -93,6 +92,8 @@ class InstallCommand extends AbstractLockedCommand
      */
     private function addEmptyDirs()
     {
+        $this->emptyDirs[] = $this->getContainer()->getParameter('contao.upload_path');
+
         foreach ($this->emptyDirs as $path) {
             $this->addEmptyDir($this->rootDir . '/' . $path);
         }

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -61,6 +61,7 @@ class InstallCommandTest extends TestCase
         $container = new ContainerBuilder();
         $container->setParameter('kernel.root_dir', $this->getRootDir() . '/app');
         $container->setParameter('contao.image.target_path', 'assets/images');
+        $container->setParameter('contao.upload_path', 'files');
 
         $command = new InstallCommand('contao:install');
         $command->setContainer($container);


### PR DESCRIPTION
remove 'files' path from $emptyDirs Array
merge upload_path into addEmptyDirs process
refs #393

**This only is for the core-bundle part. See below**

The install.php at the `contao/standard-edition` does not load the config.yml and so it will always fall back to 'files' during web installation.

Running `php app/console contao:install` works now as expected and creates the upload_path dir configured in config.yml