### PR TITLE
[RTM] Load the random_compat library

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -56,7 +56,9 @@ class ScriptHandler
             return;
         }
 
-        putenv(static::RANDOM_SECRET_NAME . '=' . bin2hex(random_bytes(32)));
+        if (static::loadRandomCompat($event)) {
+            putenv(static::RANDOM_SECRET_NAME . '=' . bin2hex(random_bytes(32)));
+        }
     }
 
     /**
@@ -108,5 +110,38 @@ class ScriptHandler
         }
 
         return !empty($config);
+    }
+
+    /**
+     * Makes sure the random_bytes method is available.
+     *
+     * @param Event $event
+     *
+     * @return bool
+     */
+    private static function loadRandomCompat(Event $event)
+    {
+        if (function_exists('random_bytes')) {
+            return true;
+        }
+
+        $composer = $event->getComposer();
+        $package  = $composer->getRepositoryManager()->getLocalRepository()->findPackage('paragonie/random_compat', '*');
+
+        if (null === $package) {
+            return false;
+        }
+
+        $path     = $composer->getInstallationManager()->getInstaller('library')->getInstallPath($package);
+        $autoload = $package->getAutoload();
+
+        if (!empty($autoload['files'])) {
+            foreach ($autoload['files'] as $file) {
+                /** @noinspection PhpIncludeInspection */
+                include_once $path . '/' . $file;
+            }
+        }
+
+        return function_exists('random_bytes');
     }
 }

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -137,7 +137,6 @@ class ScriptHandler
 
         if (!empty($autoload['files'])) {
             foreach ($autoload['files'] as $file) {
-                /** @noinspection PhpIncludeInspection */
                 include_once $path . '/' . $file;
             }
         }


### PR DESCRIPTION
see https://github.com/contao/standard-edition/pull/27 for the complementary PR

Unfortunately, Composer does not autoload the `files` when the scripts are executed. This results in `random_bytes` not being available to our random secret generator. We have to manually load the necessary library…