### PR TITLE
[WIP] Writing DCA files in the YAML notation

### DIFF
--- a/src/Config/Loader/YamlDcaFileLoader.php
+++ b/src/Config/Loader/YamlDcaFileLoader.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Config\Loader;
+
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Reads YAML files and returns the content.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class YamlDcaFileLoader extends Loader
+{
+    /**
+     * Reads the contents of a YAML file.
+     *
+     * @param string      $file A YAML file path
+     * @param string|null $type The resource type
+     *
+     * @return string The PHP code without the PHP tags
+     */
+    public function load($file, $type = null)
+    {
+        $table = basename($file, '.yml');
+        $data = var_export(Yaml::parse(file_get_contents($file)), true);
+        return "\$GLOBALS['TL_DCA']['$table'] = array_replace_recursive($data, \$GLOBALS['TL_DCA']['$table']);\n";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'yml' === pathinfo($resource, PATHINFO_EXTENSION);
+    }
+}

--- a/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/src/Resources/contao/library/Contao/DcaLoader.php
@@ -9,6 +9,7 @@
  */
 
 namespace Contao;
+use Symfony\Component\Yaml\Yaml;
 
 
 /**
@@ -83,6 +84,14 @@ class DcaLoader extends \Controller
 				foreach (\System::getContainer()->get('contao.resource_locator')->locate('dca/' . $this->strTable . '.php', null, false) as $file)
 				{
 					include $file;
+				}
+
+				foreach (\System::getContainer()->get('contao.resource_locator')->locate('dca/' . $this->strTable . '.yml', null, false) as $file)
+				{
+					$GLOBALS['TL_DCA'][$this->strTable] = array_replace_recursive(
+						Yaml::parse($file),
+						$GLOBALS['TL_DCA'][$this->strTable]
+					);
 				}
 			}
 			catch (\InvalidArgumentException $e) {}


### PR DESCRIPTION
I found that for me personally, it's way easier to write a DCA in YAML instead of PHP. I'm way faster and I make less typos. Here's a proposal for Contao 4.2, obviously it's still missing tests and stuff but I wanted to hear your feedback about it :-)

Also, that way we could decide that starting from Contao 4.2 (or whatever version) using PHP DCA files is deprecated. This would give the users enough time to slowly migrate to using YAML files which in contrast to our php files can be cached someday :-)
