### PR TITLE
Webprofiler redesign

### DIFF
--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -216,9 +216,12 @@ class ContaoDataCollector extends DataCollector
 
         $this->data['summary'] = [
             'version' => $this->getContaoVersion(),
-            'layout' => $this->getLayoutName(),
             'framework' => $framework,
             'models' => $modelCount,
+            'frontend' => isset($GLOBALS['objPage']),
+            'preview' => BE_USER_LOGGED_IN === true,
+            'layout' => $this->getLayoutName(),
+            'template' => $this->getTemplateName(),
         ];
     }
 
@@ -229,18 +232,40 @@ class ContaoDataCollector extends DataCollector
      */
     private function getLayoutName()
     {
-        if (!$this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
-            return '';
-        }
+        $layout = $this->getLayout();
 
-        /** @var PageModel $objPage */
-        global $objPage;
-
-        /** @var LayoutModel $layout */
-        if (null === $objPage || null === ($layout = $objPage->getRelated('layout'))) {
+        if (null === $layout) {
             return '';
         }
 
         return sprintf('%s (ID %s)', $layout->name, $layout->id);
+    }
+
+    private function getTemplateName()
+    {
+        $layout = $this->getLayout();
+
+        if (null === $layout) {
+            return '';
+        }
+
+        return $layout->template;
+    }
+
+    /**
+     * @return LayoutModel|null
+     * @throws \Exception
+     */
+    private function getLayout()
+    {
+        /** @var PageModel $objPage */
+        global $objPage;
+
+        /** @var LayoutModel $layout */
+        if (null === $objPage) {
+            return null;
+        }
+
+        return $objPage->getRelated('layout');
     }
 }

--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -216,29 +216,10 @@ class ContaoDataCollector extends DataCollector
 
         $this->data['summary'] = [
             'version' => $this->getContaoVersion(),
-            'scope' => $this->getContainerScope(),
             'layout' => $this->getLayoutName(),
             'framework' => $framework,
             'models' => $modelCount,
         ];
-    }
-
-    /**
-     * Returns the scope from the container.
-     *
-     * @return string
-     */
-    private function getContainerScope()
-    {
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
-            return ContaoCoreBundle::SCOPE_BACKEND;
-        }
-
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
-            return ContaoCoreBundle::SCOPE_FRONTEND;
-        }
-
-        return '';
     }
 
     /**

--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -10,7 +10,6 @@
 
 namespace Contao\CoreBundle\DataCollector;
 
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\LayoutModel;
 use Contao\Model\Registry;
 use Contao\PageModel;
@@ -166,13 +165,15 @@ class ContaoDataCollector extends DataCollector
             return [];
         }
 
-        unset($data['summary']);
-        unset($data['contao_version']);
-        unset($data['classes_aliased']);
-        unset($data['classes_set']);
-        unset($data['database_queries']);
-        unset($data['unknown_insert_tags']);
-        unset($data['unknown_insert_tag_flags']);
+        unset(
+            $data['summary'],
+            $data['contao_version'],
+            $data['classes_aliased'],
+            $data['classes_set'],
+            $data['database_queries'],
+            $data['unknown_insert_tags'],
+            $data['unknown_insert_tag_flags']
+        );
 
         return $data;
     }
@@ -215,13 +216,13 @@ class ContaoDataCollector extends DataCollector
         }
 
         $this->data['summary'] = [
-            'version' => $this->getContaoVersion(),
+            'version'   => $this->getContaoVersion(),
             'framework' => $framework,
-            'models' => $modelCount,
-            'frontend' => isset($GLOBALS['objPage']),
-            'preview' => BE_USER_LOGGED_IN === true,
-            'layout' => $this->getLayoutName(),
-            'template' => $this->getTemplateName(),
+            'models'    => $modelCount,
+            'frontend'  => isset($GLOBALS['objPage']),
+            'preview'   => defined('BE_USER_LOGGED_IN') && true === BE_USER_LOGGED_IN,
+            'layout'    => $this->getLayoutName(),
+            'template'  => $this->getTemplateName(),
         ];
     }
 

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -2,8 +2,8 @@
 
 {% block toolbar %}
     {% set icon %}
-        <img width="26" height="28" alt="Contao" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAQAAADVGmdYAAACZUlEQVQ4y81US2gUQRCtycQfRFBQL3oIGFScrdcjESRGJeQk4s2jtwheRCE3kYiHHEREEPGsnkQFQVFBYvCb+FlJgtkQEPQiIoggIaC47m7Gqv7MTMxdnGLpne569apeVw3RP3uSXjPCVX7Lh+1rlB8U/9qImM0IJvAUbzBa2U24hwyZub91tRzH3j32FgUQkRlWP+dLeIWMP3RvJupr/4vBASKKulYQbVqFUfH8Jb8qYUyWkxYSBUhlJw9WTmGvhcUBj36FiL0gTGF+x3ai7mUBwkP4qYfc0mC27g7eZg7iPObs/jihJnRtPnOJygfswQK3bDInzABflRK++oqaFsTTuONrUSO+IEe/0RRQI5TuTAK5UAJ6x9dzkKp02Sa24BK07g2J39S9AlRmkhRxxoJaPnrLOedcDoQZUSOIq9d4tMSxKLkSSJjep2u8tMrUj/pSkGMrmCbxI0295AJMO80Xp9JSE6BXryqvhzxImDpX8hMFhTryWkQMkaThQOPSTcP+nmyX8aUAyjVcFAJjhOey3C7fFI6Ewsur2DzP8i3+pL33TF6nsME3rFaV2nZphvLxDY9x0QyYPbyWdCpqJDOSYY57Cil8VXXLojWcLbe9TNSMSy+rHPeiu5YdtIC66+pkv571teuAdK3njzxthRCXm/m4CXTLOsvvarqmzrqrmSS9kvaEnSexzyaRreVhDOW2zuEubvCxpCMfzNg1mahn70kzP12MtnPyk+z3lMds5Fnxfkl44BP5jl2lOY3zz0tcAPmK/0ZwDx7htdRQ46ESl6zCFOdfDG3lfeI1iYeq9H/9/AHhPHbawQYHsgAAAABJRU5ErkJggg==">
-        <span class="sf-toolbar-info-piece-additional sf-toolbar-status">{{ collector.summary.version }}</span>
+        {{ include('ContaoCoreBundle:Collector:contao.svg') }}
+        <span class="sf-toolbar-value">{{ collector.summary.version }}</span>
     {% endset %}
     {% set text %}
         <div class="sf-toolbar-info-piece">
@@ -19,12 +19,12 @@
             {{ collector.summary.layout|default('n/a') }}
         </div>
     {% endset %}
-    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'contao', additional_classes: 'sf-toolbar-block-right' }) }}
 {% endblock %}
 
 {% block menu %}
     <span class="label">
-        <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACoAAAAeCAQAAADwIURrAAAC20lEQVRIx7WWTWgTQRTHZ5P4GYVSetJShVqLbubthlwUBEMVP24iBsSDHvWgUkQvpXiwhyr04kHxoiCKXopezIfGBATpRaFFhIKIIJ6KRaz0oG2y63tvk81MuruBVjOEndmd95s3/zfzZoT4vz9Iwh2oyBcwBcPYNDr1l6PYMw8lKEIF7kIyGDoBLhU5Y3Z3hMaESPXDD8+Cy0QwtMrI+VS/ELm4CsgmEBLDd8pA1MM6ghZ1qMESPqvB0AJBrUtCZNbpPgW2DBxKwFO0WUawC4VgaB4/ze7cqE0da+m91ph8DpNwObNZiGwiF0dcowf0wiJa1fBfCoVat7Spo19wDn77uk0Nbm1+yibsATgtx1nXCChOXx5WoIi0bdZrCae4TDV5P9NjHYVr8AQ+so9UHJ5+MFS+Qk93t6CkmbyJ3f/4xhSWOSXiDg7lvQ31tAKLZp8SDNTNesyBcBWsy29qCHL8dgS0Cj/T2xQoPuUDDeoBHK3dAVqGuj3QgtL0rTFW1O1QIqAlcE2rTdOLjdiuGkrRP96C0hMOMdJZPZQW/4iypChQ2+XC2qGTevRFDKYbRmuATvO+N5T43+uoap1DGaHpgpR6qKzzIVDKTrRem9IUg6FFTn0nPJif3g6wH7qqjjbMHLxHu5ehSwo36nU9VHgefG5T1RvgF7zD/XYVhuyu1B7cyq8joDwNQ8tTDzUBqFaGIRg01/uWqcjFj+Wb3dXCsqonNShuWutKU55cnAIrD4Yn6VJjmsdaqhLc3AKfOFc5nJUIvI9PB8PX/UI0FNOcHFcTNdXkGS1Mt1WB+PsjfJsPh5Ins7s2tB8pcBY+yHn4LmfoDNNXcqZHfg33tMDakQCnFAEaiP2b0jvMPj7BlAFJUZ58KLTKntKqfKubtsmhrQ2zG74wtBp5meAtcGPF4WzQ2a9dMbgun0VfJpJ4eangvipCGS8/vSuwAbcUTI1vULbwa8+/+/0FfI41lT36pN8AAAAASUVORK5CYII=" alt="Contao"></span>
+        <span class="icon">{{ include('ContaoCoreBundle:Collector:contao.svg') }}</span>
         <strong>Contao</strong>
     </span>
 {% endblock %}
@@ -62,7 +62,7 @@
             <tbody>
                 {% for name in collector.unknowninserttags %}
                     <tr>
-                        <td><pre>{{ '{{' }}{{ name }}{{ '}}' }}</pre></td>
+                        <td><pre>{{ '{{' ~ name ~ '}}' }}</pre></td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -11,10 +11,6 @@
             {{ collector.summary.version }}
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>Container scope</b>
-            {{ collector.summary.scope|default('n/a') }}
-        </div>
-        <div class="sf-toolbar-info-piece">
             <b>Reg. models</b>
             <span class="sf-toolbar-status sf-toolbar-status-{{ collector.summary.models > 50 ? 'red' : 'green' }}">{{ collector.summary.models }}</span>
         </div>
@@ -39,16 +35,6 @@
         <tr>
             <th>Version</th>
             <td>{{ collector.summary.version }}</td>
-        </tr>
-        <tr>
-            <th>Container scope</th>
-            <td>
-                {% if collector.summary.scope %}
-                    <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.summary.scope }}</span>
-                {% else %}
-                    <span class="sf-toolbar-status sf-toolbar-status-red">unknown</span>
-                {% endif %}
-            </td>
         </tr>
         <tr>
             <th>Registered models</th>

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -31,20 +31,25 @@
 
 {% block panel %}
     <h2>Summary</h2>
-    <table>
-        <tr>
-            <th>Version</th>
-            <td>{{ collector.summary.version }}</td>
-        </tr>
-        <tr>
-            <th>Registered models</th>
-            <td>{{ collector.summary.models }}</td>
-        </tr>
-        <tr>
-            <th>Page layout</th>
-            <td>{{ collector.summary.layout }}</td>
-        </tr>
-    </table>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.summary.version }}</span>
+            <span class="label">Contao version</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ collector.summary.models }}</span>
+            <span class="label">Registered models</span>
+        </div>
+
+        {% if collector.summary.layout %}
+            <div class="metric">
+                <span class="value">{{ collector.summary.layout }}</span>
+                <span class="label">Page layout</span>
+            </div>
+        {% endif %}
+    </div>
 
     <h2>Unknown insert tags</h2>
     {% if collector.unknowninserttags %}

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -2,29 +2,45 @@
 
 {% block toolbar %}
     {% set icon %}
-        {{ include('ContaoCoreBundle:Collector:contao.svg') }}
+        {{ include('@ContaoCore/Collector/contao.svg') }}
         <span class="sf-toolbar-value">{{ collector.summary.version }}</span>
     {% endset %}
     {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Contao</b>
-            {{ collector.summary.version }}
+        {% if collector.summary.frontend %}
+        <div class="sf-toolbar-info-group">
+            <div class="sf-toolbar-info-piece">
+                <b>Page layout</b>
+                <span>{{ collector.summary.layout }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Template</b>
+                <span>{{ collector.summary.template|default('n/a') }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Frontend preview</b>
+                {% if collector.summary.preview %}
+                    <span class="sf-toolbar-status sf-toolbar-status-yellow">enabled</span>
+                {% else %}
+                    <span>disabled</span>
+                {% endif %}
+            </div>
         </div>
-        <div class="sf-toolbar-info-piece">
-            <b>Reg. models</b>
-            <span class="sf-toolbar-status sf-toolbar-status-{{ collector.summary.models > 50 ? 'red' : 'green' }}">{{ collector.summary.models }}</span>
-        </div>
-        <div class="sf-toolbar-info-piece">
-            <b>Page layout</b>
-            {{ collector.summary.layout|default('n/a') }}
+        {% endif %}
+        <div class="sf-toolbar-info-group">
+            <div class="sf-toolbar-info-piece">
+                <b>Resources</b>
+                <span>
+                    <a href="https://docs.contao.org/" target="_blank" rel="help">Read Contao Docs</a>
+                </span>
+            </div>
         </div>
     {% endset %}
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'contao', additional_classes: 'sf-toolbar-block-right' }) }}
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'contao', additional_classes: ((collector.summary.preview ? 'sf-toolbar-status-yellow ' : '') ~ 'sf-toolbar-block-right') }) }}
 {% endblock %}
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ include('ContaoCoreBundle:Collector:contao.svg') }}</span>
+        <span class="icon">{{ include('@ContaoCore/Collector/contao.svg') }}</span>
         <strong>Contao</strong>
     </span>
 {% endblock %}

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -49,14 +49,18 @@
     <h2>Unknown insert tags</h2>
     {% if collector.unknowninserttags %}
         <table>
-            <tr>
-                <th>Insert tag</th>
-            </tr>
-            {% for name in collector.unknowninserttags %}
+            <thead>
                 <tr>
-                    <td><pre>{{ '{{' }}{{ name }}{{ '}}' }}</pre></td>
+                    <th>Insert tag</th>
                 </tr>
-            {% endfor %}
+            </thead>
+            <tbody>
+                {% for name in collector.unknowninserttags %}
+                    <tr>
+                        <td><pre>{{ '{{' }}{{ name }}{{ '}}' }}</pre></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
         </table>
     {% else %}
         <p><em>No unknown insert tags used on the page.</em></p>
@@ -65,14 +69,18 @@
     <h2>Unknown insert tag flags</h2>
     {% if collector.unknowninserttagflags %}
         <table>
-            <tr>
-                <th>Insert tag flag</th>
-            </tr>
-            {% for name in collector.unknowninserttagflags %}
+            <thead>
                 <tr>
-                    <td><pre>{{ name }}</pre></td>
+                    <th>Insert tag flag</th>
                 </tr>
-            {% endfor %}
+            </thead>
+            <tbody>
+                {% for name in collector.unknowninserttagflags %}
+                    <tr>
+                        <td><pre>{{ name }}</pre></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
         </table>
     {% else %}
         <p><em>No unknown insert tag flags used on the page.</em></p>
@@ -80,28 +88,36 @@
 
     <h2>Classes aliased</h2>
     <table>
-        <tr>
-            <th>Alias name</th>
-            <th>Original name</th>
-        </tr>
-        {% for class in collector.classesaliased %}
+        <thead>
             <tr>
-                <td><pre>{{ class.alias }}</pre></td>
-                <td><pre>{{ class.original }}</pre></td>
+                <th>Alias name</th>
+                <th>Original name</th>
             </tr>
-        {% endfor %}
+        </thead>
+        <tbody>
+            {% for class in collector.classesaliased %}
+                <tr>
+                    <td><pre>{{ class.alias }}</pre></td>
+                    <td><pre>{{ class.original }}</pre></td>
+                </tr>
+            {% endfor %}
+        </tbody>
     </table>
 
     <h2>Classes set</h2>
     <table>
-        <tr>
-            <th>Class name</th>
-        </tr>
-        {% for class in collector.classesset %}
-        <tr>
-            <td><pre>{{ class }}</pre></td>
-        </tr>
-        {% endfor %}
+        <thead>
+            <tr>
+                <th>Class name</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for class in collector.classesset %}
+                <tr>
+                    <td><pre>{{ class }}</pre></td>
+                </tr>
+            {% endfor %}
+        </tbody>
     </table>
 
     {% if collector.additionaldata %}

--- a/src/Resources/views/Collector/contao.svg
+++ b/src/Resources/views/Collector/contao.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="-272 399 49.9 44.1" style="enable-background:new -272 399 49.9 44.1;" xml:space="preserve" width="23" height="23">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g id="g10" transform="matrix(1.25,0,0,-1.25,-28.4725,179.16875)">
+	<path id="path232" class="st0" d="M-192.2-176c-1.5,0-2.6-1.2-2.6-2.6v-29.8c0-1.5,1.2-2.6,2.6-2.6h6.2c-3.3,3.6-4.2,8.6-5.3,13.8
+		c-1.4,6.4-2.8,12.4,0.7,17.9c0.8,1.3,1.8,2.4,2.9,3.4L-192.2-176L-192.2-176z M-164.5-176c1.7-1.7,3.1-3.9,4.1-6.6l-10.7-2.3
+		c-1.2,2.3-3,4.2-6.4,3.4c-1.9-0.4-3.2-1.5-3.8-2.7c-0.7-1.5-1-3.1,0.6-10.9c1.7-7.8,2.6-9.2,3.9-10.3c1-0.9,2.6-1.3,4.5-0.9
+		c3.5,0.7,4.4,3.2,4.5,5.7l10.7,2.3c0.3-5.6-1.5-9.9-4.5-12.9h4.1c1.5,0,2.6,1.2,2.6,2.6v29.8c0,1.5-1.2,2.6-2.6,2.6L-164.5-176
+		L-164.5-176z"/>
+</g>
+</svg>


### PR DESCRIPTION
rewrote the profiler for Symfony 2.8. Not sure if it still works/looks good with 2.7, but we should update the dependencies anyway.

![bildschirmfoto 2016-01-13 um 22 41 01](https://cloud.githubusercontent.com/assets/1073273/12308659/c4524f8e-ba46-11e5-8dd3-b1482ddbb226.png)
