### PR TITLE
Never load valid classes from service container

### DIFF
--- a/src/Resources/contao/library/Contao/System.php
+++ b/src/Resources/contao/library/Contao/System.php
@@ -154,7 +154,7 @@ abstract class System
 		{
 			$container = static::getContainer();
 
-			if ($container->has($strClass))
+			if (!class_exists($strClass) && $container->has($strClass))
 			{
 				$this->arrObjects[$strKey] = $container->get($strClass);
 			}
@@ -187,7 +187,7 @@ abstract class System
 		{
 			$container = static::getContainer();
 
-			if ($container->has($strClass))
+			if (!class_exists($strClass) && $container->has($strClass))
 			{
 				static::$arrStaticObjects[$strKey] = $container->get($strClass);
 			}


### PR DESCRIPTION
I've got the following error message:

> Attempted to call an undefined method named "getData" of class "Symfony\Component\HttpFoundation\Session\Session".

This is because `System::import('Session')` would load the Symfony service instead of the legacy class.
