### PR TITLE
[RTM] Added a DBAL field type for UUIDs

### DIFF
--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -15,9 +15,8 @@ use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\DoctrineMigrationsPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\DoctrineTypesPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
-use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
-use Doctrine\DBAL\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -43,23 +42,9 @@ class ContaoCoreBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function boot()
-    {
-        if (!Type::hasType(BinaryStringType::NAME)) {
-            Type::addType(BinaryStringType::NAME, BinaryStringType::class);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
-        if (!Type::hasType(BinaryStringType::NAME)) {
-            Type::addType(BinaryStringType::NAME, BinaryStringType::class);
-        }
 
         $container->addCompilerPass(
             new AddPackagesPass($container->getParameter('kernel.root_dir').'/../vendor/composer/installed.json')
@@ -69,5 +54,6 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new AddResourcesPathsPass());
         $container->addCompilerPass(new AddImagineClassPass());
         $container->addCompilerPass(new DoctrineMigrationsPass());
+        $container->addCompilerPass(new DoctrineTypesPass());
     }
 }

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -16,6 +16,8 @@ use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\DoctrineMigrationsPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
+use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
+use Doctrine\DBAL\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -41,9 +43,23 @@ class ContaoCoreBundle extends Bundle
     /**
      * {@inheritdoc}
      */
+    public function boot()
+    {
+        if (!Type::hasType(BinaryStringType::NAME)) {
+            Type::addType(BinaryStringType::NAME, BinaryStringType::class);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        if (!Type::hasType(BinaryStringType::NAME)) {
+            Type::addType(BinaryStringType::NAME, BinaryStringType::class);
+        }
 
         $container->addCompilerPass(
             new AddPackagesPass($container->getParameter('kernel.root_dir').'/../vendor/composer/installed.json')

--- a/src/DependencyInjection/Compiler/DoctrineTypesPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineTypesPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class DoctrineTypesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('doctrine.dbal.connection_factory.types')) {
+            return;
+        }
+
+        $types = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        $types[BinaryStringType::NAME] = [
+            'class' => BinaryStringType::class,
+            'commented' => true
+        ];
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', $types);
+        $container->getDefinition('doctrine.dbal.connection_factory')->replaceArgument(0, $types);
+    }
+}

--- a/src/Doctrine/DBAL/Types/BinaryStringType.php
+++ b/src/Doctrine/DBAL/Types/BinaryStringType.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Type that maps a PHP string to a binary database field.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class BinaryStringType extends Type
+{
+    /**
+     * @var string
+     */
+    const NAME = 'binary_string';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        if (isset($fieldDeclaration['fixed']) && $fieldDeclaration['fixed']) {
+            return $platform->getBinaryTypeDeclarationSQL($fieldDeclaration);
+        } else {
+            return $platform->getBlobTypeDeclarationSQL($fieldDeclaration);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Doctrine\DBAL\Types;
+
+use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
+use Contao\CoreBundle\Test\TestCase;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Tests the BinaryStringType class.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class BinaryStringTypeTest extends TestCase
+{
+    /**
+     * @var BinaryStringType
+     */
+    private $type;
+
+    public static function setUpBeforeClass()
+    {
+        Type::addType(BinaryStringType::NAME, BinaryStringType::class);
+    }
+
+    protected function setUp()
+    {
+        $this->type = Type::getType(BinaryStringType::NAME);
+    }
+
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType', $this->type);
+    }
+
+    /**
+     * Tests getSqlDeclaration returns binary definition for fixed length fields.
+     */
+    public function testGetSQLDeclarationWithFixedLength()
+    {
+        $fieldDefinition = ['fixed' => true];
+
+        $platform = $this->getMock(AbstractPlatform::class);
+
+        $platform
+            ->expects($this->once())
+            ->method('getBinaryTypeDeclarationSQL')
+        ;
+
+        $platform
+            ->expects($this->never())
+            ->method('getBlobTypeDeclarationSQL')
+        ;
+
+        $this->type->getSQLDeclaration($fieldDefinition, $platform);
+    }
+
+    /**
+     * Tests getSqlDeclaration returns blob definition for variable length fields.
+     */
+    public function testGetSQLDeclarationWithVariableLength()
+    {
+        $fieldDefinition = ['false' => true];
+
+        $platform = $this->getMock(AbstractPlatform::class);
+
+        $platform
+            ->expects($this->never())
+            ->method('getBinaryTypeDeclarationSQL')
+        ;
+
+        $platform
+            ->expects($this->once())
+            ->method('getBlobTypeDeclarationSQL')
+        ;
+
+        $this->type->getSQLDeclaration($fieldDefinition, $platform);
+    }
+
+    /**
+     * Tests the name.
+     */
+    public function testName()
+    {
+        $this->assertEquals(BinaryStringType::NAME, $this->type->getName());
+    }
+
+    /**
+     * Tests the custom type requires an SQL hint.
+     */
+    public function testRequiresSQLCommentHint()
+    {
+        $platform = $this->getMock(AbstractPlatform::class);
+
+        $this->assertTrue($this->type->requiresSQLCommentHint($platform));
+    }
+}

--- a/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -83,7 +83,7 @@ class BinaryStringTypeTest extends TestCase
      */
     public function testGetSQLDeclarationWithVariableLength()
     {
-        $fieldDefinition = ['false' => true];
+        $fieldDefinition = ['fixed' => false];
 
         /** @var AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject $platform */
         $platform = $this

--- a/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -27,16 +27,21 @@ class BinaryStringTypeTest extends TestCase
      */
     private $type;
 
+    /**
+     * {@inheritdoc}
+     */
     public static function setUpBeforeClass()
     {
         Type::addType(BinaryStringType::NAME, BinaryStringType::class);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp()
     {
         $this->type = Type::getType(BinaryStringType::NAME);
     }
-
 
     /**
      * Tests the object instantiation.
@@ -47,7 +52,7 @@ class BinaryStringTypeTest extends TestCase
     }
 
     /**
-     * Tests getSqlDeclaration returns binary definition for fixed length fields.
+     * Tests that getSqlDeclaration() returns a binary definition for fixed length fields.
      */
     public function testGetSQLDeclarationWithFixedLength()
     {
@@ -74,7 +79,7 @@ class BinaryStringTypeTest extends TestCase
     }
 
     /**
-     * Tests getSqlDeclaration returns blob definition for variable length fields.
+     * Tests that getSqlDeclaration() returns a blob definition for variable length fields.
      */
     public function testGetSQLDeclarationWithVariableLength()
     {

--- a/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -53,7 +53,12 @@ class BinaryStringTypeTest extends TestCase
     {
         $fieldDefinition = ['fixed' => true];
 
-        $platform = $this->getMock(AbstractPlatform::class);
+        /** @var AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject $platform */
+        $platform = $this
+            ->getMockBuilder(AbstractPlatform::class)
+            ->setMethods(['getBinaryTypeDeclarationSQL', 'getBlobTypeDeclarationSQL'])
+            ->getMockForAbstractClass()
+        ;
 
         $platform
             ->expects($this->once())
@@ -75,7 +80,12 @@ class BinaryStringTypeTest extends TestCase
     {
         $fieldDefinition = ['false' => true];
 
-        $platform = $this->getMock(AbstractPlatform::class);
+        /** @var AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject $platform */
+        $platform = $this
+            ->getMockBuilder(AbstractPlatform::class)
+            ->setMethods(['getBinaryTypeDeclarationSQL', 'getBlobTypeDeclarationSQL'])
+            ->getMockForAbstractClass()
+        ;
 
         $platform
             ->expects($this->never())
@@ -103,7 +113,7 @@ class BinaryStringTypeTest extends TestCase
      */
     public function testRequiresSQLCommentHint()
     {
-        $platform = $this->getMock(AbstractPlatform::class);
+        $platform = $this->getMockForAbstractClass(AbstractPlatform::class);
 
         $this->assertTrue($this->type->requiresSQLCommentHint($platform));
     }


### PR DESCRIPTION
Our current UUID field types are not supported by Doctrine. I started using ORM and the binary column was not usable because it returns a resource by default.
I think Contao core bundle should provide a type to handle it's default fields.
