### PR TITLE
Fix the pretty error screen exception handling

### DIFF
--- a/src/EventListener/ExceptionConverterListener.php
+++ b/src/EventListener/ExceptionConverterListener.php
@@ -51,14 +51,14 @@ class ExceptionConverterListener
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
-        $class = get_class($exception);
 
-        if (!isset($this->mapper[$class])) {
-            return;
-        }
-
-        if (null !== ($httpException = $this->convertToHttpException($exception, $this->mapper[$class]))) {
-            $event->setException($httpException);
+        foreach ($this->mapper as $origin => $dest) {
+            if ($exception instanceof $origin) {
+                if (null !== ($httpException = $this->convertToHttpException($exception, $dest))) {
+                    $event->setException($httpException);
+                }
+                break;
+            }
         }
     }
 

--- a/src/EventListener/PrettyErrorScreenListener.php
+++ b/src/EventListener/PrettyErrorScreenListener.php
@@ -232,10 +232,10 @@ class PrettyErrorScreenListener
      */
     private function getTemplateForException(\Exception $exception)
     {
-        $class = get_class($exception);
-
-        if (isset($this->mapper[$class])) {
-            return $this->mapper[$class];
+        foreach ($this->mapper as $class => $template) {
+            if ($exception instanceof $class) {
+                return $template;
+            }
         }
 
         return null;

--- a/tests/EventListener/ExceptionConverterListenerTest.php
+++ b/tests/EventListener/ExceptionConverterListenerTest.php
@@ -20,6 +20,7 @@ use Contao\CoreBundle\Exception\NoActivePageFoundException;
 use Contao\CoreBundle\Exception\NoLayoutSpecifiedException;
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Test\Fixtures\Exception\DerivedPageNotFoundException;
 use Contao\CoreBundle\Test\TestCase;
 use Lexik\Bundle\MaintenanceBundle\Exception\ServiceUnavailableException;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,6 +63,27 @@ class ExceptionConverterListenerTest extends TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', $exception);
         $this->assertInstanceOf('Contao\CoreBundle\Exception\AccessDeniedException', $exception->getPrevious());
+    }
+
+    /**
+     * Tests converting the derived PageNotFoundException exception.
+     */
+    public function testConvertDerivedPageNotFoundException()
+    {
+        $event = new GetResponseForExceptionEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            new DerivedPageNotFoundException()
+        );
+
+        $listener = new ExceptionConverterListener();
+        $listener->onKernelException($event);
+
+        $exception = $event->getException();
+
+        $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $exception);
+        $this->assertInstanceOf('Contao\CoreBundle\Exception\PageNotFoundException', $exception->getPrevious());
     }
 
     /**

--- a/tests/Fixtures/Exception/DerivedPageNotFoundException.php
+++ b/tests/Fixtures/Exception/DerivedPageNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Contao\CoreBundle\Test\Fixtures\Exception;
+
+use Contao\CoreBundle\Exception\PageNotFoundException;
+
+class DerivedPageNotFoundException extends PageNotFoundException
+{
+}


### PR DESCRIPTION
Consider the following code:

```php
// NewsNotFoundException.php
class NewsNotFoundException extends PageNotFoundException {}

// NewsListModule.php
if ($newsModel === null) {
    throw new NewsNotFoundException();
}
```

Normally this would result in a pretty 500 screen message because you checked strictly for the exception class name. I think you should check for the instanceof instead so we can define our own exceptions that extend ```PageNotFoundException``` and thus result in pretty 404 screen message.

Basically the issue was in ```ExceptionConverterListener``` but I have also found similar snippet in ```PrettyErrorScreenListener```.