### PR TITLE
Catch all exceptions from the database

### DIFF
--- a/src/Cache/ContaoCacheWarmer.php
+++ b/src/Cache/ContaoCacheWarmer.php
@@ -331,7 +331,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     {
         try {
             $this->connection->query('SELECT COUNT(*) FROM tl_page');
-        } catch (TableNotFoundException $e) {
+        } catch (\Exception $e) {
             return false;
         }
 


### PR DESCRIPTION
Otherwise an exception because of invalid access details etc. would not be catched.