### PR TITLE
[WIP] Autoloading of system/modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/yaml": "~2.8|~3.0",
         "sensio/framework-extra-bundle": "^3.0.2",
+        "mmoreram/symfony-bundle-dependencies": "~1.2",
         "psr/log": "~1.0",
         "twig/twig": "~1.20",
         "doctrine/doctrine-bundle": "^1.5.2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/yaml": "~2.8|~3.0",
         "sensio/framework-extra-bundle": "^3.0.2",
-        "mmoreram/symfony-bundle-dependencies": "~1.2",
+        "mmoreram/symfony-bundle-dependencies": "~1.1",
         "psr/log": "~1.0",
         "twig/twig": "~1.20",
         "doctrine/doctrine-bundle": "^1.5.2",

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -32,22 +32,6 @@ class ContaoCoreBundle extends Bundle implements DependentBundleInterface
     const SCOPE_FRONTEND = 'frontend';
 
     /**
-     * Register class loader for generated bundle names.
-     *
-     * @param KernelInterface $kernel
-     */
-    public function __construct(KernelInterface $kernel = null)
-    {
-        global $loader;
-
-        if (null === $kernel || !$loader instanceof ClassLoader) {
-            return;
-        }
-
-        $loader->add('Contao\CoreBundle\HttpKernel\Bundle', $kernel->getCacheDir() . '/contao/bundles');
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getContainerExtension()

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle;
 
+use Composer\Autoload\ClassLoader;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
@@ -29,6 +30,22 @@ class ContaoCoreBundle extends Bundle implements DependentBundleInterface
 {
     const SCOPE_BACKEND = 'backend';
     const SCOPE_FRONTEND = 'frontend';
+
+    /**
+     * Register class loader for generated bundle names.
+     *
+     * @param KernelInterface $kernel
+     */
+    public function __construct(KernelInterface $kernel = null)
+    {
+        global $loader;
+
+        if (null === $kernel || !$loader instanceof ClassLoader) {
+            return;
+        }
+
+        $loader->add('Contao\CoreBundle\HttpKernel\Bundle', $kernel->getCacheDir() . '/contao/bundles');
+    }
 
     /**
      * {@inheritdoc}

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -13,9 +13,11 @@ namespace Contao\CoreBundle;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
 use Patchwork\Utf8\Bootup;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Configures the Contao core bundle.
@@ -23,7 +25,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
  */
-class ContaoCoreBundle extends Bundle
+class ContaoCoreBundle extends Bundle implements DependentBundleInterface
 {
     const SCOPE_BACKEND = 'backend';
     const SCOPE_FRONTEND = 'frontend';
@@ -56,5 +58,20 @@ class ContaoCoreBundle extends Bundle
         );
 
         $container->addCompilerPass(new AddResourcesPathsPass());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Symfony\Bundle\SecurityBundle\SecurityBundle',
+            'Symfony\Bundle\TwigBundle\TwigBundle',
+            'Symfony\Bundle\MonologBundle\MonologBundle',
+            'Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+        ];
     }
 }

--- a/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
+++ b/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
@@ -41,7 +41,7 @@ class AddResourcesPathsPass implements CompilerPassInterface
         $rootDir = dirname($container->getParameter('kernel.root_dir'));
 
         foreach ($container->getParameter('kernel.bundles') as $name => $class) {
-            if ('Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle' === $class) {
+            if (is_a($class, 'Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle', true)) {
                 $paths[] = sprintf('%s/system/modules/%s', $rootDir, $name);
             } elseif (null !== ($path = $this->getResourcesPathFromClassName($class))) {
                 $paths[] = $path;

--- a/src/HttpKernel/Bundle/ContaoModuleAutoloadBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleAutoloadBundle.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\HttpKernel\Bundle;
+
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Automatically register all legacy modules as dependencies.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+final class ContaoModuleAutoloadBundle extends Bundle implements DependentBundleInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        $kernelDir  = $kernel->getRootDir();
+        $bundles    = [];
+
+        foreach (static::getContaoModules(dirname($kernelDir)) as $module) {
+            $bundles[] = ['Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle', [$module, $kernelDir]];
+        }
+
+        return $bundles;
+    }
+
+    /**
+     * Find Contao modules in system/modules that are not marked as skippable
+     *
+     * @param string $contaoRoot
+     *
+     * @return array
+     */
+    private static function getContaoModules($contaoRoot)
+    {
+        $modules = [];
+
+        foreach (scandir($contaoRoot . '/system/modules') as $dir) {
+            if ('.' === $dir || '..' === $dir) {
+                continue;
+            }
+
+            if (is_dir($contaoRoot . '/system/modules/' . $dir)
+                && !file_exists($contaoRoot . '/system/modules/' . $dir . '/.skip')
+            ) {
+                $modules[] = $dir;
+            }
+        }
+
+        return $modules;
+    }
+}

--- a/src/HttpKernel/Bundle/ContaoModuleAutoloadBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleAutoloadBundle.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\HttpKernel\Bundle;
 
 use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -22,15 +23,27 @@ use Symfony\Component\HttpKernel\KernelInterface;
 final class ContaoModuleAutoloadBundle extends Bundle implements DependentBundleInterface
 {
     /**
+     * @var string
+     */
+    public static $cacheDir;
+
+    /**
      * @inheritdoc
      */
     public static function getBundleDependencies(KernelInterface $kernel)
     {
+        if (null === static::$cacheDir) {
+            static::$cacheDir = $kernel->getCacheDir() . '/contao/bundles';
+        }
+
         $kernelDir  = $kernel->getRootDir();
         $bundles    = [];
 
+        $generator = new ModuleBundleGenerator();
+        $generator->generateBundles(static::$cacheDir, $kernelDir);
+
         foreach (static::getContaoModules(dirname($kernelDir)) as $module) {
-            $bundles[] = ['Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle', [$module, $kernelDir]];
+            $bundles[] = sprintf('Contao\CoreBundle\HttpKernel\Bundle\%sModuleBundle', Container::camelize($module));
         }
 
         return $bundles;

--- a/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\HttpKernel\Bundle;
 
 use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -20,8 +21,24 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Andreas Schempp <https://github.com/aschempp>
  */
-final class ContaoModuleBundle extends Bundle implements DependentBundleInterface
+class ContaoModuleBundle extends Bundle implements DependentBundleInterface
 {
+    /**
+     * Old module names
+     * @var array
+     */
+    private static $moduleMapping =
+        [
+            'core'       => 'Contao\CoreBundle\ContaoCoreBundle',
+            'calendar'   => 'Contao\CalendarBundle\ContaoCalendarBundle',
+            'comments'   => 'Contao\CommentsBundle\ContaoCommentsBundle',
+            'faq'        => 'Contao\FaqBundle\ContaoFaqBundle',
+            'listing'    => 'Contao\ListingBundle\ContaoListingBundle',
+            'news'       => 'Contao\NewsBundle\ContaoNewsBundle',
+            'newsletter' => 'Contao\NewsletterBundle\ContaoNewsletterBundle',
+        ];
+
+
     /**
      * Sets the module name and application root directory.
      *
@@ -38,6 +55,10 @@ final class ContaoModuleBundle extends Bundle implements DependentBundleInterfac
         if (!is_dir($this->path)) {
             throw new \LogicException('The module folder "system/modules/' . $this->name . '" does not exist.');
         }
+
+        if (file_exists($this->path . '/.skip')) {
+            throw new \RuntimeException('The module "system/modules/' . $this->name . '" as been disabled.');
+        }
     }
 
     /**
@@ -48,5 +69,70 @@ final class ContaoModuleBundle extends Bundle implements DependentBundleInterfac
         return [
             'Contao\CoreBundle\ContaoCoreBundle',
         ];
+    }
+
+    /**
+     * @param string          $module
+     * @param KernelInterface $kernel
+     *
+     * @return array
+     *
+     * @throws \RuntimeException if a required module is not installed
+     */
+    protected static function getModuleDependencies($module, KernelInterface $kernel)
+    {
+        $bundles = [];
+        $requires = self::getAutoloadRequires(dirname($kernel->getRootDir()) . '/system/modules/' . $module);
+
+        foreach ($requires as $name) {
+            $moduleClass = self::convertModuleToClass($name);
+
+            if (!class_exists($moduleClass)) {
+                if (0 === strpos($name, '*')) {
+                    continue;
+                }
+
+                throw new \RuntimeException(
+                    sprintf('Contao module "%s" is required by "%s" but not installed.', $name, $module)
+                );
+            }
+
+            $bundles[] = $moduleClass;
+        }
+
+        return $bundles;
+    }
+
+    /**
+     * @param string $moduleDir
+     *
+     * @return array
+     */
+    private static function getAutoloadRequires($moduleDir)
+    {
+        $requires = ['core'];
+        $iniFile  = $moduleDir . '/config/autoload.ini';
+
+        if (!file_exists($iniFile)) {
+            return $requires;
+        }
+
+        $autoload = parse_ini_file($iniFile, true);
+
+        if (false === $autoload || !isset($autoload['requires']) || !is_array($autoload['requires'])) {
+            return $requires;
+        }
+
+        return array_unique(array_merge($requires, $autoload['requires']));
+    }
+
+
+    private static function convertModuleToClass($name)
+    {
+        if (array_key_exists($name, self::$moduleMapping)) {
+            return self::$moduleMapping[$name];
+        }
+
+        return 'Contao\CoreBundle\HttpKernel\Bundle\\' . Container::camelize($name);
     }
 }

--- a/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -57,7 +57,7 @@ class ContaoModuleBundle extends Bundle implements DependentBundleInterface
         }
 
         if (file_exists($this->path . '/.skip')) {
-            throw new \RuntimeException('The module "system/modules/' . $this->name . '" as been disabled.');
+            throw new \RuntimeException('The module "system/modules/' . $this->name . '" has been disabled.');
         }
     }
 
@@ -126,7 +126,13 @@ class ContaoModuleBundle extends Bundle implements DependentBundleInterface
         return array_unique(array_merge($requires, $autoload['requires']));
     }
 
-
+    /**
+     * Returns FQCN from module folder and maps legacy core module names.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
     private static function convertModuleToClass($name)
     {
         if (array_key_exists($name, self::$moduleMapping)) {

--- a/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -10,14 +10,17 @@
 
 namespace Contao\CoreBundle\HttpKernel\Bundle;
 
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Allows to register legacy Contao modules as bundle.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
+ * @author Andreas Schempp <https://github.com/aschempp>
  */
-final class ContaoModuleBundle extends Bundle
+final class ContaoModuleBundle extends Bundle implements DependentBundleInterface
 {
     /**
      * Sets the module name and application root directory.
@@ -35,5 +38,15 @@ final class ContaoModuleBundle extends Bundle
         if (!is_dir($this->path)) {
             throw new \LogicException('The module folder "system/modules/' . $this->name . '" does not exist.');
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [
+            'Contao\CoreBundle\ContaoCoreBundle',
+        ];
     }
 }

--- a/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -11,7 +11,6 @@
 namespace Contao\CoreBundle\HttpKernel\Bundle;
 
 use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -23,22 +22,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class ContaoModuleBundle extends Bundle implements DependentBundleInterface
 {
-    /**
-     * Old module names
-     * @var array
-     */
-    private static $moduleMapping =
-        [
-            'core'       => 'Contao\CoreBundle\ContaoCoreBundle',
-            'calendar'   => 'Contao\CalendarBundle\ContaoCalendarBundle',
-            'comments'   => 'Contao\CommentsBundle\ContaoCommentsBundle',
-            'faq'        => 'Contao\FaqBundle\ContaoFaqBundle',
-            'listing'    => 'Contao\ListingBundle\ContaoListingBundle',
-            'news'       => 'Contao\NewsBundle\ContaoNewsBundle',
-            'newsletter' => 'Contao\NewsletterBundle\ContaoNewsletterBundle',
-        ];
-
-
     /**
      * Sets the module name and application root directory.
      *
@@ -85,7 +68,7 @@ class ContaoModuleBundle extends Bundle implements DependentBundleInterface
         $requires = self::getAutoloadRequires(dirname($kernel->getRootDir()) . '/system/modules/' . $module);
 
         foreach ($requires as $name) {
-            $moduleClass = self::convertModuleToClass($name);
+            $moduleClass = ModuleBundleGenerator::convertModuleToClass($name);
 
             if (!class_exists($moduleClass)) {
                 if (0 === strpos($name, '*')) {
@@ -124,21 +107,5 @@ class ContaoModuleBundle extends Bundle implements DependentBundleInterface
         }
 
         return array_unique(array_merge($requires, $autoload['requires']));
-    }
-
-    /**
-     * Returns FQCN from module folder and maps legacy core module names.
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    private static function convertModuleToClass($name)
-    {
-        if (array_key_exists($name, self::$moduleMapping)) {
-            return self::$moduleMapping[$name];
-        }
-
-        return 'Contao\CoreBundle\HttpKernel\Bundle\\' . Container::camelize($name) . 'ModuleBundle';
     }
 }

--- a/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -133,6 +133,6 @@ class ContaoModuleBundle extends Bundle implements DependentBundleInterface
             return self::$moduleMapping[$name];
         }
 
-        return 'Contao\CoreBundle\HttpKernel\Bundle\\' . Container::camelize($name);
+        return 'Contao\CoreBundle\HttpKernel\Bundle\\' . Container::camelize($name) . 'ModuleBundle';
     }
 }

--- a/src/HttpKernel/Bundle/ModuleBundleGenerator.php
+++ b/src/HttpKernel/Bundle/ModuleBundleGenerator.php
@@ -78,10 +78,9 @@ class ModuleBundleGenerator
 
 namespace Contao\CoreBundle\HttpKernel\Bundle;
 
-use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class $className extends ContaoModuleBundle implements DependentBundleInterface
+class $className extends ContaoModuleBundle
 {
     public function __construct()
     {

--- a/src/HttpKernel/Bundle/ModuleBundleGenerator.php
+++ b/src/HttpKernel/Bundle/ModuleBundleGenerator.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\HttpKernel\Bundle;
+
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Generates classes for Contao modules
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class ModuleBundleGenerator
+{
+
+    public function generateBundles($cacheDir, $rootDir, Filesystem $filesystem = null)
+    {
+        if (null === $filesystem) {
+            $filesystem = new Filesystem();
+        }
+
+        $filesystem->remove($cacheDir);
+        $filesystem->mkdir($cacheDir);
+
+        $modules = $this->getContaoModules(dirname($rootDir) . '/system/modules');
+
+        foreach ($modules as $module) {
+            $this->createBundleClass($module, $cacheDir, $rootDir);
+        }
+    }
+
+    /**
+     * Find Contao modules in system/modules that are not marked as skippable
+     *
+     * @param string $modulesDir
+     *
+     * @return array
+     */
+    private function getContaoModules($modulesDir)
+    {
+        $modules = [];
+
+        foreach (scandir($modulesDir) as $dir) {
+            if ('.' === $dir || '..' === $dir) {
+                continue;
+            }
+
+            if (is_dir($modulesDir . '/' . $dir)) {
+                $modules[] = $dir;
+            }
+        }
+
+        return $modules;
+    }
+
+    private function createBundleClass($module, $cacheDir, $rootDir)
+    {
+        $className = Container::camelize($module) . 'ModuleBundle';
+
+        $code = <<<CLASS
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\HttpKernel\Bundle;
+
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class $className extends ContaoModuleBundle implements DependentBundleInterface
+{
+    public function __construct()
+    {
+        parent::__construct('$module', '$rootDir');
+    }
+    
+    public static function getBundleDependencies(KernelInterface \$kernel)
+    {
+        return parent::getModuleDependencies('$module', \$kernel);
+    }
+}
+
+CLASS;
+
+        file_put_contents($cacheDir . '/' . $className . '.php', $code);
+    }
+}

--- a/src/HttpKernel/Bundle/ModuleBundleGenerator.php
+++ b/src/HttpKernel/Bundle/ModuleBundleGenerator.php
@@ -80,6 +80,9 @@ namespace Contao\CoreBundle\HttpKernel\Bundle;
 
 use Symfony\Component\HttpKernel\KernelInterface;
 
+/**
+ * Generated bundle class for Contao module in system/modules/$module
+ */
 class $className extends ContaoModuleBundle
 {
     public function __construct()


### PR DESCRIPTION
This is a very early draft to show autoloading of `system/modules` using https://github.com/mmoreram/symfony-bundle-dependencies

The great thing about this is that it allows for full flexibility for developers while providing easy installation for regular users. If you do not want bundle autoloading at all, simply do not use the trait. If you do not want autoloading of `system/modules`, simply do not load the `ContaoModuleAutoloadBundle`.

For a regular user though, this means using composer to install a legacy extension (like currently possible) will **automatically** enable it like in all previous Contao versions. I think that's a big step forward to the acceptance of Contao 4.
### Testing

The following changes to your installation are required to test this. I have added **one** module to `system/modules` and it was automatically loaded (see tasks about multiple modules).
1. Adjust your `composer json`
   
   ``` json
   "require": {
       "contao/core-bundle": "dev-bundle-dependencies as 4.2.9999"
   },
   "repositories": [
       {
           "type": "vcs",
           "url": "https://github.com/aschempp/contao-core-bundle.git"
       }
   ],
   "minimum-stability": "dev",
   "prefer-stable": true
   ```
2. Adjust your `AppKernel.php`
   
   ``` php
   public function registerBundles()
   {
       global $loader;
   
       if ($loader instanceof \Composer\Autoload\ClassLoader) {
           $loader->addPsr4('Contao\CoreBundle\HttpKernel\Bundle\\', $this->getCacheDir() . '/contao/bundles');
       }
   
       $bundles = [
           'Lexik\Bundle\MaintenanceBundle\LexikMaintenanceBundle',
           'Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle',
           'Contao\CoreBundle\ContaoCoreBundle',
           'Contao\CalendarBundle\ContaoCalendarBundle',
           'Contao\CommentsBundle\ContaoCommentsBundle',
           'Contao\FaqBundle\ContaoFaqBundle',
           'Contao\ListingBundle\ContaoListingBundle',
           'Contao\NewsBundle\ContaoNewsBundle',
           'Contao\NewsletterBundle\ContaoNewsletterBundle',
           'Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleAutoloadBundle',
       ];
   
       return $this->getBundleInstances($this, $bundles);
   }
   ```
3. Update composer dependencies (obviously)
### Open questions / tasks
- [x] `ContaoModuleBundle` should parse `autoload.ini` to add dependencies of a module. Probably restore our drafts from early 2015 to parse the ini-file dependencies (see https://github.com/contao/core-bundle/tree/feature/symfony2/src/Autoload).
- [x] Discuss if we should keep the core bundles (like `FrameworkBundle`) in the `AppKernel`. They **must** be in `ContaoCoreBundle` though, otherwise the order of loading would not be correct.
- [x] Check if the current dependency resolver library does correctly resolve multiple times the same class with different constructor arguments.
