### PR TITLE
[RFC] Extract the framework initialization logic

### DIFF
--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -10,70 +10,25 @@
 
 namespace Contao\CoreBundle\Framework;
 
-use Contao\ClassLoader;
-use Contao\Config;
-use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
-use Contao\CoreBundle\Exception\IncompleteInstallationException;
-use Contao\CoreBundle\Exception\InvalidRequestTokenException;
-use Contao\Input;
-use Contao\RequestToken;
-use Contao\System;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\RouterInterface;
-
 /**
- * Initializes the Contao framework.
+ * Contao 3 framework service.
  *
- * @author Christian Schiffler <https://github.com/discordier>
  * @author Yanick Witschi <https://github.com/toflar>
  * @author Leo Feyer <https://github.com/leofeyer>
- * @author Dominik Tomasi <https://github.com/dtomasi>
- * @author Andreas Schempp <https://github.com/aschempp>
  *
  * @internal Do not instantiate this class in your code. Use the "contao.framework" service instead.
  */
 class ContaoFramework implements ContaoFrameworkInterface
 {
-    use ContainerAwareTrait;
-
     /**
      * @var bool
      */
     private static $initialized = false;
 
     /**
-     * @var RouterInterface
+     * @var FrameworkInitializer
      */
-    private $router;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
-     * @var string
-     */
-    private $rootDir;
-
-    /**
-     * @var int
-     */
-    private $errorLevel;
-
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var Request
-     */
-    private $request;
+    private $initializer;
 
     /**
      * @var array
@@ -81,37 +36,13 @@ class ContaoFramework implements ContaoFrameworkInterface
     private $adapterCache = [];
 
     /**
-     * @var array
-     */
-    private $basicClasses = [
-        'System',
-        'Config',
-        'ClassLoader',
-        'TemplateLoader',
-        'ModuleLoader',
-    ];
-
-    /**
-     * Constructor.
+     * Sets the framework initializer.
      *
-     * @param RequestStack     $requestStack The request stack
-     * @param RouterInterface  $router       The router service
-     * @param SessionInterface $session      The session service
-     * @param string           $rootDir      The kernel root directory
-     * @param int              $errorLevel   The PHP error level
+     * @param FrameworkInitializer $initializer The framework initializer
      */
-    public function __construct(
-        RequestStack $requestStack,
-        RouterInterface $router,
-        SessionInterface $session,
-        $rootDir,
-        $errorLevel
-    ) {
-        $this->router = $router;
-        $this->session = $session;
-        $this->rootDir = dirname($rootDir);
-        $this->errorLevel = $errorLevel;
-        $this->requestStack = $requestStack;
+    public function setInitializer(FrameworkInitializer $initializer)
+    {
+        $this->initializer = $initializer;
     }
 
     /**
@@ -136,15 +67,12 @@ class ContaoFramework implements ContaoFrameworkInterface
         // Set before calling any methods to prevent recursion
         self::$initialized = true;
 
-        if (null === $this->container) {
-            throw new \LogicException('The service container has not been set.');
+        if (null === $this->initializer) {
+            throw new \LogicException('The framwork initializer has not been set.');
         }
 
-        // Set the current request
-        $this->request = $this->requestStack->getCurrentRequest();
-
-        $this->setConstants();
-        $this->initializeFramework();
+        $this->initializer->setFramework($this);
+        $this->initializer->initialize();
     }
 
     /**
@@ -171,293 +99,5 @@ class ContaoFramework implements ContaoFrameworkInterface
         }
 
         return $this->adapterCache[$class];
-    }
-
-    /**
-     * Sets the Contao constants.
-     *
-     * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
-     */
-    private function setConstants()
-    {
-        if (!defined('TL_MODE')) {
-            define('TL_MODE', $this->getMode());
-        }
-
-        define('TL_START', microtime(true));
-        define('TL_ROOT', $this->rootDir);
-        define('TL_REFERER_ID', $this->getRefererId());
-
-        if (!defined('TL_SCRIPT')) {
-            define('TL_SCRIPT', $this->getRoute());
-        }
-
-        // Define the login status constants in the back end (see #4099, #5279)
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
-            define('BE_USER_LOGGED_IN', false);
-            define('FE_USER_LOGGED_IN', false);
-        }
-
-        // Define the relative path to the installation (see #5339)
-        define('TL_PATH', $this->getPath());
-    }
-
-    /**
-     * Returns the TL_MODE value.
-     *
-     * @return string|null The TL_MODE value or null
-     */
-    private function getMode()
-    {
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
-            return 'BE';
-        }
-
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
-            return 'FE';
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns the referer ID.
-     *
-     * @return string|null The referer ID or null
-     */
-    private function getRefererId()
-    {
-        if (null === $this->request) {
-            return null;
-        }
-
-        return $this->request->attributes->get('_contao_referer_id', '');
-    }
-
-    /**
-     * Returns the route.
-     *
-     * @return string The route
-     */
-    private function getRoute()
-    {
-        if (null === $this->request) {
-            return 'console';
-        }
-
-        $route = $this->router->generate(
-            $this->request->attributes->get('_route'),
-            $this->request->attributes->get('_route_params')
-        );
-
-        return substr($route, strlen($this->request->getBasePath()) + 1);
-    }
-
-    /**
-     * Returns the base path.
-     *
-     * @return string|null The base path
-     */
-    private function getPath()
-    {
-        if (null === $this->request) {
-            return null;
-        }
-
-        return $this->request->getBasePath();
-    }
-
-    /**
-     * Initializes the framework.
-     */
-    private function initializeFramework()
-    {
-        // Set the error_reporting level
-        error_reporting($this->errorLevel);
-
-        $this->includeHelpers();
-        $this->includeBasicClasses();
-
-        // Set the container
-        System::setContainer($this->container);
-
-        /** @var Config $config */
-        $config = $this->getAdapter('Contao\Config');
-
-        // Preload the configuration (see #5872)
-        $config->preload();
-
-        // Register the class loader
-        ClassLoader::scanAndRegister();
-
-        $this->initializeLegacySessionAccess();
-        $this->setDefaultLanguage();
-
-        // Fully load the configuration
-        $config->getInstance();
-
-        $this->validateInstallation();
-
-        Input::initialize();
-
-        $this->setTimezone();
-        $this->triggerInitializeSystemHook();
-        $this->handleRequestToken();
-    }
-
-    /**
-     * Includes some helper files.
-     */
-    private function includeHelpers()
-    {
-        require __DIR__ . '/../Resources/contao/helper/functions.php';
-        require __DIR__ . '/../Resources/contao/config/constants.php';
-        require __DIR__ . '/../Resources/contao/helper/interface.php';
-        require __DIR__ . '/../Resources/contao/helper/exception.php';
-    }
-
-    /**
-     * Includes the basic classes required for further processing.
-     */
-    private function includeBasicClasses()
-    {
-        foreach ($this->basicClasses as $class) {
-            if (!class_exists($class, false)) {
-                require_once __DIR__ . '/../Resources/contao/library/Contao/' . $class . '.php';
-                class_alias('Contao\\' . $class, $class);
-            }
-        }
-    }
-
-    /**
-     * Initializes session access for $_SESSION['FE_DATA'] and $_SESSION['BE_DATA'].
-     */
-    private function initializeLegacySessionAccess()
-    {
-        if (!$this->session->isStarted()) {
-            return;
-        }
-
-        $_SESSION['BE_DATA'] = $this->session->getBag('contao_backend');
-        $_SESSION['FE_DATA'] = $this->session->getBag('contao_frontend');
-    }
-
-    /**
-     * Sets the default language.
-     */
-    private function setDefaultLanguage()
-    {
-        $language = 'en';
-
-        if (null !== $this->request) {
-            $language = str_replace('_', '-', $this->request->getLocale());
-        }
-
-        // Deprecated since Contao 4.0, to be removed in Contao 5.0
-        $GLOBALS['TL_LANGUAGE'] = $language;
-        $_SESSION['TL_LANGUAGE'] = $language;
-    }
-
-    /**
-     * Validates the installation.
-     *
-     * @throws IncompleteInstallationException If the installation has not been completed
-     */
-    private function validateInstallation()
-    {
-        if (null === $this->request) {
-            return;
-        }
-
-        /** @var Config $config */
-        $config = $this->getAdapter('Contao\Config');
-
-        // Show the "incomplete installation" message
-        if (!$config->isComplete()) {
-            throw new IncompleteInstallationException(
-                'The installation has not been completed. Open the Contao install tool to continue.'
-            );
-        }
-    }
-
-    /**
-     * Sets the time zone.
-     */
-    private function setTimezone()
-    {
-        /** @var Config $config */
-        $config = $this->getAdapter('Contao\Config');
-
-        $this->iniSet('date.timezone', $config->get('timeZone'));
-        date_default_timezone_set($config->get('timeZone'));
-    }
-
-    /**
-     * Triggers the initializeSystem hook (see #5665).
-     */
-    private function triggerInitializeSystemHook()
-    {
-        if (isset($GLOBALS['TL_HOOKS']['initializeSystem']) && is_array($GLOBALS['TL_HOOKS']['initializeSystem'])) {
-            foreach ($GLOBALS['TL_HOOKS']['initializeSystem'] as $callback) {
-                System::importStatic($callback[0])->{$callback[1]}();
-            }
-        }
-
-        if (file_exists($this->rootDir . '/system/config/initconfig.php')) {
-            include $this->rootDir . '/system/config/initconfig.php';
-        }
-    }
-
-    /**
-     * Handles the request token.
-     *
-     * @throws AjaxRedirectResponseException|InvalidRequestTokenException If the token is invalid
-     */
-    private function handleRequestToken()
-    {
-        /** @var RequestToken $requestToken */
-        $requestToken = $this->getAdapter('Contao\RequestToken');
-
-        // Deprecated since Contao 4.0, to be removed in Contao 5.0
-        if (!defined('REQUEST_TOKEN')) {
-            define('REQUEST_TOKEN', $requestToken->get());
-        }
-
-        if ($this->canSkipTokenCheck() || $requestToken->validate($this->request->request->get('REQUEST_TOKEN'))) {
-            return;
-        }
-
-        if ($this->request->isXmlHttpRequest()) {
-            throw new AjaxRedirectResponseException($this->router->generate('contao_backend'));
-        }
-
-        throw new InvalidRequestTokenException('Invalid request token. Please reload the page and try again.');
-    }
-
-    /**
-     * Tries to set a php.ini configuration option.
-     *
-     * @param string $key   The key
-     * @param mixed  $value The value
-     */
-    private function iniSet($key, $value)
-    {
-        if (function_exists('ini_set')) {
-            ini_set($key, $value);
-        }
-    }
-
-    /**
-     * Checks if the token check can be skipped.
-     *
-     * @return bool True if the token check can be skipped
-     */
-    private function canSkipTokenCheck()
-    {
-        return null === $this->request
-            || 'POST' !== $this->request->getRealMethod()
-            || !$this->request->attributes->has('_token_check')
-            || false === $this->request->attributes->get('_token_check')
-        ;
     }
 }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -38,9 +38,9 @@ class ContaoFramework implements ContaoFrameworkInterface
     /**
      * Sets the framework initializer.
      *
-     * @param FrameworkInitializer $initializer The framework initializer
+     * @param FrameworkInitializer|null $initializer The framework initializer
      */
-    public function setInitializer(FrameworkInitializer $initializer)
+    public function setInitializer(FrameworkInitializer $initializer = null)
     {
         $this->initializer = $initializer;
     }

--- a/src/Framework/FrameworkAwareTrait.php
+++ b/src/Framework/FrameworkAwareTrait.php
@@ -41,9 +41,9 @@ trait FrameworkAwareTrait
     /**
      * Sets the framework service.
      *
-     * @param ContaoFrameworkInterface $framework The framework service
+     * @param ContaoFrameworkInterface|null $framework The framework service
      */
-    public function setFramework(ContaoFrameworkInterface $framework)
+    public function setFramework(ContaoFrameworkInterface $framework = null)
     {
         $this->framework = $framework;
     }

--- a/src/Framework/FrameworkInitializer.php
+++ b/src/Framework/FrameworkInitializer.php
@@ -114,7 +114,7 @@ class FrameworkInitializer
      *
      * @param ContaoFrameworkInterface $framework The framework
      */
-    public function setFramework(ContaoFrameworkInterface $framework)
+    public function setFramework(ContaoFrameworkInterface $framework = null)
     {
         $this->framework = $framework;
     }
@@ -131,7 +131,7 @@ class FrameworkInitializer
         }
 
         if (null === $this->framework) {
-            throw new \LogicException('The Contao 3 framework has not been set.');
+            throw new \LogicException('The Contao framework has not been set.');
         }
 
         // Set the current request

--- a/src/Framework/FrameworkInitializer.php
+++ b/src/Framework/FrameworkInitializer.php
@@ -1,0 +1,429 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Framework;
+
+use Contao\ClassLoader;
+use Contao\Config;
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
+use Contao\CoreBundle\Exception\IncompleteInstallationException;
+use Contao\CoreBundle\Exception\InvalidRequestTokenException;
+use Contao\Input;
+use Contao\RequestToken;
+use Contao\System;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Initializes the Contao 3 framework.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ * @author Yanick Witschi <https://github.com/toflar>
+ * @author Leo Feyer <https://github.com/leofeyer>
+ * @author Dominik Tomasi <https://github.com/dtomasi>
+ * @author Andreas Schempp <https://github.com/aschempp>
+ *
+ * @internal Do not use this class in your code. Use the "contao.framework" service instead.
+ */
+class FrameworkInitializer
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var string
+     */
+    private $rootDir;
+
+    /**
+     * @var int
+     */
+    private $errorLevel;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $framework;
+
+    /**
+     * @var array
+     */
+    private $basicClasses = [
+        'System',
+        'Config',
+        'ClassLoader',
+        'TemplateLoader',
+        'ModuleLoader',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param RequestStack     $requestStack The request stack
+     * @param RouterInterface  $router       The router service
+     * @param SessionInterface $session      The session service
+     * @param string           $rootDir      The kernel root directory
+     * @param int              $errorLevel   The PHP error level
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        RouterInterface $router,
+        SessionInterface $session,
+        $rootDir,
+        $errorLevel
+    ) {
+        $this->router = $router;
+        $this->session = $session;
+        $this->rootDir = dirname($rootDir);
+        $this->errorLevel = $errorLevel;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Sets the framework.
+     *
+     * @param ContaoFrameworkInterface $framework The framework
+     */
+    public function setFramework(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LogicException If the container or the framwork is not set
+     */
+    public function initialize()
+    {
+        if (null === $this->container) {
+            throw new \LogicException('The service container has not been set.');
+        }
+
+        if (null === $this->framework) {
+            throw new \LogicException('The Contao 3 framework has not been set.');
+        }
+
+        // Set the current request
+        $this->request = $this->requestStack->getCurrentRequest();
+
+        $this->setConstants();
+        $this->initializeFramework();
+    }
+
+    /**
+     * Sets the Contao constants.
+     */
+    private function setConstants()
+    {
+        if (!defined('TL_MODE')) {
+            define('TL_MODE', $this->getMode());
+        }
+
+        define('TL_START', microtime(true));
+        define('TL_ROOT', $this->rootDir);
+        define('TL_REFERER_ID', $this->getRefererId());
+
+        if (!defined('TL_SCRIPT')) {
+            define('TL_SCRIPT', $this->getRoute());
+        }
+
+        // Define the login status constants in the back end (see #4099, #5279)
+        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
+            define('BE_USER_LOGGED_IN', false);
+            define('FE_USER_LOGGED_IN', false);
+        }
+
+        // Define the relative path to the installation (see #5339)
+        define('TL_PATH', $this->getPath());
+    }
+
+    /**
+     * Returns the TL_MODE value.
+     *
+     * @return string|null The TL_MODE value or null
+     */
+    private function getMode()
+    {
+        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
+            return 'BE';
+        }
+
+        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
+            return 'FE';
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the referer ID.
+     *
+     * @return string|null The referer ID or null
+     */
+    private function getRefererId()
+    {
+        if (null === $this->request) {
+            return null;
+        }
+
+        return $this->request->attributes->get('_contao_referer_id', '');
+    }
+
+    /**
+     * Returns the route.
+     *
+     * @return string The route
+     */
+    private function getRoute()
+    {
+        if (null === $this->request) {
+            return 'console';
+        }
+
+        $route = $this->router->generate(
+            $this->request->attributes->get('_route'),
+            $this->request->attributes->get('_route_params')
+        );
+
+        return substr($route, strlen($this->request->getBasePath()) + 1);
+    }
+
+    /**
+     * Returns the base path.
+     *
+     * @return string|null The base path
+     */
+    private function getPath()
+    {
+        if (null === $this->request) {
+            return null;
+        }
+
+        return $this->request->getBasePath();
+    }
+
+    /**
+     * Initializes the framework.
+     */
+    private function initializeFramework()
+    {
+        // Set the error_reporting level
+        error_reporting($this->errorLevel);
+
+        $this->includeHelpers();
+        $this->includeBasicClasses();
+
+        // Set the container
+        System::setContainer($this->container);
+
+        /** @var Config $config */
+        $config = $this->framework->getAdapter('Contao\Config');
+
+        // Preload the configuration (see #5872)
+        $config->preload();
+
+        // Register the class loader
+        ClassLoader::scanAndRegister();
+
+        $this->initializeLegacySessionAccess();
+        $this->setDefaultLanguage();
+
+        // Fully load the configuration
+        $config->getInstance();
+
+        $this->validateInstallation();
+
+        Input::initialize();
+
+        $this->setTimezone();
+        $this->triggerInitializeSystemHook();
+        $this->handleRequestToken();
+    }
+
+    /**
+     * Includes some helper files.
+     */
+    private function includeHelpers()
+    {
+        require __DIR__ . '/../Resources/contao/helper/functions.php';
+        require __DIR__ . '/../Resources/contao/config/constants.php';
+        require __DIR__ . '/../Resources/contao/helper/interface.php';
+        require __DIR__ . '/../Resources/contao/helper/exception.php';
+    }
+
+    /**
+     * Includes the basic classes required for further processing.
+     */
+    private function includeBasicClasses()
+    {
+        foreach ($this->basicClasses as $class) {
+            if (!class_exists($class, false)) {
+                require_once __DIR__ . '/../Resources/contao/library/Contao/' . $class . '.php';
+                class_alias('Contao\\' . $class, $class);
+            }
+        }
+    }
+
+    /**
+     * Initializes session access for $_SESSION['FE_DATA'] and $_SESSION['BE_DATA'].
+     */
+    private function initializeLegacySessionAccess()
+    {
+        if (!$this->session->isStarted()) {
+            return;
+        }
+
+        $_SESSION['BE_DATA'] = $this->session->getBag('contao_backend');
+        $_SESSION['FE_DATA'] = $this->session->getBag('contao_frontend');
+    }
+
+    /**
+     * Sets the default language.
+     */
+    private function setDefaultLanguage()
+    {
+        $language = 'en';
+
+        if (null !== $this->request) {
+            $language = str_replace('_', '-', $this->request->getLocale());
+        }
+
+        // Deprecated since Contao 4.0, to be removed in Contao 5.0
+        $GLOBALS['TL_LANGUAGE'] = $language;
+        $_SESSION['TL_LANGUAGE'] = $language;
+    }
+
+    /**
+     * Validates the installation.
+     *
+     * @throws IncompleteInstallationException If the installation has not been completed
+     */
+    private function validateInstallation()
+    {
+        if (null === $this->request) {
+            return;
+        }
+
+        /** @var Config $config */
+        $config = $this->framework->getAdapter('Contao\Config');
+
+        // Show the "incomplete installation" message
+        if (!$config->isComplete()) {
+            throw new IncompleteInstallationException(
+                'The installation has not been completed. Open the Contao install tool to continue.'
+            );
+        }
+    }
+
+    /**
+     * Sets the time zone.
+     */
+    private function setTimezone()
+    {
+        /** @var Config $config */
+        $config = $this->framework->getAdapter('Contao\Config');
+
+        $this->iniSet('date.timezone', $config->get('timeZone'));
+        date_default_timezone_set($config->get('timeZone'));
+    }
+
+    /**
+     * Triggers the initializeSystem hook (see #5665).
+     */
+    private function triggerInitializeSystemHook()
+    {
+        if (isset($GLOBALS['TL_HOOKS']['initializeSystem']) && is_array($GLOBALS['TL_HOOKS']['initializeSystem'])) {
+            foreach ($GLOBALS['TL_HOOKS']['initializeSystem'] as $callback) {
+                System::importStatic($callback[0])->{$callback[1]}();
+            }
+        }
+
+        if (file_exists($this->rootDir . '/system/config/initconfig.php')) {
+            include $this->rootDir . '/system/config/initconfig.php';
+        }
+    }
+
+    /**
+     * Handles the request token.
+     *
+     * @throws AjaxRedirectResponseException|InvalidRequestTokenException If the token is invalid
+     */
+    private function handleRequestToken()
+    {
+        /** @var RequestToken $requestToken */
+        $requestToken = $this->framework->getAdapter('Contao\RequestToken');
+
+        // Deprecated since Contao 4.0, to be removed in Contao 5.0
+        if (!defined('REQUEST_TOKEN')) {
+            define('REQUEST_TOKEN', $requestToken->get());
+        }
+
+        if ($this->canSkipTokenCheck() || $requestToken->validate($this->request->request->get('REQUEST_TOKEN'))) {
+            return;
+        }
+
+        if ($this->request->isXmlHttpRequest()) {
+            throw new AjaxRedirectResponseException($this->router->generate('contao_backend'));
+        }
+
+        throw new InvalidRequestTokenException('Invalid request token. Please reload the page and try again.');
+    }
+
+    /**
+     * Tries to set a php.ini configuration option.
+     *
+     * @param string $key   The key
+     * @param mixed  $value The value
+     */
+    private function iniSet($key, $value)
+    {
+        if (function_exists('ini_set')) {
+            ini_set($key, $value);
+        }
+    }
+
+    /**
+     * Checks if the token check can be skipped.
+     *
+     * @return bool True if the token check can be skipped
+     */
+    private function canSkipTokenCheck()
+    {
+        return null === $this->request
+            || 'POST' !== $this->request->getRealMethod()
+            || !$this->request->attributes->has('_token_check')
+            || false === $this->request->attributes->get('_token_check')
+        ;
+    }
+}

--- a/src/Framework/FrameworkInitializer.php
+++ b/src/Framework/FrameworkInitializer.php
@@ -34,7 +34,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Dominik Tomasi <https://github.com/dtomasi>
  * @author Andreas Schempp <https://github.com/aschempp>
  *
- * @internal Do not use this class in your code. Use the "contao.framework" service instead.
+ * @internal Do not use this class in your code. Use $container->get('contao.framework')->initialize() instead.
  */
 class FrameworkInitializer
 {

--- a/src/Framework/FrameworkInitializer.php
+++ b/src/Framework/FrameworkInitializer.php
@@ -112,7 +112,7 @@ class FrameworkInitializer
     /**
      * Sets the framework.
      *
-     * @param ContaoFrameworkInterface $framework The framework
+     * @param ContaoFrameworkInterface|null $framework The framework
      */
     public function setFramework(ContaoFrameworkInterface $framework = null)
     {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -17,6 +17,12 @@ services:
 
     contao.framework:
         class: Contao\CoreBundle\Framework\ContaoFramework
+        calls:
+            - ["setInitializer", ["@contao.framework_initializer"]]
+
+    contao.framework_initializer:
+        class: Contao\CoreBundle\Framework\FrameworkInitializer
+        public: false
         arguments:
             - "@request_stack"
             - "@router"

--- a/tests/Cache/ContaoCacheWarmerTest.php
+++ b/tests/Cache/ContaoCacheWarmerTest.php
@@ -98,13 +98,16 @@ class ContaoCacheWarmerTest extends TestCase
             ->willReturnOnConsecutiveCalls($class1, $class2, false)
         ;
 
+        $framework = $this->mockContaoFramework();
+        $framework->setInitializer($this->mockFrameworkInitializer());
+
         $warmer = new ContaoCacheWarmer(
             new Filesystem(),
             new ResourceFinder($this->getRootDir() . '/vendor/contao/test-bundle/Resources/contao'),
             new FileLocator($this->getRootDir() . '/vendor/contao/test-bundle/Resources/contao'),
             $this->getRootDir() . '/vendor/contao/test-bundle/Resources/contao',
             $connection,
-            $this->mockContaoFramework()
+            $framework
         );
 
         $warmer->warmUp($this->getCacheDir());

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -10,21 +10,14 @@
 
 namespace Contao\CoreBundle\Test\Framework;
 
-use Contao\Config;
-use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Test\TestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 /**
  * Tests the ContaoFramework class.
  *
- * @author Christian Schiffler <https://github.com/discordier>
  * @author Yanick Witschi <https://github.com/toflar>
- * @author Dominik Tomasi <https://github.com/dtomasi>
+ * @author Leo Feyer <https://github.com/leofeyer>
  *
  * @preserveGlobalState disabled
  */
@@ -35,173 +28,22 @@ class ContaoFrameworkTest extends TestCase
      */
     public function testInstantiation()
     {
-        $framework = $this->mockContaoFramework();
+        $framework = new ContaoFramework();
 
         $this->assertInstanceOf('Contao\CoreBundle\Framework\ContaoFramework', $framework);
         $this->assertInstanceOf('Contao\CoreBundle\Framework\ContaoFrameworkInterface', $framework);
     }
 
     /**
-     * Tests initializing the framework with a front end request.
+     * Tests initializing the framework without an initializer.
      *
      * @runInSeparateProcess
+     * @expectedException \LogicException
      */
-    public function testFrontendRequest()
+    public function testInitializerNotSet()
     {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/index.html')
-        );
-
-        $initializer->setContainer($container);
-
         $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
         $framework->initialize();
-
-        $this->assertTrue(defined('TL_MODE'));
-        $this->assertTrue(defined('TL_START'));
-        $this->assertTrue(defined('TL_ROOT'));
-        $this->assertTrue(defined('TL_REFERER_ID'));
-        $this->assertTrue(defined('TL_SCRIPT'));
-        $this->assertFalse(defined('BE_USER_LOGGED_IN'));
-        $this->assertFalse(defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('TL_PATH'));
-        $this->assertEquals('FE', TL_MODE);
-        $this->assertEquals($this->getRootDir(), TL_ROOT);
-        $this->assertEquals('', TL_REFERER_ID);
-        $this->assertEquals('index.html', TL_SCRIPT);
-        $this->assertEquals('', TL_PATH);
-        $this->assertEquals('en', $GLOBALS['TL_LANGUAGE']);
-        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\ArrayAttributeBag', $_SESSION['BE_DATA']);
-        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\ArrayAttributeBag', $_SESSION['FE_DATA']);
-    }
-
-    /**
-     * Tests initializing the framework with a back end request.
-     *
-     * @runInSeparateProcess
-     */
-    public function testBackendRequest()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_contao_referer_id', 'foobar');
-        $request->setLocale('de');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-
-        $this->assertTrue(defined('TL_MODE'));
-        $this->assertTrue(defined('TL_START'));
-        $this->assertTrue(defined('TL_ROOT'));
-        $this->assertTrue(defined('TL_REFERER_ID'));
-        $this->assertTrue(defined('TL_SCRIPT'));
-        $this->assertTrue(defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('TL_PATH'));
-        $this->assertEquals('BE', TL_MODE);
-        $this->assertEquals($this->getRootDir(), TL_ROOT);
-        $this->assertEquals('foobar', TL_REFERER_ID);
-        $this->assertEquals('contao/install', TL_SCRIPT);
-        $this->assertEquals('', TL_PATH);
-        $this->assertEquals('de', $GLOBALS['TL_LANGUAGE']);
-    }
-
-    /**
-     * Tests initializing the framework without a request.
-     *
-     * @runInSeparateProcess
-     */
-    public function testWithoutRequest()
-    {
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->set('request_stack', new RequestStack());
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-
-        $this->assertTrue(defined('TL_MODE'));
-        $this->assertTrue(defined('TL_START'));
-        $this->assertTrue(defined('TL_ROOT'));
-        $this->assertTrue(defined('TL_REFERER_ID'));
-        $this->assertTrue(defined('TL_SCRIPT'));
-        $this->assertTrue(defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('TL_PATH'));
-        $this->assertEquals('BE', TL_MODE);
-        $this->assertEquals($this->getRootDir(), TL_ROOT);
-        $this->assertNull(TL_REFERER_ID);
-        $this->assertEquals('console', TL_SCRIPT);
-        $this->assertNull(TL_PATH);
-    }
-
-    /**
-     * Tests initializing the framework without a scope.
-     *
-     * @runInSeparateProcess
-     */
-    public function testWithoutScope()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_contao_referer_id', 'foobar');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-
-        $this->assertTrue(defined('TL_MODE'));
-        $this->assertTrue(defined('TL_START'));
-        $this->assertTrue(defined('TL_ROOT'));
-        $this->assertTrue(defined('TL_REFERER_ID'));
-        $this->assertTrue(defined('TL_SCRIPT'));
-        $this->assertFalse(defined('BE_USER_LOGGED_IN'));
-        $this->assertFalse(defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(defined('TL_PATH'));
-        $this->assertNull(TL_MODE);
-        $this->assertEquals($this->getRootDir(), TL_ROOT);
-        $this->assertEquals('foobar', TL_REFERER_ID);
-        $this->assertEquals('contao/install', TL_SCRIPT);
-        $this->assertEquals('', TL_PATH);
     }
 
     /**
@@ -211,18 +53,6 @@ class ContaoFrameworkTest extends TestCase
      */
     public function testNotInitializedTwice()
     {
-        $request = new Request();
-        $request->attributes->set('_contao_referer_id', 'foobar');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-        $container->setParameter('contao.csrf_token_name', 'dummy_token');
-        $container->set('security.csrf.token_manager', new CsrfTokenManager());
-
-        // Ensure to use the fixtures class
-        Config::preload();
-
         $framework = $this->mockContaoFramework();
         $framework->setInitializer($this->mockFrameworkInitializer());
 
@@ -234,281 +64,6 @@ class ContaoFrameworkTest extends TestCase
 
         $framework->initialize();
         $framework->initialize();
-    }
-
-    /**
-     * Tests that the error level will get updated when configured.
-     *
-     * @runInSeparateProcess
-     */
-    public function testErrorLevelOverride()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_contao_referer_id', 'foobar');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $errorReporting = error_reporting();
-        error_reporting(E_ALL ^ E_USER_NOTICE);
-
-        $this->assertNotEquals(
-            $errorReporting,
-            error_reporting(),
-            'Test is invalid, error level has not changed.'
-        );
-
-        $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-
-        $this->assertEquals($errorReporting, error_reporting());
-
-        error_reporting($errorReporting);
-    }
-
-    /**
-     * Tests initializing the framework with a valid request token.
-     *
-     * @runInSeparateProcess
-     */
-    public function testValidRequestToken()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_token_check', true);
-        $request->setMethod('POST');
-        $request->request->set('REQUEST_TOKEN', 'foobar');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework();
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-    }
-
-    /**
-     * Tests initializing the framework with an invalid request token.
-     *
-     * @runInSeparateProcess
-     * @expectedException \Contao\CoreBundle\Exception\InvalidRequestTokenException
-     */
-    public function testInvalidRequestToken()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_token_check', true);
-        $request->setMethod('POST');
-        $request->request->set('REQUEST_TOKEN', 'invalid');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $rtAdapter = $this
-            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
-            ->setMethods(['get', 'validate'])
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $rtAdapter
-            ->expects($this->any())
-            ->method('get')
-            ->willReturn('nonsense')
-        ;
-
-        $rtAdapter
-            ->expects($this->once())
-            ->method('validate')
-            ->willReturn(false)
-        ;
-
-        $initializer = $this->mockFrameworkInitializer($container->get('request_stack'));
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework(['Contao\RequestToken' => $rtAdapter]);
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-    }
-
-    /**
-     * Tests if the request token check is skipped if the attribute is false.
-     *
-     * @runInSeparateProcess
-     */
-    public function testRequestTokenCheckSkippedIfAttributeFalse()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-        $request->attributes->set('_token_check', false);
-        $request->setMethod('POST');
-        $request->request->set('REQUEST_TOKEN', 'foobar');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $rtAdapter = $this
-            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
-            ->setMethods(['get', 'validate'])
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $rtAdapter
-            ->expects($this->any())
-            ->method('get')
-            ->willReturn('foobar')
-        ;
-
-        $rtAdapter
-            ->expects($this->never())
-            ->method('validate')
-        ;
-
-        $initializer = $this->mockFrameworkInitializer($container->get('request_stack'));
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework(['Contao\RequestToken' => $rtAdapter]);
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-    }
-
-    /**
-     * Tests initializing the framework with an incomplete installation.
-     *
-     * @runInSeparateProcess
-     * @expectedException \Contao\CoreBundle\Exception\IncompleteInstallationException
-     */
-    public function testIncompleteInstallation()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $configAdapter = $this
-            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
-            ->disableOriginalConstructor()
-            ->setMethods(['isComplete', 'get', 'preload', 'getInstance'])
-            ->getMock()
-        ;
-
-        $configAdapter
-            ->expects($this->any())
-            ->method('isComplete')
-            ->willReturn(false)
-        ;
-
-        $configAdapter
-            ->expects($this->any())
-            ->method('get')
-            ->willReturnCallback(function ($key) {
-                switch ($key) {
-                    case 'characterSet':
-                        return 'UTF-8';
-
-                    case 'timeZone':
-                        return 'Europe/Berlin';
-
-                    default:
-                        return null;
-                }
-            })
-        ;
-
-        $initializer = $this->mockFrameworkInitializer(
-            $container->get('request_stack'),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-
-        $framework = $this->mockContaoFramework(['Contao\Config' => $configAdapter]);
-        $framework->setInitializer($initializer);
-        $framework->initialize();
-    }
-
-    /**
-     * Tests initializing the framework without an initializer.
-     *
-     * @runInSeparateProcess
-     * @expectedException \LogicException
-     */
-    public function testInitializerNotSet()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-        $container->get('request_stack')->push($request);
-
-        $framework = $this->mockContaoFramework();
-        $framework->initialize();
-    }
-
-    /**
-     * Tests initializing the framework without a container.
-     *
-     * @runInSeparateProcess
-     * @expectedException \LogicException
-     */
-    public function testContainerNotSet()
-    {
-        $initializer = $this->mockFrameworkInitializer(
-            new RequestStack(),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer(null);
-        $initializer->initialize();
-    }
-
-    /**
-     * Tests initializing the framework without setting the framework in the initializer.
-     *
-     * @runInSeparateProcess
-     * @expectedException \LogicException
-     */
-    public function testFrameworkNotSet()
-    {
-        $request = new Request();
-        $request->attributes->set('_route', 'dummy');
-
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-        $container->get('request_stack')->push($request);
-
-        $initializer = $this->mockFrameworkInitializer(
-            new RequestStack(),
-            $this->mockRouter('/contao/install')
-        );
-
-        $initializer->setContainer($container);
-        $initializer->setFramework(null);
-        $initializer->initialize();
     }
 
     /**

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -35,6 +35,30 @@ class ContaoFrameworkTest extends TestCase
     }
 
     /**
+     * Tests initializing the framework.
+     *
+     * @runInSeparateProcess
+     */
+    public function testInitialize()
+    {
+        $initializer = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\FrameworkInitializer')
+            ->disableOriginalConstructor()
+            ->setMethods(['initialize'])
+            ->getMock()
+        ;
+
+        $initializer
+            ->expects($this->once())
+            ->method('initialize')
+        ;
+
+        $framework = $this->mockContaoFramework();
+        $framework->setInitializer($initializer);
+        $framework->initialize();
+    }
+
+    /**
      * Tests initializing the framework without an initializer.
      *
      * @runInSeparateProcess

--- a/tests/Framework/FrameworkInitializerTest.php
+++ b/tests/Framework/FrameworkInitializerTest.php
@@ -10,12 +10,10 @@
 
 namespace Contao\CoreBundle\Test\Framework;
 
-use Contao\Config;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 /**
  * Tests the FrameworkInitializer class.

--- a/tests/Framework/FrameworkInitializerTest.php
+++ b/tests/Framework/FrameworkInitializerTest.php
@@ -1,0 +1,434 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Framework;
+
+use Contao\Config;
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
+
+/**
+ * Tests the FrameworkInitializer class.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ * @author Yanick Witschi <https://github.com/toflar>
+ * @author Dominik Tomasi <https://github.com/dtomasi>
+ *
+ * @preserveGlobalState disabled
+ */
+class FrameworkInitializerTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $framework = $this->mockFrameworkInitializer();
+
+        $this->assertInstanceOf('Contao\CoreBundle\Framework\FrameworkInitializer', $framework);
+    }
+
+    /**
+     * Tests initializing the framework with a front end request.
+     *
+     * @runInSeparateProcess
+     */
+    public function testFrontendRequest()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/index.html')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+
+        $this->assertTrue(defined('TL_MODE'));
+        $this->assertTrue(defined('TL_START'));
+        $this->assertTrue(defined('TL_ROOT'));
+        $this->assertTrue(defined('TL_REFERER_ID'));
+        $this->assertTrue(defined('TL_SCRIPT'));
+        $this->assertFalse(defined('BE_USER_LOGGED_IN'));
+        $this->assertFalse(defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('TL_PATH'));
+        $this->assertEquals('FE', TL_MODE);
+        $this->assertEquals($this->getRootDir(), TL_ROOT);
+        $this->assertEquals('', TL_REFERER_ID);
+        $this->assertEquals('index.html', TL_SCRIPT);
+        $this->assertEquals('', TL_PATH);
+        $this->assertEquals('en', $GLOBALS['TL_LANGUAGE']);
+        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\ArrayAttributeBag', $_SESSION['BE_DATA']);
+        $this->assertInstanceOf('Contao\CoreBundle\Session\Attribute\ArrayAttributeBag', $_SESSION['FE_DATA']);
+    }
+
+    /**
+     * Tests initializing the framework with a back end request.
+     *
+     * @runInSeparateProcess
+     */
+    public function testBackendRequest()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_contao_referer_id', 'foobar');
+        $request->setLocale('de');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+
+        $this->assertTrue(defined('TL_MODE'));
+        $this->assertTrue(defined('TL_START'));
+        $this->assertTrue(defined('TL_ROOT'));
+        $this->assertTrue(defined('TL_REFERER_ID'));
+        $this->assertTrue(defined('TL_SCRIPT'));
+        $this->assertTrue(defined('BE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('TL_PATH'));
+        $this->assertEquals('BE', TL_MODE);
+        $this->assertEquals($this->getRootDir(), TL_ROOT);
+        $this->assertEquals('foobar', TL_REFERER_ID);
+        $this->assertEquals('contao/install', TL_SCRIPT);
+        $this->assertEquals('', TL_PATH);
+        $this->assertEquals('de', $GLOBALS['TL_LANGUAGE']);
+    }
+
+    /**
+     * Tests initializing the framework without a request.
+     *
+     * @runInSeparateProcess
+     */
+    public function testWithoutRequest()
+    {
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->set('request_stack', new RequestStack());
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+
+        $this->assertTrue(defined('TL_MODE'));
+        $this->assertTrue(defined('TL_START'));
+        $this->assertTrue(defined('TL_ROOT'));
+        $this->assertTrue(defined('TL_REFERER_ID'));
+        $this->assertTrue(defined('TL_SCRIPT'));
+        $this->assertTrue(defined('BE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('TL_PATH'));
+        $this->assertEquals('BE', TL_MODE);
+        $this->assertEquals($this->getRootDir(), TL_ROOT);
+        $this->assertNull(TL_REFERER_ID);
+        $this->assertEquals('console', TL_SCRIPT);
+        $this->assertNull(TL_PATH);
+    }
+
+    /**
+     * Tests initializing the framework without a scope.
+     *
+     * @runInSeparateProcess
+     */
+    public function testWithoutScope()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_contao_referer_id', 'foobar');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+
+        $this->assertTrue(defined('TL_MODE'));
+        $this->assertTrue(defined('TL_START'));
+        $this->assertTrue(defined('TL_ROOT'));
+        $this->assertTrue(defined('TL_REFERER_ID'));
+        $this->assertTrue(defined('TL_SCRIPT'));
+        $this->assertFalse(defined('BE_USER_LOGGED_IN'));
+        $this->assertFalse(defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('TL_PATH'));
+        $this->assertNull(TL_MODE);
+        $this->assertEquals($this->getRootDir(), TL_ROOT);
+        $this->assertEquals('foobar', TL_REFERER_ID);
+        $this->assertEquals('contao/install', TL_SCRIPT);
+        $this->assertEquals('', TL_PATH);
+    }
+
+    /**
+     * Tests that the error level will get updated when configured.
+     *
+     * @runInSeparateProcess
+     */
+    public function testErrorLevelOverride()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_contao_referer_id', 'foobar');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $errorReporting = error_reporting();
+        error_reporting(E_ALL ^ E_USER_NOTICE);
+
+        $this->assertNotEquals(
+            $errorReporting,
+            error_reporting(),
+            'Test is invalid, error level has not changed.'
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+
+        $this->assertEquals($errorReporting, error_reporting());
+
+        error_reporting($errorReporting);
+    }
+
+    /**
+     * Tests initializing the framework with a valid request token.
+     *
+     * @runInSeparateProcess
+     */
+    public function testValidRequestToken()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_token_check', true);
+        $request->setMethod('POST');
+        $request->request->set('REQUEST_TOKEN', 'foobar');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->initialize();
+    }
+
+    /**
+     * Tests initializing the framework with an invalid request token.
+     *
+     * @runInSeparateProcess
+     * @expectedException \Contao\CoreBundle\Exception\InvalidRequestTokenException
+     */
+    public function testInvalidRequestToken()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_token_check', true);
+        $request->setMethod('POST');
+        $request->request->set('REQUEST_TOKEN', 'invalid');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $rtAdapter = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
+            ->setMethods(['get', 'validate'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $rtAdapter
+            ->expects($this->any())
+            ->method('get')
+            ->willReturn('nonsense')
+        ;
+
+        $rtAdapter
+            ->expects($this->once())
+            ->method('validate')
+            ->willReturn(false)
+        ;
+
+        $initializer = $this->mockFrameworkInitializer($container->get('request_stack'));
+        $initializer->setContainer($container);
+        $initializer->setFramework($this->mockContaoFramework(['Contao\RequestToken' => $rtAdapter]));
+        $initializer->initialize();
+    }
+
+    /**
+     * Tests if the request token check is skipped if the attribute is false.
+     *
+     * @runInSeparateProcess
+     */
+    public function testRequestTokenCheckSkippedIfAttributeFalse()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_token_check', false);
+        $request->setMethod('POST');
+        $request->request->set('REQUEST_TOKEN', 'foobar');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $rtAdapter = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
+            ->setMethods(['get', 'validate'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $rtAdapter
+            ->expects($this->any())
+            ->method('get')
+            ->willReturn('foobar')
+        ;
+
+        $rtAdapter
+            ->expects($this->never())
+            ->method('validate')
+        ;
+
+        $initializer = $this->mockFrameworkInitializer($container->get('request_stack'));
+        $initializer->setContainer($container);
+        $initializer->initialize();
+    }
+
+    /**
+     * Tests initializing the framework with an incomplete installation.
+     *
+     * @runInSeparateProcess
+     * @expectedException \Contao\CoreBundle\Exception\IncompleteInstallationException
+     */
+    public function testIncompleteInstallation()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container->get('request_stack')->push($request);
+
+        $configAdapter = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
+            ->disableOriginalConstructor()
+            ->setMethods(['isComplete', 'get', 'preload', 'getInstance'])
+            ->getMock()
+        ;
+
+        $configAdapter
+            ->expects($this->any())
+            ->method('isComplete')
+            ->willReturn(false)
+        ;
+
+        $configAdapter
+            ->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($key) {
+                switch ($key) {
+                    case 'characterSet':
+                        return 'UTF-8';
+
+                    case 'timeZone':
+                        return 'Europe/Berlin';
+
+                    default:
+                        return null;
+                }
+            })
+        ;
+
+        $initializer = $this->mockFrameworkInitializer(
+            $container->get('request_stack'),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->setFramework($this->mockContaoFramework(['Contao\Config' => $configAdapter]));
+        $initializer->initialize();
+    }
+
+    /**
+     * Tests initializing the framework without a container.
+     *
+     * @runInSeparateProcess
+     * @expectedException \LogicException
+     */
+    public function testContainerNotSet()
+    {
+        $initializer = $this->mockFrameworkInitializer(
+            new RequestStack(),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer(null);
+        $initializer->initialize();
+    }
+
+    /**
+     * Tests initializing the framework without setting the framework in the initializer.
+     *
+     * @runInSeparateProcess
+     * @expectedException \LogicException
+     */
+    public function testFrameworkNotSet()
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'dummy');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
+        $container->get('request_stack')->push($request);
+
+        $initializer = $this->mockFrameworkInitializer(
+            new RequestStack(),
+            $this->mockRouter('/contao/install')
+        );
+
+        $initializer->setContainer($container);
+        $initializer->setFramework(null);
+        $initializer->initialize();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -259,10 +259,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @return FrameworkInitializer The object instance
      */
-    public function mockFrameworkInitializer(
-        RequestStack $requestStack = null,
-        RouterInterface $router = null
-    ) {
+    public function mockFrameworkInitializer(RequestStack $requestStack = null, RouterInterface $router = null)
+    {
         $container = $this->mockContainerWithContaoScopes();
 
         if (null === $requestStack) {


### PR DESCRIPTION
This PR extracts the framework initialization logic from the `ContaoFramework` class.

The `ContaoFramework` class now does more than just initializing the Contao 3 framework, therefore the initialization logic should not be in the class anymore. I have created a `FrameworkInitializer` service instead, which is injected only if the `initialize()` method is called.

All the changes are internal, so the API remains exactly the same as before.

@contao/developers Any objections?