### PR TITLE
[RTM] Stop using container scopes

### DIFF
--- a/src/Command/FrameworkAwareTrait.php
+++ b/src/Command/FrameworkAwareTrait.php
@@ -10,7 +10,11 @@
 
 namespace Contao\CoreBundle\Command;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+@trigger_error(
+    'Using ' . __NAMESPACE__ . '\FrameworkAwareTrait has been deprecated and will no longer work in Contao 5.0. '
+        . 'Use Contao\CoreBundle\Framework\FrameworkAwareTrait instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * Provides methods to inject the framework service.
@@ -22,46 +26,5 @@ use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
  */
 trait FrameworkAwareTrait
 {
-    /**
-     * @var ContaoFrameworkInterface
-     */
-    private $framework;
-
-    /**
-     * Returns the framework service.
-     *
-     * @return ContaoFrameworkInterface The framework service
-     *
-     * @throws \LogicException If the framework service is not set
-     */
-    public function getFramework()
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\Command\FrameworkAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\FrameworkAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        if (null === $this->framework) {
-            throw new \LogicException('The framework service has not been set.');
-        }
-
-        return $this->framework;
-    }
-
-    /**
-     * Sets the framework service.
-     *
-     * @param ContaoFrameworkInterface $framework The framework service
-     */
-    public function setFramework(ContaoFrameworkInterface $framework)
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\Command\FrameworkAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\FrameworkAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        $this->framework = $framework;
-    }
+    use \Contao\CoreBundle\Framework\FrameworkAwareTrait;
 }

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -43,9 +43,6 @@ class ContaoCoreBundle extends Bundle
     public function boot()
     {
         Bootup::initAll();
-
-        $this->container->addScope(new Scope(self::SCOPE_BACKEND, 'request'));
-        $this->container->addScope(new Scope(self::SCOPE_FRONTEND, 'request'));
     }
 
     /**

--- a/src/Controller/InitializeController.php
+++ b/src/Controller/InitializeController.php
@@ -56,7 +56,11 @@ class InitializeController extends Controller
 
         // Initialize the framework with the real request
         $this->get('request_stack')->push($realRequest);
-        $this->container->enterScope($scope);
+
+        if (method_exists('Symfony\Component\DependencyInjection\Container', 'enterScope')) {
+            $this->container->enterScope($scope);
+        }
+
         $this->container->get('contao.framework')->initialize();
 
         // Add the master request again. When Kernel::handle() is finished,

--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\DataCollector;
 
 use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\LayoutModel;
 use Contao\Model\Registry;
 use Contao\PageModel;
@@ -26,10 +27,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 class ContaoDataCollector extends DataCollector
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    use ScopeAwareTrait;
 
     /**
      * @var array
@@ -230,11 +228,11 @@ class ContaoDataCollector extends DataCollector
      */
     private function getContainerScope()
     {
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
+        if ($this->isBackendScope()) {
             return ContaoCoreBundle::SCOPE_BACKEND;
         }
 
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
+        if ($this->isFrontendScope()) {
             return ContaoCoreBundle::SCOPE_FRONTEND;
         }
 
@@ -248,7 +246,7 @@ class ContaoDataCollector extends DataCollector
      */
     private function getLayoutName()
     {
-        if (!$this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
+        if (!$this->isFrontendScope()) {
             return '';
         }
 

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -117,8 +117,5 @@ class ContaoCoreExtension extends ConfigurableExtension
         );
 
         $container->setDefinition('contao.listener.container_scope', $definition);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
     }
 }

--- a/src/DependencyInjection/ContaoCoreExtension.php
+++ b/src/DependencyInjection/ContaoCoreExtension.php
@@ -10,11 +10,13 @@
 
 namespace Contao\CoreBundle\DependencyInjection;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 /**
@@ -115,5 +117,8 @@ class ContaoCoreExtension extends ConfigurableExtension
         );
 
         $container->setDefinition('contao.listener.container_scope', $definition);
+
+        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
+        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
     }
 }

--- a/src/EventListener/ContainerScopeListener.php
+++ b/src/EventListener/ContainerScopeListener.php
@@ -10,7 +10,9 @@
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -38,6 +40,7 @@ class ContainerScopeListener
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
+        $this->addContaoScopesIfNotSet();
     }
 
     /**
@@ -80,5 +83,19 @@ class ContainerScopeListener
         }
 
         return $request->attributes->get('_scope');
+    }
+
+    /**
+     * Adds the Contao scopes to the container.
+     */
+    private function addContaoScopesIfNotSet()
+    {
+        if (!$this->container->hasScope(ContaoCoreBundle::SCOPE_BACKEND)) {
+            $this->container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND, 'request'));
+        }
+
+        if (!$this->container->hasScope(ContaoCoreBundle::SCOPE_FRONTEND)) {
+            $this->container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND, 'request'));
+        }
     }
 }

--- a/src/EventListener/ContainerScopeListener.php
+++ b/src/EventListener/ContainerScopeListener.php
@@ -76,13 +76,7 @@ class ContainerScopeListener
      */
     private function getScopeFromEvent(KernelEvent $event)
     {
-        $request = $event->getRequest();
-
-        if (!$request->attributes->has('_scope')) {
-            return null;
-        }
-
-        return $request->attributes->get('_scope');
+        return $event->getRequest()->attributes->get('_scope');
     }
 
     /**

--- a/src/EventListener/ContainerScopeListener.php
+++ b/src/EventListener/ContainerScopeListener.php
@@ -19,6 +19,9 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
  * Changes the container scope based on the route configuration.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
+ *
+ * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.0.
+ *             Use the _scope request attribute instead.
  */
 class ContainerScopeListener
 {
@@ -70,16 +73,12 @@ class ContainerScopeListener
      */
     private function getScopeFromEvent(KernelEvent $event)
     {
-        if (!$event->getRequest()->attributes->has('_scope')) {
+        $request = $event->getRequest();
+
+        if (!$request->attributes->has('_scope')) {
             return null;
         }
 
-        $scope = $event->getRequest()->attributes->get('_scope');
-
-        if (!$this->container->hasScope($scope)) {
-            return null;
-        }
-
-        return $scope;
+        return $request->attributes->get('_scope');
     }
 }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/EventListener/OutputFromCacheListener.php
+++ b/src/EventListener/OutputFromCacheListener.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\Frontend;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 

--- a/src/EventListener/RefererIdListener.php
+++ b/src/EventListener/RefererIdListener.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;

--- a/src/EventListener/ScopeAwareTrait.php
+++ b/src/EventListener/ScopeAwareTrait.php
@@ -64,7 +64,7 @@ trait ScopeAwareTrait
     }
 
     /**
-     * Checks whether the request is a Contao front end master request
+     * Checks whether the request is a Contao front end master request.
      *
      * @param KernelEvent $event The HttpKernel event
      *

--- a/src/EventListener/ScopeAwareTrait.php
+++ b/src/EventListener/ScopeAwareTrait.php
@@ -10,9 +10,11 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\ContaoCoreBundle;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
-use Symfony\Component\HttpKernel\Event\KernelEvent;
+@trigger_error(
+    'Using ' . __NAMESPACE__ . '\ScopeAwareTrait has been deprecated and will no longer work in Contao 5.0. '
+        . 'Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * Provides methods to test the request scope.
@@ -25,135 +27,5 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
  */
 trait ScopeAwareTrait
 {
-    use ContainerAwareTrait;
-
-    /**
-     * Checks whether the request is a Contao the master request.
-     *
-     * @param KernelEvent $event The HttpKernel event
-     *
-     * @return bool True the request is a Contao the master request
-     */
-    protected function isContaoMasterRequest(KernelEvent $event)
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $event->isMasterRequest() && $this->isContaoScope();
-    }
-
-    /**
-     * Checks whether the request is a Contao back end master request.
-     *
-     * @param KernelEvent $event The HttpKernel event
-     *
-     * @return bool True the request is a Contao back end master request
-     */
-    protected function isBackendMasterRequest(KernelEvent $event)
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $event->isMasterRequest() && $this->isBackendScope();
-    }
-
-    /**
-     * Checks whether the request is a Contao front end master request.
-     *
-     * @param KernelEvent $event The HttpKernel event
-     *
-     * @return bool True if the request is a Contao front end master request
-     */
-    protected function isFrontendMasterRequest(KernelEvent $event)
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $event->isMasterRequest() && $this->isFrontendScope();
-    }
-
-    /**
-     * Checks whether the request is a Contao request.
-     *
-     * @return bool True if the request is a Contao request
-     */
-    protected function isContaoScope()
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $this->isBackendScope() || $this->isFrontendScope();
-    }
-
-    /**
-     * Checks whether the request is a Contao back end request.
-     *
-     * @return bool True if the request is a Contao back end request
-     */
-    protected function isBackendScope()
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $this->isScope(ContaoCoreBundle::SCOPE_BACKEND);
-    }
-
-    /**
-     * Checks whether the request is a Contao front end request.
-     *
-     * @return bool True if the request is a Contao front end request
-     */
-    protected function isFrontendScope()
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $this->isScope(ContaoCoreBundle::SCOPE_FRONTEND);
-    }
-
-    /**
-     * Checks whether the _scope attributes matches a scope.
-     *
-     * @param string $scope The scope
-     *
-     * @return bool True if the _scope attributes matches a scope
-     */
-    private function isScope($scope)
-    {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
-        if (null === $this->container) {
-            return false;
-        }
-
-        $request = $this->container->get('request_stack')->getCurrentRequest();
-
-        if (null === $request && !$request->attributes->has('_scope')) {
-            return false;
-        }
-
-        return $scope === $request->attributes->get('_scope');
-    }
+    use \Contao\CoreBundle\Framework\ScopeAwareTrait;
 }

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;

--- a/src/EventListener/ToggleViewListener.php
+++ b/src/EventListener/ToggleViewListener.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/EventListener/UserAwareTrait.php
+++ b/src/EventListener/UserAwareTrait.php
@@ -48,6 +48,6 @@ trait UserAwareTrait
             return false;
         }
 
-        return (!$user instanceof AnonymousToken);
+        return !$user instanceof AnonymousToken;
     }
 }

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\FrontendUser;
 use Contao\User;
 use Doctrine\DBAL\Connection;

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -12,14 +12,12 @@ namespace Contao\CoreBundle\Framework;
 
 use Contao\ClassLoader;
 use Contao\Config;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
 use Contao\CoreBundle\Exception\IncompleteInstallationException;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\Input;
 use Contao\RequestToken;
 use Contao\System;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -38,7 +36,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class ContaoFramework implements ContaoFrameworkInterface
 {
-    use ContainerAwareTrait;
+    use ScopeAwareTrait;
 
     /**
      * @var bool
@@ -193,7 +191,7 @@ class ContaoFramework implements ContaoFrameworkInterface
         }
 
         // Define the login status constants in the back end (see #4099, #5279)
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
+        if (!$this->isFrontendScope()) {
             define('BE_USER_LOGGED_IN', false);
             define('FE_USER_LOGGED_IN', false);
         }
@@ -209,11 +207,11 @@ class ContaoFramework implements ContaoFrameworkInterface
      */
     private function getMode()
     {
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)) {
+        if ($this->isBackendScope()) {
             return 'BE';
         }
 
-        if ($this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)) {
+        if ($this->isFrontendScope()) {
             return 'FE';
         }
 

--- a/src/Framework/ScopeAwareTrait.php
+++ b/src/Framework/ScopeAwareTrait.php
@@ -49,7 +49,7 @@ trait ScopeAwareTrait
     }
 
     /**
-     * Checks whether the request is a Contao front end master request
+     * Checks whether the request is a Contao front end master request.
      *
      * @param KernelEvent $event The HttpKernel event
      *
@@ -105,7 +105,7 @@ trait ScopeAwareTrait
 
         $request = $this->container->get('request_stack')->getCurrentRequest();
 
-        if (null === $request && !$request->attributes->has('_scope')) {
+        if (null === $request || !$request->attributes->has('_scope')) {
             return false;
         }
 

--- a/src/Framework/ScopeAwareTrait.php
+++ b/src/Framework/ScopeAwareTrait.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\EventListener;
+namespace Contao\CoreBundle\Framework;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -19,9 +19,6 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  * @author Leo Feyer <https://github.com/leofeyer>
- *
- * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
- *             Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.
  */
 trait ScopeAwareTrait
 {
@@ -36,12 +33,6 @@ trait ScopeAwareTrait
      */
     protected function isContaoMasterRequest(KernelEvent $event)
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $event->isMasterRequest() && $this->isContaoScope();
     }
 
@@ -54,12 +45,6 @@ trait ScopeAwareTrait
      */
     protected function isBackendMasterRequest(KernelEvent $event)
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $event->isMasterRequest() && $this->isBackendScope();
     }
 
@@ -72,12 +57,6 @@ trait ScopeAwareTrait
      */
     protected function isFrontendMasterRequest(KernelEvent $event)
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $event->isMasterRequest() && $this->isFrontendScope();
     }
 
@@ -88,12 +67,6 @@ trait ScopeAwareTrait
      */
     protected function isContaoScope()
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $this->isBackendScope() || $this->isFrontendScope();
     }
 
@@ -104,12 +77,6 @@ trait ScopeAwareTrait
      */
     protected function isBackendScope()
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $this->isScope(ContaoCoreBundle::SCOPE_BACKEND);
     }
 
@@ -120,12 +87,6 @@ trait ScopeAwareTrait
      */
     protected function isFrontendScope()
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         return $this->isScope(ContaoCoreBundle::SCOPE_FRONTEND);
     }
 
@@ -138,12 +99,6 @@ trait ScopeAwareTrait
      */
     private function isScope($scope)
     {
-        @trigger_error(
-            'Using Contao\CoreBundle\EventListener\ScopeAwareTrait has been deprecated and will no longer work in '
-                . 'Contao 5.0. Use Contao\CoreBundle\Framework\ScopeAwareTrait instead.',
-            E_USER_DEPRECATED
-        );
-
         if (null === $this->container) {
             return false;
         }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -62,14 +62,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
 
-    contao.listener.container_scope:
-        class: Contao\CoreBundle\EventListener\ContainerScopeListener
-        arguments:
-            - "@service_container"
-        tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 30 }
-            - { name: kernel.event_listener, event: kernel.finish_request, method: onKernelFinishRequest, priority: -254 }
-
     contao.listener.exception_converter:
         class: Contao\CoreBundle\EventListener\ExceptionConverterListener
         tags:

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -10,11 +10,10 @@
 
 namespace Contao\CoreBundle\Security;
 
-use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\CoreBundle\Security\Authentication\ContaoToken;
 use Contao\User;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -30,7 +29,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthenticatorInterface
 {
-    use ContainerAwareTrait;
+    use ScopeAwareTrait;
 
     /**
      * Creates an authentication token.
@@ -111,8 +110,6 @@ class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthentic
             throw new \LogicException('The service container has not been set.');
         }
 
-        return !$this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND)
-            && !$this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND)
-        ;
+        return !$this->isContaoScope();
     }
 }

--- a/src/Security/User/ContaoUserProvider.php
+++ b/src/Security/User/ContaoUserProvider.php
@@ -11,8 +11,8 @@
 namespace Contao\CoreBundle\Security\User;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\FrontendUser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -27,10 +27,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class ContaoUserProvider implements UserProviderInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    use ScopeAwareTrait;
 
     /**
      * @var ContaoFrameworkInterface
@@ -96,7 +93,7 @@ class ContaoUserProvider implements UserProviderInterface
      */
     private function isFrontendUsername($username)
     {
-        return 'frontend' === $username && $this->container->isScopeActive(ContaoCoreBundle::SCOPE_FRONTEND);
+        return 'frontend' === $username && $this->isFrontendScope();
     }
 
     /**
@@ -108,6 +105,6 @@ class ContaoUserProvider implements UserProviderInterface
      */
     private function isBackendUsername($username)
     {
-        return 'backend' === $username && $this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND);
+        return 'backend' === $username && $this->isBackendScope();
     }
 }

--- a/tests/DataCollector/ContaoDataCollectorTest.php
+++ b/tests/DataCollector/ContaoDataCollectorTest.php
@@ -39,10 +39,10 @@ class ContaoDataCollectorTest extends TestCase
      */
     public function testCollectInBackendScope()
     {
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
-        $collector = new ContaoDataCollector($container, ['contao/core-bundle' => '4.0.0']);
+        $collector = new ContaoDataCollector(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND),
+            ['contao/core-bundle' => '4.0.0']
+        );
 
         $GLOBALS['TL_DEBUG'] = [
             'classes_aliased' => ['ContentText <span>Contao\ContentText</span>'],
@@ -90,10 +90,7 @@ class ContaoDataCollectorTest extends TestCase
      */
     public function testCollectInFrontendScope()
     {
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $collector = new ContaoDataCollector($container, []);
+        $collector = new ContaoDataCollector($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND), []);
 
         $layout = new \stdClass();
         $layout->name = 'Default';

--- a/tests/EventListener/ContainerScopeListenerTest.php
+++ b/tests/EventListener/ContainerScopeListenerTest.php
@@ -28,6 +28,18 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!method_exists('Symfony\Component\DependencyInjection\Container', 'enterScope')) {
+            $this->markTestSkipped('Container scopes are not supported in this Symfony version.');
+        }
+    }
+
+    /**
      * Tests the object instantiation.
      */
     public function testInstantiation()
@@ -103,6 +115,8 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Tests the onKernelController method without the container scope.
+     *
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
     public function testWithoutContainerScope()
     {
@@ -116,8 +130,5 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
-
-        $this->assertFalse($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
-        $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
     }
 }

--- a/tests/EventListener/ContainerScopeListenerTest.php
+++ b/tests/EventListener/ContainerScopeListenerTest.php
@@ -55,15 +55,15 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
     public function testOnKernelRequest()
     {
         $container = new ContainerBuilder();
-        $listener = new ContainerScopeListener($container);
+        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $request = new Request();
 
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
+        $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
+        $listener = new ContainerScopeListener($container);
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
@@ -76,18 +76,17 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
     public function testOnKernelFinishRequest()
     {
         $container = new ContainerBuilder();
-        $listener = new ContainerScopeListener($container);
+        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
+        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $request = new Request();
-        $response = new Response();
 
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener->onKernelFinishRequest(new FinishRequestEvent($kernel, $request, $response));
+        $listener = new ContainerScopeListener($container);
+        $listener->onKernelFinishRequest(new FinishRequestEvent($kernel, $request, new Response()));
 
         $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
         $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
@@ -99,15 +98,13 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
     public function testWithoutRequestScope()
     {
         $container = new ContainerBuilder();
-        $listener = new ContainerScopeListener($container);
+        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $request = new Request();
 
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-
-        $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $listener = new ContainerScopeListener($container);
+        $listener->onKernelRequest(new GetResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
         $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
@@ -121,14 +118,14 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
     public function testWithoutContainerScope()
     {
         $container = new ContainerBuilder();
-        $listener = new ContainerScopeListener($container);
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $request = new Request();
 
+        $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
+        $listener = new ContainerScopeListener($container);
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
     }
 }

--- a/tests/EventListener/ContainerScopeListenerTest.php
+++ b/tests/EventListener/ContainerScopeListenerTest.php
@@ -28,6 +28,11 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()
@@ -37,6 +42,10 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
         if (!method_exists('Symfony\Component\DependencyInjection\Container', 'enterScope')) {
             $this->markTestSkipped('Container scopes are not supported in this Symfony version.');
         }
+
+        $this->container = new ContainerBuilder();
+        $this->container->addScope(new Scope('request'));
+        $this->container->enterScope('request');
     }
 
     /**
@@ -44,7 +53,7 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInstantiation()
     {
-        $listener = new ContainerScopeListener(new ContainerBuilder());
+        $listener = new ContainerScopeListener($this->container);
 
         $this->assertInstanceOf('Contao\CoreBundle\EventListener\ContainerScopeListener', $listener);
     }
@@ -54,8 +63,7 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequest()
     {
-        $container = new ContainerBuilder();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND, 'request'));
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
@@ -63,11 +71,11 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = new ContainerScopeListener($container);
+        $listener = new ContainerScopeListener($this->container);
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
-        $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
-        $this->assertTrue($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertTrue($this->container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertTrue($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
     }
 
     /**
@@ -75,9 +83,8 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelFinishRequest()
     {
-        $container = new ContainerBuilder();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $this->container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND, 'request'));
+        $this->container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
@@ -85,11 +92,11 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = new ContainerScopeListener($container);
+        $listener = new ContainerScopeListener($this->container);
         $listener->onKernelFinishRequest(new FinishRequestEvent($kernel, $request, new Response()));
 
-        $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
-        $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertTrue($this->container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertFalse($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
     }
 
     /**
@@ -97,23 +104,20 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithoutRequestScope()
     {
-        $container = new ContainerBuilder();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND, 'request'));
 
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
 
-        $listener = new ContainerScopeListener($container);
+        $listener = new ContainerScopeListener($this->container);
         $listener->onKernelRequest(new GetResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST));
 
-        $this->assertTrue($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
-        $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertTrue($this->container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertFalse($this->container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
     }
 
     /**
      * Tests the onKernelController method without the container scope.
-     *
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
     public function testWithoutContainerScope()
     {
@@ -125,7 +129,10 @@ class ContainerScopeListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = new ContainerScopeListener($container);
+        $listener = new ContainerScopeListener($this->container);
         $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        $this->assertFalse($container->hasScope(ContaoCoreBundle::SCOPE_BACKEND));
+        $this->assertFalse($container->isScopeActive(ContaoCoreBundle::SCOPE_BACKEND));
     }
 }

--- a/tests/EventListener/OutputFromCacheListenerTest.php
+++ b/tests/EventListener/OutputFromCacheListenerTest.php
@@ -12,8 +12,7 @@ namespace Contao\CoreBundle\Test\EventListener;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\OutputFromCacheListener;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
+use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -25,7 +24,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
-class OutputFromCacheListenerTest extends \PHPUnit_Framework_TestCase
+class OutputFromCacheListenerTest extends TestCase
 {
     /**
      * @var ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
@@ -77,17 +76,15 @@ class OutputFromCacheListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request();
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new OutputFromCacheListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new OutputFromCacheListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -100,17 +97,15 @@ class OutputFromCacheListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request();
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new OutputFromCacheListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', 'invalid');
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new OutputFromCacheListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -123,12 +118,14 @@ class OutputFromCacheListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+
         $request = new Request();
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new OutputFromCacheListener($this->framework);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new OutputFromCacheListener($this->framework);
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());

--- a/tests/EventListener/RefererIdListenerTest.php
+++ b/tests/EventListener/RefererIdListenerTest.php
@@ -13,8 +13,6 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\RefererIdListener;
 use Contao\CoreBundle\Test\TestCase;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -23,6 +21,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * Tests the RefererIdListener class.
  *
  * @author Yanick Witschi <https:/github.com/toflar>
+ * @author Leo Feyer <https:/github.com/leofeyer>
  */
 class RefererIdListenerTest extends TestCase
 {
@@ -43,15 +42,14 @@ class RefererIdListenerTest extends TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+
         $request = new Request();
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
         $listener = new RefererIdListener($this->mockTokenManager());
-        $container = new Container();
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
-        $listener->setContainer($container);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($request->attributes->has('_contao_referer_id'));
@@ -65,15 +63,14 @@ class RefererIdListenerTest extends TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+
         $request = new Request();
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
         $listener = new RefererIdListener($this->mockTokenManager());
-        $container = new Container();
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $listener->setContainer($container);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($request->attributes->has('_contao_referer_id'));
@@ -86,15 +83,14 @@ class RefererIdListenerTest extends TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
+
         $request = new Request();
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
+
         $listener = new RefererIdListener($this->mockTokenManager());
-        $container = new Container();
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
-        $listener->setContainer($container);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($request->attributes->has('_contao_referer_id'));

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -66,12 +66,10 @@ class StoreRefererListenerTest extends TestCase
             ->willReturn($token)
         ;
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope($scope);
-
-        $session = $this->mockSession();
+        $container = $this->mockContainerWithContaoScopes($scope);
 
         // Set the current referer URLs
+        $session = $this->mockSession();
         $session->set('referer', $currentReferer);
 
         $listener = $this->getListener($session, $tokenStorage);
@@ -151,9 +149,7 @@ class StoreRefererListenerTest extends TestCase
             new Response()
         );
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
 
         $session

--- a/tests/EventListener/ToggleViewListenerTest.php
+++ b/tests/EventListener/ToggleViewListenerTest.php
@@ -12,8 +12,7 @@ namespace Contao\CoreBundle\Test\EventListener;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\ToggleViewListener;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
+use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +25,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
  *
  * @author Andreas Schempp <https:/github.com/aschempp>
  */
-class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
+class ToggleViewListenerTest extends TestCase
 {
     /**
      * @var ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
@@ -72,12 +71,13 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $request = new Request(['toggle_view' => 'desktop']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
 
+        $request = new Request(['toggle_view' => 'desktop']);
         $request->attributes->set('_route', 'dummy');
 
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -90,17 +90,15 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request(['toggle_view' => 'desktop']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -113,17 +111,15 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request();
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -136,17 +132,15 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request(['toggle_view' => 'desktop']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -160,17 +154,15 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request(['toggle_view' => 'mobile']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -184,17 +176,15 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request(['toggle_view' => 'foobar']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
-        $listener->setContainer($container);
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -208,23 +198,21 @@ class ToggleViewListenerTest extends \PHPUnit_Framework_TestCase
     {
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
-        $container = new Container();
+
         $request = new Request(['toggle_view' => 'desktop']);
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $listener = new ToggleViewListener($this->framework);
-        $reflection = new \ReflectionClass($request);
-
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         // Set the base path to /foo/bar
+        $reflection = new \ReflectionClass($request);
         $basePath = $reflection->getProperty('basePath');
         $basePath->setAccessible(true);
         $basePath->setValue($request, '/foo/bar');
 
-        $listener->setContainer($container);
+        $listener = new ToggleViewListener($this->framework);
+        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -64,9 +64,6 @@ class UserSessionListenerTest extends TestCase
             HttpKernelInterface::MASTER_REQUEST
         );
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope($scope);
-
         $session = $this->mockSession();
 
         $user = $this
@@ -99,7 +96,7 @@ class UserSessionListenerTest extends TestCase
         ;
 
         $listener = $this->getListener($session, null, $tokenStorage);
-        $listener->setContainer($container);
+        $listener->setContainer($this->mockContainerWithContaoScopes($scope));
         $listener->onKernelRequest($responseEvent);
 
         /* @var AttributeBagInterface $bag */
@@ -167,11 +164,8 @@ class UserSessionListenerTest extends TestCase
             ->willReturn($token)
         ;
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope($scope);
-
         $listener = $this->getListener($this->mockSession(), $connection, $tokenStorage);
-        $listener->setContainer($container);
+        $listener->setContainer($this->mockContainerWithContaoScopes($scope));
         $listener->onKernelResponse($responseEvent);
     }
 

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -53,9 +53,9 @@ class ContaoFrameworkTest extends TestCase
     {
         $request = new Request();
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
         $container->get('request_stack')->push($request);
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/index.html'));
@@ -89,11 +89,11 @@ class ContaoFrameworkTest extends TestCase
     {
         $request = new Request();
         $request->attributes->set('_route', 'dummy');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
         $request->attributes->set('_contao_referer_id', 'foobar');
         $request->setLocale('de');
 
         $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/contao/install'));
@@ -124,7 +124,6 @@ class ContaoFrameworkTest extends TestCase
     public function testWithoutRequest()
     {
         $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
         $container->set('request_stack', new RequestStack());
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/contao/install'));
@@ -139,7 +138,7 @@ class ContaoFrameworkTest extends TestCase
         $this->assertTrue(defined('BE_USER_LOGGED_IN'));
         $this->assertTrue(defined('FE_USER_LOGGED_IN'));
         $this->assertTrue(defined('TL_PATH'));
-        $this->assertEquals('BE', TL_MODE);
+        $this->assertNull(TL_MODE);
         $this->assertEquals($this->getRootDir(), TL_ROOT);
         $this->assertNull(TL_REFERER_ID);
         $this->assertEquals('console', TL_SCRIPT);
@@ -169,8 +168,8 @@ class ContaoFrameworkTest extends TestCase
         $this->assertTrue(defined('TL_ROOT'));
         $this->assertTrue(defined('TL_REFERER_ID'));
         $this->assertTrue(defined('TL_SCRIPT'));
-        $this->assertFalse(defined('BE_USER_LOGGED_IN'));
-        $this->assertFalse(defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('BE_USER_LOGGED_IN'));
+        $this->assertTrue(defined('FE_USER_LOGGED_IN'));
         $this->assertTrue(defined('TL_PATH'));
         $this->assertNull(TL_MODE);
         $this->assertEquals($this->getRootDir(), TL_ROOT);
@@ -189,8 +188,7 @@ class ContaoFrameworkTest extends TestCase
         $request = new Request();
         $request->attributes->set('_contao_referer_id', 'foobar');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
         $container->setParameter('contao.csrf_token_name', 'dummy_token');
         $container->set('security.csrf.token_manager', new CsrfTokenManager());
@@ -241,8 +239,7 @@ class ContaoFrameworkTest extends TestCase
         $request->attributes->set('_route', 'dummy');
         $request->attributes->set('_contao_referer_id', 'foobar');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/contao/install'));
@@ -277,8 +274,7 @@ class ContaoFrameworkTest extends TestCase
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foobar');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $framework = $this->mockContaoFramework(
@@ -304,8 +300,7 @@ class ContaoFrameworkTest extends TestCase
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'invalid');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $rtAdapter = $this
@@ -350,8 +345,7 @@ class ContaoFrameworkTest extends TestCase
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foobar');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $rtAdapter = $this
@@ -393,8 +387,7 @@ class ContaoFrameworkTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', 'dummy');
 
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
+        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $container->get('request_stack')->push($request);
 
         $configAdapter = $this

--- a/tests/Security/ContaoAuthenticatorTest.php
+++ b/tests/Security/ContaoAuthenticatorTest.php
@@ -57,11 +57,8 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testAuthenticateToken()
     {
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $authenticator = new ContaoAuthenticator();
-        $authenticator->setContainer($container);
+        $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
 
         $provider = $this->mockUserProvider();
 
@@ -88,11 +85,8 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testAuthenticateInvalidToken()
     {
-        $container = $this->mockContainerWithContaoScopes();
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
         $authenticator = new ContaoAuthenticator();
-        $authenticator->setContainer($container);
+        $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $authenticator->authenticateToken(new PreAuthenticatedToken('foo', 'bar', 'console'), $this->mockUserProvider(), 'console');
     }
 

--- a/tests/Security/User/ContaoUserProviderTest.php
+++ b/tests/Security/User/ContaoUserProviderTest.php
@@ -13,6 +13,7 @@ namespace Contao\CoreBundle\Test\Security\Authentication;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Security\User\ContaoUserProvider;
+use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\Security\Core\User\User;
@@ -23,7 +24,7 @@ use Symfony\Component\Security\Core\User\User;
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
  */
-class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
+class ContaoUserProviderTest extends TestCase
 {
     /**
      * @var ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
@@ -62,11 +63,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadUserBackend()
     {
-        $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_BACKEND);
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND),
+            $this->framework
+        );
 
         $this->assertInstanceOf('Contao\BackendUser', $provider->loadUserByUsername('backend'));
     }
@@ -79,11 +79,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadUserFrontend()
     {
-        $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND),
+            $this->framework
+        );
 
         $this->assertInstanceOf('Contao\FrontendUser', $provider->loadUserByUsername('frontend'));
     }
@@ -95,11 +94,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadWithInvalidScope()
     {
-        $container = new Container();
-        $container->addScope(new Scope('request'));
-        $container->enterScope('request');
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes('invalid'),
+            $this->framework
+        );
 
         $provider->loadUserByUsername('frontend');
     }
@@ -111,11 +109,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadUnsupportedUsername()
     {
-        $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND),
+            $this->framework
+        );
 
         $provider->loadUserByUsername('foo');
     }
@@ -127,11 +124,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testRefreshUser()
     {
-        $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND),
+            $this->framework
+        );
 
         $provider->refreshUser(new User('foo', 'bar'));
     }
@@ -141,11 +137,10 @@ class ContaoUserProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testSupportsClass()
     {
-        $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
-        $container->enterScope(ContaoCoreBundle::SCOPE_FRONTEND);
-
-        $provider = new ContaoUserProvider($container, $this->framework);
+        $provider = new ContaoUserProvider(
+            $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND),
+            $this->framework
+        );
 
         $this->assertTrue($provider->supportsClass('Contao\FrontendUser'));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,6 @@
 namespace Contao\CoreBundle\Test;
 
 use Contao\CoreBundle\Config\ResourceFinder;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Session\Attribute\ArrayAttributeBag;
@@ -180,13 +179,13 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * Mocks a container with scopes.
      *
-     * @return Container|\PHPUnit_Framework_MockObject_MockObject The container object
+     * @param string|null $scope An optional scope
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Container The container object
      */
-    protected function mockContainerWithContaoScopes()
+    protected function mockContainerWithContaoScopes($scope = null)
     {
         $container = new Container();
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_BACKEND));
-        $container->addScope(new Scope(ContaoCoreBundle::SCOPE_FRONTEND));
         $container->setParameter('kernel.root_dir', $this->getRootDir());
         $container->setParameter('kernel.cache_dir', $this->getCacheDir());
         $container->setParameter('kernel.debug', false);
@@ -205,6 +204,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         $request = new Request();
         $request->server->set('REMOTE_ADDR', '123.456.789.0');
+
+        if (null !== $scope) {
+            $request->attributes->set('_scope', $scope);
+        }
 
         $requestStack = new RequestStack();
         $requestStack->push($request);


### PR DESCRIPTION
Stop using container scopes but keep using the `_scope` attribute until we have agreed on another solution. Also, only register the container scope listener in Symfony 2.