### PR TITLE
[RTM] Added PaletteManipulator

### DIFF
--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -1,0 +1,300 @@
+<?php
+
+/*
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\DataContainer;
+
+class PaletteManipulator
+{
+    const POSITION_PREPEND       = 'prepend';
+    const POSITION_APPEND        = 'append';
+    const POSITION_BEFORE_FIELD  = 'before_field';
+    const POSITION_AFTER_FIELD   = 'after_field';
+    const POSITION_BEFORE_LEGEND = 'before_legend';
+    const POSITION_AFTER_LEGEND  = 'after_legend';
+
+    /**
+     * @var string
+     */
+    private $position;
+
+    /**
+     * @var array
+     */
+    private $new;
+
+    /**
+     * @var string
+     */
+    private $target;
+
+    /**
+     * @var PaletteManipulator
+     */
+    private $fallback;
+
+    /**
+     * Constructor.
+     *
+     * @param string $position
+     * @param array  $new
+     * @param string $target
+     */
+    public function __construct($position, array $new, $target)
+    {
+        $this->position = $position;
+        $this->new      = $new;
+        $this->target   = $target;
+    }
+
+    /**
+     * @param PaletteManipulator $fallback
+     *
+     * @return $this
+     */
+    public function setFallback(PaletteManipulator $fallback)
+    {
+        $this->fallback = $fallback;
+
+        return $this;
+    }
+
+
+    public function applyTo($palette)
+    {
+        $config = $this->explode($palette);
+
+        switch ($this->position) {
+            case self::POSITION_PREPEND:
+                $result = $this->addFields($config, $palette, $this->target, 0);
+                break;
+
+            case self::POSITION_APPEND:
+                $result = $this->addFields($config, $palette, $this->target, count($config));
+                break;
+
+            case self::POSITION_BEFORE_FIELD:
+                $result = $this->addFields($config, $palette, $this->findPaletteForField($config, $this->target), 0, $this->target);
+                break;
+
+            case self::POSITION_AFTER_FIELD:
+                $result = $this->addFields($config, $palette, $this->findPaletteForField($config, $this->target), 1, $this->target);
+                break;
+
+            case self::POSITION_BEFORE_LEGEND:
+                $result = $this->addLegend($config, $palette, 0);
+                break;
+
+            case self::POSITION_AFTER_LEGEND:
+                $result = $this->addLegend($config, $palette, 1);
+                break;
+
+            default:
+                throw new \InvalidArgumentException(sprintf('Unknown position "%s"', $this->position));
+        }
+
+        return false === $result ? $palette : $this->implode($config);
+    }
+
+    /**
+     * @param string $palette
+     *
+     * @return array
+     */
+    private function explode($palette)
+    {
+        $legendCount = 0;
+        $legendMap   = [];
+
+        foreach (array_map('trim', explode(';', $palette)) as $group) {
+            $legend = null;
+            $hide   = false;
+            $fields = array_map('trim', explode(',', $group));
+
+            if (preg_match('#\{(.+?)(:hide)?\}#', $fields[0], $matches)) {
+                $legend = $matches[1];
+                $hide   = count($matches) > 2 && ':hide' === $matches[2];
+                array_shift($fields);
+            } else {
+                $legend = $legendCount++;
+            }
+
+            $legendMap[$legend] = [
+                'fields' => $fields,
+                'hide'   => $hide,
+            ];
+        }
+
+        return $legendMap;
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return string
+     */
+    private function implode(array $config)
+    {
+        $palette = '';
+
+        foreach ($config as $legend => $group) {
+            if ('' !== $palette) {
+                $palette .= ';';
+            }
+
+            if (!is_int($legend)) {
+                $palette .= '{' . $legend . (isset($group['hide']) && $group['hide'] ? ':hide' : '') . '},';
+            }
+
+            $palette .= implode(',', $group['fields']);
+        }
+
+        return $palette;
+    }
+
+    /**
+     * @param array  $config
+     * @param string $palette
+     * @param string $legend
+     * @param int    $offset
+     */
+    private function addFields(array &$config, &$palette, $legend, $offset, $target = null)
+    {
+        // If legend does not exist, try to apply fallback or append new legend to the end
+        if (false === $legend || !isset($config[$legend])) {
+            if ($this->applyFallback($palette)) {
+                return false;
+            }
+            
+            $config[$legend] = ['fields' => $this->new];
+
+            return true;
+        }
+
+        if (null !== $target) {
+            $offset = array_search($this->target, $config[$legend]['fields'], true) + $offset;
+        }
+        
+        array_splice($config[$legend]['fields'], $offset,0, $this->new);
+        
+        return true;
+    }
+
+    /**
+     * @param array  $config
+     * @param string $palette
+     * @param int    $offset
+     */
+    private function addLegend(array &$config, &$palette, $offset)
+    {
+        if (!isset($config[$this->target])) {
+            if ($this->applyFallback($palette)) {
+                return false;
+            }
+
+            foreach ($this->new as $legend => $group) {
+                $config[$legend] = $group;
+            }
+
+            return true;
+        }
+
+        $offset = array_search($this->target, array_keys($config), true) + $offset;
+
+        $before = array_splice($config, 0, $offset);
+
+        $config = $before + $this->new + $config;
+
+        return true;
+    }
+
+    /**
+     * @param array  $config
+     * @param string $field
+     *
+     * @return string|bool
+     */
+    private function findPaletteForField(array $config, $field)
+    {
+        foreach ($config as $legend => $group) {
+            if (in_array($field, $group['fields'], true)) {
+                return $legend;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $palette
+     *
+     * @return bool
+     */
+    private function applyFallback(&$palette)
+    {
+        if (null === $this->fallback) {
+            return false;
+        }
+
+        $palette = $this->fallback->applyTo($palette);
+
+        return true;
+    }
+
+
+    public static function prepend($legend, $new)
+    {
+        return new static(self::POSITION_PREPEND, (array) $new, $legend);
+    }
+
+    public static function append($legend, $new)
+    {
+        return new static(self::POSITION_APPEND, (array) $new, $legend);
+    }
+
+    public static function beforeField($field, $new)
+    {
+        return new static(self::POSITION_BEFORE_FIELD, (array) $new, $field);
+    }
+
+    public static function afterField($field, $new)
+    {
+        return new static(self::POSITION_AFTER_FIELD, (array) $new, $field);
+    }
+
+    public static function beforeLegend($beforeLegend, $name, $new, $hide = false)
+    {
+        return new static(
+            self::POSITION_BEFORE_LEGEND,
+            [
+                $name => [
+                    'fields' => (array) $new,
+                    'hide'   => $hide
+                ]
+            ],
+            $beforeLegend,
+            null
+        );
+    }
+
+    public static function afterLegend($afterLegend, $name, $new, $hide = false)
+    {
+        return new static(
+            self::POSITION_AFTER_LEGEND,
+            [
+                $name => [
+                    'fields' => (array) $new,
+                    'hide'   => $hide
+                ]
+            ],
+            $afterLegend,
+            null
+        );
+    }
+}

--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -10,105 +10,181 @@
 
 namespace Contao\CoreBundle\DataContainer;
 
+/**
+ * PaletteManipulator is a tool to add fields and legends to DCA palettes.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
 class PaletteManipulator
 {
-    const POSITION_PREPEND       = 'prepend';
-    const POSITION_APPEND        = 'append';
-    const POSITION_BEFORE_FIELD  = 'before_field';
-    const POSITION_AFTER_FIELD   = 'after_field';
-    const POSITION_BEFORE_LEGEND = 'before_legend';
-    const POSITION_AFTER_LEGEND  = 'after_legend';
+    const POSITION_PREPEND = 'prepend';
+    const POSITION_APPEND  = 'append';
+    const POSITION_BEFORE  = 'before';
+    const POSITION_AFTER   = 'after';
+
+    private $legends = [];
+    private $fields  = [];
 
     /**
-     * @var string
-     */
-    private $position;
-
-    /**
-     * @var array
-     */
-    private $new;
-
-    /**
-     * @var string
-     */
-    private $target;
-
-    /**
-     * @var PaletteManipulator
-     */
-    private $fallback;
-
-    /**
-     * Constructor.
+     * Adds a new legend into the palette.
+     * If the legend already exists, nothing will be changed on the palette.
      *
-     * @param string $position
-     * @param array  $new
-     * @param string $target
-     */
-    public function __construct($position, array $new, $target)
-    {
-        $this->position = $position;
-        $this->new      = $new;
-        $this->target   = $target;
-    }
-
-    /**
-     * @param PaletteManipulator $fallback
+     * @param string       $name     Name of the new legend.
+     * @param string|array $parent   The name of the relative legend in regards to position.
+     *                               If value is an array, each legend will be tried, first wins.
+     * @param string       $position Where to place the new legend.
+     * @param bool         $hide     If the new legend should be collapsed by default.
      *
      * @return $this
+     *
+     * @throws \InvalidArgumentException If $position or $fallbackPosition is invalid.
      */
-    public function setFallback(PaletteManipulator $fallback)
+    public function addLegend($name, $parent, $position = self::POSITION_AFTER, $hide = false)
     {
-        $this->fallback = $fallback;
+        $this->validatePosition($position);
+
+        $this->legends[] = [
+            'name'     => $name,
+            'parents'  => (array) $parent,
+            'position' => $position,
+            'hide'     => (bool) $hide
+        ];
 
         return $this;
     }
 
+    /**
+     * Adds a new field to the palette.
+     * If position is PREPEND or APPEND, pass a legend as parent. Otherwise pass a field name.
+     *
+     * @param string|array          $name             Name of the new field. Can be an array to add multiple fields.
+     * @param string|array          $parent           The name of the relative field or legend in regards to position.
+     *                                                If value is an array, each field/legend will be tried, first wins.
+     * @param string                $position         Where to place the new field(s)
+     * @param string|array|\Closure $fallback         Name or list of fallback palettes if none of the fields is found.
+     *                                                Can also be a Closure to be executed when unsuccessful.
+     * @param string                $fallbackPosition Position to use for fallback (PREPEND or APPEND to legend).
+     *
+     * @return $this
+     *
+     * @throws \InvalidArgumentException If $position or $fallbackPosition is invalid.
+     */
+    public function addField(
+        $name,
+        $parent,
+        $position = self::POSITION_AFTER,
+        $fallback = null,
+        $fallbackPosition = self::POSITION_APPEND
+    ) {
+        $this->validatePosition($position);
 
-    public function applyTo($palette)
-    {
-        $config = $this->explode($palette);
-
-        switch ($this->position) {
-            case self::POSITION_PREPEND:
-                $result = $this->addFields($config, $palette, $this->target, 0);
-                break;
-
-            case self::POSITION_APPEND:
-                $result = $this->addFields($config, $palette, $this->target, count($config));
-                break;
-
-            case self::POSITION_BEFORE_FIELD:
-                $result = $this->addFields($config, $palette, $this->findPaletteForField($config, $this->target), 0, $this->target);
-                break;
-
-            case self::POSITION_AFTER_FIELD:
-                $result = $this->addFields($config, $palette, $this->findPaletteForField($config, $this->target), 1, $this->target);
-                break;
-
-            case self::POSITION_BEFORE_LEGEND:
-                $result = $this->addLegend($config, $palette, 0);
-                break;
-
-            case self::POSITION_AFTER_LEGEND:
-                $result = $this->addLegend($config, $palette, 1);
-                break;
-
-            default:
-                throw new \InvalidArgumentException(sprintf('Unknown position "%s"', $this->position));
+        if (self::POSITION_BEFORE === $fallbackPosition || self::POSITION_AFTER === $fallbackPosition) {
+            throw new \InvalidArgumentException('Fallback legend position can only be PREPEND or APPEND');
         }
 
-        return false === $result ? $palette : $this->implode($config);
+        $this->fields[] = [
+            'fields'           => (array) $name,
+            'parents'          => (array) $parent,
+            'position'         => $position,
+            'fallback'         => is_scalar($fallback) ? [$fallback] : $fallback,
+            'fallbackPosition' => $fallbackPosition,
+        ];
+
+        return $this;
     }
 
     /**
+     * Apply changes to a palette on a DCA table.
+     *
+     * @param string $name  The palette name.
+     * @param string $table The DCA table name.
+     *
+     * @return $this
+     *
+     * @throws \UnderflowException If the DCA for given table is not loaded or palette does not exist.
+     */
+    public function applyToPalette($name, $table)
+    {
+        if (!isset($GLOBALS['TL_DCA'][$table]['palettes'][$name])) {
+            throw new \UnderflowException(sprintf('Palette "%s" not found in table "%s"', $name, $table));
+        }
+
+        $GLOBALS['TL_DCA'][$table]['palettes'][$name] = $this->apply($GLOBALS['TL_DCA'][$table]['palettes'][$name]);
+
+        return $this;
+    }
+
+    /**
+     * Apply changes to a subpalette on a DCA table.
+     *
+     * @param string $name  The subpalette name.
+     * @param string $table The DCA table name.
+     *
+     * @return $this
+     *
+     * @throws \UnderflowException If the DCA for given table is not loaded or subpalette does not exist.
+     */
+    public function applyToSubpalette($name, $table)
+    {
+        if (!isset($GLOBALS['TL_DCA'][$table]['subpalettes'][$name])) {
+            throw new \UnderflowException(sprintf('Subpalette "%s" not found in table "%s"', $name, $table));
+        }
+
+        $GLOBALS['TL_DCA'][$table]['subpalettes'][$name] = $this->apply(
+            $GLOBALS['TL_DCA'][$table]['subpalettes'][$name],
+            true
+        );
+
+        return $this;
+    }
+
+    /**
+     * Apply changes to the given palette string.
+     *
+     * @param string $palette     A palette or subpalette string.
+     * @param bool   $skipLegends If to ignore legends (e.g. for subpalettes).
+     *
+     * @return string
+     */
+    public function applyToString($palette, $skipLegends = false)
+    {
+        return $this->apply($palette, $skipLegends);
+    }
+
+    /**
+     * Validates the positions value is known.
+     *
+     * @param string $position
+     *
+     * @throws \InvalidArgumentException If the position is not valid.
+     */
+    private function validatePosition($position)
+    {
+        static $positions = [
+            self::POSITION_PREPEND,
+            self::POSITION_APPEND,
+            self::POSITION_BEFORE,
+            self::POSITION_AFTER,
+        ];
+
+        if (!in_array($position, $positions, true)) {
+            throw new \InvalidArgumentException('Legend position must be one of the PaletteManipulator constants.');
+        }
+    }
+
+    /**
+     * Converts palette string to a configuration array.
+     *
      * @param string $palette
      *
      * @return array
      */
     private function explode($palette)
     {
+        if ('' === (string) $palette) {
+            return [];
+        }
+
         $legendCount = 0;
         $legendMap   = [];
 
@@ -135,6 +211,8 @@ class PaletteManipulator
     }
 
     /**
+     * Converts configuration array to a palette string.
+     *
      * @param array $config
      *
      * @return string
@@ -144,12 +222,16 @@ class PaletteManipulator
         $palette = '';
 
         foreach ($config as $legend => $group) {
+            if (count($group['fields']) < 1) {
+                continue;
+            }
+
             if ('' !== $palette) {
                 $palette .= ';';
             }
 
             if (!is_int($legend)) {
-                $palette .= '{' . $legend . (isset($group['hide']) && $group['hide'] ? ':hide' : '') . '},';
+                $palette .= '{' . $legend . ($group['hide'] ? ':hide' : '') . '},';
             }
 
             $palette .= implode(',', $group['fields']);
@@ -159,57 +241,188 @@ class PaletteManipulator
     }
 
     /**
-     * @param array  $config
+     * Apply all changes to the given palette.
+     *
      * @param string $palette
-     * @param string $legend
-     * @param int    $offset
+     * @param bool   $skipLegends
+     *
+     * @return string
      */
-    private function addFields(array &$config, &$palette, $legend, $offset, $target = null)
+    private function apply($palette, $skipLegends = false)
     {
-        // If legend does not exist, try to apply fallback or append new legend to the end
-        if (false === $legend || !isset($config[$legend])) {
-            if ($this->applyFallback($palette)) {
-                return false;
+        $config = $this->explode($palette);
+
+        if (!$skipLegends) {
+            foreach ($this->legends as $legend) {
+                $this->applyLegend($config, $legend);
             }
-            
-            $config[$legend] = ['fields' => $this->new];
-
-            return true;
         }
 
-        if (null !== $target) {
-            $offset = array_search($this->target, $config[$legend]['fields'], true) + $offset;
+        // Make sure there is at least one legend
+        if (0 === count($config)) {
+            $config = [['fields' => [], 'hide' => false]];
         }
-        
-        array_splice($config[$legend]['fields'], $offset,0, $this->new);
-        
-        return true;
+
+        foreach ($this->fields as $field) {
+            $this->applyField($config, $field, $skipLegends);
+        }
+
+        return $this->implode($config);
     }
 
     /**
-     * @param array  $config
-     * @param string $palette
-     * @param int    $offset
+     * Adds a new legend to the configuration array.
+     *
+     * @param array $config
+     * @param array $action
      */
-    private function addLegend(array &$config, &$palette, $offset)
+    private function applyLegend(array &$config, array $action)
     {
-        if (!isset($config[$this->target])) {
-            if ($this->applyFallback($palette)) {
-                return false;
-            }
-
-            foreach ($this->new as $legend => $group) {
-                $config[$legend] = $group;
-            }
-
-            return true;
+        // Legend already exists, do nothing
+        if (array_key_exists($action['name'], $config)) {
+            return;
         }
 
-        $offset = array_search($this->target, array_keys($config), true) + $offset;
+        $template = [$action['name'] => ['fields' => [], 'hide' => $action['hide']]];
 
-        $before = array_splice($config, 0, $offset);
+        if (self::POSITION_PREPEND === $action['position']) {
+            /** @noinspection AdditionOperationOnArraysInspection */
+            $config = $template + $config;
+            return;
+        }
 
-        $config = $before + $this->new + $config;
+        if (self::POSITION_APPEND === $action['position']) {
+            $config += $template;
+            return;
+        }
+
+        foreach ($action['parents'] as $parent) {
+            if (array_key_exists($parent, $config)) {
+                $offset  = array_search($parent, array_keys($config), true);
+                $offset += (int) (self::POSITION_AFTER === $action['position']);
+
+                // Necessary because array_splice() would remove keys from $replacement array
+                $before = array_splice($config, 0, $offset);
+                $config = $before + $template + $config;
+                return;
+            }
+        }
+
+        // If everything fails, append new legend at the end
+        $config += $template;
+    }
+
+    /**
+     * Adds a new field to the configuration array.
+     *
+     * @param array $config
+     * @param array $action
+     * @param bool  $skipLegends
+     *
+     * @return bool
+     */
+    private function applyField(array &$config, array $action, $skipLegends = false)
+    {
+        switch ($action['position']) {
+            case self::POSITION_PREPEND:
+            case self::POSITION_APPEND:
+                return $this->applyFieldToLegend($config, $action, $skipLegends);
+
+            case self::POSITION_BEFORE:
+            case self::POSITION_AFTER:
+                return $this->applyFieldToField($config, $action, $skipLegends);
+        }
+
+        return false;
+    }
+
+    /**
+     * Adds fields to a legend.
+     *
+     * @param array $config
+     * @param array $action
+     * @param bool  $skipLegends
+     *
+     * @return bool
+     */
+    private function applyFieldToLegend(array &$config, array $action, $skipLegends = false)
+    {
+        // If $skipLegends is true, we usually only have one legend without name, so we simply append to that.
+        if ($skipLegends) {
+            if (self::POSITION_PREPEND === $action['position']) {
+                reset($config);
+            } else {
+                end($config);
+            }
+
+            $action['parents'] = [key($config)];
+        }
+
+        foreach ($action['parents'] as $parent) {
+            if (array_key_exists($parent, $config)) {
+                $offset = self::POSITION_PREPEND === $action['position'] ? 0 : count($config[$parent]['fields']);
+                array_splice($config[$parent]['fields'], $offset, 0, $action['fields']);
+
+                return true;
+            }
+        }
+
+        return $this->applyFallback($config, $action, $skipLegends);
+    }
+
+    private function applyFieldToField(array &$config, array $action, $skipLegends = false)
+    {
+        foreach ($action['parents'] as $parent) {
+            $legend = $this->findLegendForField($config, $parent);
+
+            if (is_string($legend)) {
+                $offset  = array_search($parent, $config[$legend]['fields'], true);
+                $offset += (int) (self::POSITION_AFTER === $action['position']);
+
+                array_splice($config[$legend]['fields'], $offset, 0, $action['fields']);
+
+                return true;
+            }
+        }
+
+        return $this->applyFallback($config, $action, $skipLegends);
+    }
+
+    private function applyFallback(array &$config, array $action, $skipLegends = false)
+    {
+        // Call fallback closure if none of the parents was found.
+        if ($action['fallback'] instanceof \Closure) {
+            return $action['fallback']($config, $action, $skipLegends);
+        }
+
+        end($config);
+        $fallback = key($config);
+
+        if (null !== $action['fallback']) {
+            foreach ($action['fallback'] as $parent) {
+                if (array_key_exists($parent, $config)) {
+                    $offset = self::POSITION_PREPEND === $action['fallbackPosition'] ? 0 : count($config[$parent]['fields']);
+                    array_splice($config[$parent]['fields'], $offset, 0, $action['fields']);
+
+                    return true;
+                }
+            }
+
+            // If the fallback palette was not found, create a new one.
+            $fallback = reset($action['fallback']);
+            $this->applyLegend(
+                $config,
+                [
+                    'name'     => $fallback,
+                    'position' => self::POSITION_APPEND,
+                    'hide'     => false
+                ]
+            );
+        }
+
+        // If everything fails, add to the last legend
+        $offset = self::POSITION_PREPEND === $action['fallbackPosition'] ? 0 : count($config[$fallback]['fields']);
+        array_splice($config[$fallback]['fields'], $offset, 0, $action['fields']);
 
         return true;
     }
@@ -220,7 +433,7 @@ class PaletteManipulator
      *
      * @return string|bool
      */
-    private function findPaletteForField(array $config, $field)
+    private function findLegendForField(array &$config, $field)
     {
         foreach ($config as $legend => $group) {
             if (in_array($field, $group['fields'], true)) {
@@ -232,69 +445,12 @@ class PaletteManipulator
     }
 
     /**
-     * @param string $palette
+     * Creates a new instance of PaletteManipulator.
      *
-     * @return bool
+     * @return static
      */
-    private function applyFallback(&$palette)
+    public static function create()
     {
-        if (null === $this->fallback) {
-            return false;
-        }
-
-        $palette = $this->fallback->applyTo($palette);
-
-        return true;
-    }
-
-
-    public static function prepend($legend, $new)
-    {
-        return new static(self::POSITION_PREPEND, (array) $new, $legend);
-    }
-
-    public static function append($legend, $new)
-    {
-        return new static(self::POSITION_APPEND, (array) $new, $legend);
-    }
-
-    public static function beforeField($field, $new)
-    {
-        return new static(self::POSITION_BEFORE_FIELD, (array) $new, $field);
-    }
-
-    public static function afterField($field, $new)
-    {
-        return new static(self::POSITION_AFTER_FIELD, (array) $new, $field);
-    }
-
-    public static function beforeLegend($beforeLegend, $name, $new, $hide = false)
-    {
-        return new static(
-            self::POSITION_BEFORE_LEGEND,
-            [
-                $name => [
-                    'fields' => (array) $new,
-                    'hide'   => $hide
-                ]
-            ],
-            $beforeLegend,
-            null
-        );
-    }
-
-    public static function afterLegend($afterLegend, $name, $new, $hide = false)
-    {
-        return new static(
-            self::POSITION_AFTER_LEGEND,
-            [
-                $name => [
-                    'fields' => (array) $new,
-                    'hide'   => $hide
-                ]
-            ],
-            $afterLegend,
-            null
-        );
+        return new static();
     }
 }

--- a/tests/DataContainer/PaletteManipulatorTest.php
+++ b/tests/DataContainer/PaletteManipulatorTest.php
@@ -13,6 +13,11 @@ namespace Contao\CoreBundle\Test\DataContainer;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\CoreBundle\Test\TestCase;
 
+/**
+ * Tests the PaletteManipulator class
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
 class PaletteManipulatorTest extends TestCase
 {
 
@@ -32,17 +37,17 @@ class PaletteManipulatorTest extends TestCase
             ->addField('foo', 'config_legend', PaletteManipulator::POSITION_PREPEND, 'config_legend')
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo,bar',
             $pm->applyToString('{config_legend},bar')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo,bar;{foo_legend},baz',
             $pm->applyToString('{config_legend},bar;{foo_legend},baz')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{foo_legend},baz;{config_legend},foo',
             $pm->applyToString('{foo_legend},baz')
         );
@@ -54,17 +59,17 @@ class PaletteManipulatorTest extends TestCase
             ->addField('bar', 'config_legend', PaletteManipulator::POSITION_APPEND, 'config_legend')
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo,bar',
             $pm->applyToString('{config_legend},foo')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo,bar;{foo_legend},baz',
             $pm->applyToString('{config_legend},foo;{foo_legend},baz')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{foo_legend},baz;{config_legend},bar',
             $pm->applyToString('{foo_legend},baz')
         );
@@ -77,12 +82,12 @@ class PaletteManipulatorTest extends TestCase
             ->addField('foo', 'config_legend', PaletteManipulator::POSITION_APPEND)
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo;{foo_legend},baz',
             $pm->applyToString('{foo_legend},baz')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{bar_legend},baz;{config_legend},foo',
             $pm->applyToString('{bar_legend},baz')
         );
@@ -95,12 +100,12 @@ class PaletteManipulatorTest extends TestCase
             ->addField('foo', 'config_legend')
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{foo_legend},baz;{config_legend},foo',
             $pm->applyToString('{foo_legend},baz')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{bar_legend},baz;{config_legend},foo',
             $pm->applyToString('{bar_legend},baz')
         );
@@ -112,12 +117,12 @@ class PaletteManipulatorTest extends TestCase
             ->addField('bar', 'foo', PaletteManipulator::POSITION_BEFORE)
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},bar,foo',
             $pm->applyToString('{config_legend},foo')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},baz,bar',
             $pm->applyToString('{config_legend},baz')
         );
@@ -129,14 +134,262 @@ class PaletteManipulatorTest extends TestCase
             ->addField('bar', 'foo', PaletteManipulator::POSITION_AFTER)
         ;
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},foo,bar',
             $pm->applyToString('{config_legend},foo')
         );
 
-        static::assertEquals(
+        $this->assertEquals(
             '{config_legend},baz,bar',
             $pm->applyToString('{config_legend},baz')
         );
+    }
+
+    public function testSkipLegends()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('foobar_legend', '', PaletteManipulator::POSITION_APPEND)
+            ->addField('field3', 'field1')
+            ->addField('field4', 'field3')
+            ->addField('field2', 'field1')
+            ->addField('foobar', 'foobar_legend', PaletteManipulator::POSITION_APPEND)
+            ->addField('first', '', PaletteManipulator::POSITION_PREPEND)
+        ;
+
+        $this->assertEquals(
+            'first,field1,field2,field3,field4,foobar',
+            $pm->applyToString('field1', true)
+        );
+    }
+
+    public function testMultipleParents()
+    {
+        $pm = PaletteManipulator::create()
+            ->addField('bar', ['baz', 'foo'])
+        ;
+
+        $this->assertEquals(
+            '{foobar_legend},foo,bar',
+            $pm->applyToString('{foobar_legend},foo')
+        );
+    }
+
+    public function testAddFieldToEmptyPalette()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('name_legend', '', PaletteManipulator::POSITION_PREPEND)
+            ->addField('name', 'name_legend', PaletteManipulator::POSITION_APPEND)
+        ;
+
+        $this->assertEquals(
+            '{name_legend},name',
+            $pm->applyToString('')
+        );
+
+        $pm = PaletteManipulator::create()
+            ->addField('name', 'name_legend', PaletteManipulator::POSITION_APPEND)
+        ;
+
+        $this->assertEquals(
+            'name',
+            $pm->applyToString('')
+        );
+
+        $pm = PaletteManipulator::create()
+            ->addField('name', 'name_legend', PaletteManipulator::POSITION_APPEND, 'name_legend')
+        ;
+
+        $this->assertEquals(
+            '{name_legend},name',
+            $pm->applyToString('')
+        );
+    }
+
+    public function testAddToNamelessLegend()
+    {
+        $pm = PaletteManipulator::create()
+            ->addField('bar', 'foo', PaletteManipulator::POSITION_AFTER)
+        ;
+
+        $this->assertEquals(
+            '{name_legend},name;foo,bar',
+            $pm->applyToString('{name_legend},name;foo')
+        );
+    }
+
+    public function testIgnoresEmptyLegend()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('empty_legend', '', PaletteManipulator::POSITION_APPEND)
+            ->addField('foo', 'bar', PaletteManipulator::POSITION_BEFORE)
+        ;
+
+        $this->assertEquals(
+            '{foobar_legend},foo,bar',
+            $pm->applyToString('{foobar_legend},bar')
+        );
+    }
+
+    public function testIgnoresDuplicateLegend()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('foobar_legend', '', PaletteManipulator::POSITION_APPEND)
+            ->addField('bar', 'foo', PaletteManipulator::POSITION_AFTER)
+        ;
+
+        $this->assertEquals(
+            '{foobar_legend},foo,bar;{other_legend},other',
+            $pm->applyToString('{foobar_legend},foo;{other_legend},other')
+        );
+    }
+
+    public function testHideLegend()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('foobar_legend', '', PaletteManipulator::POSITION_APPEND, true)
+            ->addField(['foo', 'bar'], 'foobar_legend', PaletteManipulator::POSITION_APPEND)
+        ;
+
+        $this->assertEquals(
+            '{name_legend},name;{foobar_legend:hide},foo,bar',
+            $pm->applyToString('{name_legend},name')
+        );
+    }
+
+    public function testApplyToDcaPalette()
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('foobar_legend', '', PaletteManipulator::POSITION_APPEND)
+            ->addField(['foo', 'bar'], 'foobar_legend', PaletteManipulator::POSITION_APPEND)
+        ;
+
+        $GLOBALS['TL_DCA']['tl_test']['palettes']['default'] = '{name_legend},name';
+
+        $pm->applyToPalette('default', 'tl_test');
+
+        $this->assertEquals(
+            '{name_legend},name;{foobar_legend},foo,bar',
+            $GLOBALS['TL_DCA']['tl_test']['palettes']['default']
+        );
+    }
+
+    public function testApplyToDcaSubpalette()
+    {
+        $pm = PaletteManipulator::create()
+            ->addField(['foo', 'bar'], 'lastname')
+        ;
+
+        $GLOBALS['TL_DCA']['tl_test']['subpalettes']['name'] = 'firstname,lastname';
+
+        $pm->applyToSubpalette('name', 'tl_test');
+
+        $this->assertEquals(
+            'firstname,lastname,foo,bar',
+            $GLOBALS['TL_DCA']['tl_test']['subpalettes']['name']
+        );
+    }
+
+    public function testFallbackCreatesPalette()
+    {
+        $pm = PaletteManipulator::create()
+            ->addField(
+                'bar',
+                'foo',
+                PaletteManipulator::POSITION_AFTER,
+                'name_legend'
+            )
+        ;
+
+        $this->assertEquals(
+            '{name_legend},name,bar',
+            $pm->applyToString('{name_legend},name')
+        );
+    }
+
+    public function testFallbackClosure()
+    {
+        $closureCalled = false;
+
+        $pm = PaletteManipulator::create()
+            ->addField(
+                'bar',
+                'foo',
+                PaletteManipulator::POSITION_AFTER,
+                function ($config, $action, $skipLegends) use (&$closureCalled) {
+                    $closureCalled = true;
+
+                    $this->assertInternalType('array', $config);
+                    $this->assertInternalType('array', $action);
+                    $this->assertInternalType('bool', $skipLegends);
+
+                    $this->assertArrayHasKey('fields', $action);
+                    $this->assertArrayHasKey('parents', $action);
+                    $this->assertArrayHasKey('position', $action);
+                }
+            )
+        ;
+
+        $pm->applyToString('baz');
+
+        $this->assertTrue($closureCalled);
+    }
+
+    /**
+     * @expectedException \UnderflowException
+     */
+    public function testMissingDcaPalette()
+    {
+        $pm = PaletteManipulator::create()
+                                ->addLegend('foobar_legend', '', PaletteManipulator::POSITION_APPEND)
+                                ->addField(['foo', 'bar'], 'foobar_legend', PaletteManipulator::POSITION_APPEND)
+        ;
+
+        // Make sure the palette is not here (for whatever reason another test might have set it)
+        unset($GLOBALS['TL_DCA']['tl_test']['palettes']['default']);
+
+        $pm->applyToPalette('default', 'tl_test');
+    }
+
+    /**
+     * @expectedException \UnderflowException
+     */
+    public function testMissingDcaSubpalette()
+    {
+        $pm = PaletteManipulator::create()
+            ->addField(['foo', 'bar'], 'lastname')
+        ;
+
+        // Make sure the palette is not here (for whatever reason another test might have set it)
+        unset($GLOBALS['TL_DCA']['tl_test']['subpalettes']['name']);
+
+        $pm->applyToSubpalette('name', 'tl_test');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidPosition()
+    {
+        PaletteManipulator::create()
+            ->addField('bar', 'foo', 'foo_position')
+            ->applyToString('foo')
+        ;
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidFallbackPosition()
+    {
+        PaletteManipulator::create()
+            ->addField(
+                'bar',
+                'foo',
+                PaletteManipulator::POSITION_AFTER,
+                'foobar_legend',
+                PaletteManipulator::POSITION_AFTER
+            )
+            ->applyToString('foo');
+        ;
     }
 }

--- a/tests/DataContainer/PaletteManipulatorTest.php
+++ b/tests/DataContainer/PaletteManipulatorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\DataContainer;
+
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\CoreBundle\Test\TestCase;
+
+class PaletteManipulatorTest extends TestCase
+{
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $pm = new PaletteManipulator('', [], '');
+
+        static::assertInstanceOf('Contao\CoreBundle\DataContainer\PaletteManipulator', $pm);
+    }
+
+    public function testPrependFieldToPalette()
+    {
+        $pm = PaletteManipulator::prepend('config_legend', 'foo');
+
+        static::assertEquals(
+            '{config_legend},foo,bar',
+            $pm->applyTo('{config_legend},bar')
+        );
+
+        static::assertEquals(
+            '{config_legend},foo,bar;{foo_legend},baz',
+            $pm->applyTo('{config_legend},bar;{foo_legend},baz')
+        );
+
+        static::assertEquals(
+            '{foo_legend},baz;{config_legend},foo',
+            $pm->applyTo('{foo_legend},baz')
+        );
+    }
+
+    public function testAppendFieldToPalette()
+    {
+        $pm = PaletteManipulator::append('config_legend', 'bar');
+
+        static::assertEquals(
+            '{config_legend},foo,bar',
+            $pm->applyTo('{config_legend},foo')
+        );
+
+        static::assertEquals(
+            '{config_legend},foo,bar;{foo_legend},baz',
+            $pm->applyTo('{config_legend},foo;{foo_legend},baz')
+        );
+
+        static::assertEquals(
+            '{foo_legend},baz;{config_legend},bar',
+            $pm->applyTo('{foo_legend},baz')
+        );
+    }
+
+    public function testBeforeLegend()
+    {
+        $pm = PaletteManipulator::beforeLegend('foo_legend', 'config_legend', 'foo');
+
+        static::assertEquals(
+            '{config_legend},foo;{foo_legend},baz',
+            $pm->applyTo('{foo_legend},baz')
+        );
+
+        static::assertEquals(
+            '{bar_legend},baz;{config_legend},foo',
+            $pm->applyTo('{bar_legend},baz')
+        );
+    }
+
+    public function testAfterLegend()
+    {
+        $pm = PaletteManipulator::afterLegend('foo_legend', 'config_legend', 'foo');
+
+        static::assertEquals(
+            '{foo_legend},baz;{config_legend},foo',
+            $pm->applyTo('{foo_legend},baz')
+        );
+
+        static::assertEquals(
+            '{bar_legend},baz;{config_legend},foo',
+            $pm->applyTo('{bar_legend},baz')
+        );
+    }
+
+    public function testBeforeField()
+    {
+        $pm = PaletteManipulator::beforeField('foo', 'bar');
+
+        static::assertEquals(
+            '{config_legend},bar,foo',
+            $pm->applyTo('{config_legend},foo')
+        );
+
+        static::assertEquals(
+            '{config_legend},baz;bar',
+            $pm->applyTo('{config_legend},baz')
+        );
+    }
+
+    public function testAfterField()
+    {
+        $pm = PaletteManipulator::afterField('foo', 'bar');
+
+        static::assertEquals(
+            '{config_legend},baz;bar',
+            $pm->applyTo('{config_legend},baz')
+        );
+    }
+
+    public function testFallback()
+    {
+        $pm = PaletteManipulator::beforeField('foo', 'bar');
+        $fallback = PaletteManipulator::prepend('config_legend', 'bar');
+
+        static::assertEquals(
+            '{config_legend},bar,baz',
+            $pm->setFallback($fallback)->applyTo('{config_legend},baz')
+        );
+    }
+}

--- a/tests/DataContainer/PaletteManipulatorTest.php
+++ b/tests/DataContainer/PaletteManipulatorTest.php
@@ -21,114 +21,122 @@ class PaletteManipulatorTest extends TestCase
      */
     public function testInstantiation()
     {
-        $pm = new PaletteManipulator('', [], '');
+        $pm = PaletteManipulator::create();
 
         static::assertInstanceOf('Contao\CoreBundle\DataContainer\PaletteManipulator', $pm);
     }
 
-    public function testPrependFieldToPalette()
+    public function testBeforeFieldToPalette()
     {
-        $pm = PaletteManipulator::prepend('config_legend', 'foo');
+        $pm = PaletteManipulator::create()
+            ->addField('foo', 'config_legend', PaletteManipulator::POSITION_PREPEND, 'config_legend')
+        ;
 
         static::assertEquals(
             '{config_legend},foo,bar',
-            $pm->applyTo('{config_legend},bar')
+            $pm->applyToString('{config_legend},bar')
         );
 
         static::assertEquals(
             '{config_legend},foo,bar;{foo_legend},baz',
-            $pm->applyTo('{config_legend},bar;{foo_legend},baz')
+            $pm->applyToString('{config_legend},bar;{foo_legend},baz')
         );
 
         static::assertEquals(
             '{foo_legend},baz;{config_legend},foo',
-            $pm->applyTo('{foo_legend},baz')
+            $pm->applyToString('{foo_legend},baz')
         );
     }
 
     public function testAppendFieldToPalette()
     {
-        $pm = PaletteManipulator::append('config_legend', 'bar');
+        $pm = PaletteManipulator::create()
+            ->addField('bar', 'config_legend', PaletteManipulator::POSITION_APPEND, 'config_legend')
+        ;
 
         static::assertEquals(
             '{config_legend},foo,bar',
-            $pm->applyTo('{config_legend},foo')
+            $pm->applyToString('{config_legend},foo')
         );
 
         static::assertEquals(
             '{config_legend},foo,bar;{foo_legend},baz',
-            $pm->applyTo('{config_legend},foo;{foo_legend},baz')
+            $pm->applyToString('{config_legend},foo;{foo_legend},baz')
         );
 
         static::assertEquals(
             '{foo_legend},baz;{config_legend},bar',
-            $pm->applyTo('{foo_legend},baz')
+            $pm->applyToString('{foo_legend},baz')
         );
     }
 
     public function testBeforeLegend()
     {
-        $pm = PaletteManipulator::beforeLegend('foo_legend', 'config_legend', 'foo');
+        $pm = PaletteManipulator::create()
+            ->addLegend('config_legend', 'foo_legend', PaletteManipulator::POSITION_BEFORE)
+            ->addField('foo', 'config_legend', PaletteManipulator::POSITION_APPEND)
+        ;
 
         static::assertEquals(
             '{config_legend},foo;{foo_legend},baz',
-            $pm->applyTo('{foo_legend},baz')
+            $pm->applyToString('{foo_legend},baz')
         );
 
         static::assertEquals(
             '{bar_legend},baz;{config_legend},foo',
-            $pm->applyTo('{bar_legend},baz')
+            $pm->applyToString('{bar_legend},baz')
         );
     }
 
     public function testAfterLegend()
     {
-        $pm = PaletteManipulator::afterLegend('foo_legend', 'config_legend', 'foo');
+        $pm = PaletteManipulator::create()
+            ->addLegend('config_legend', 'foo_legend', PaletteManipulator::POSITION_AFTER)
+            ->addField('foo', 'config_legend')
+        ;
 
         static::assertEquals(
             '{foo_legend},baz;{config_legend},foo',
-            $pm->applyTo('{foo_legend},baz')
+            $pm->applyToString('{foo_legend},baz')
         );
 
         static::assertEquals(
             '{bar_legend},baz;{config_legend},foo',
-            $pm->applyTo('{bar_legend},baz')
+            $pm->applyToString('{bar_legend},baz')
         );
     }
 
     public function testBeforeField()
     {
-        $pm = PaletteManipulator::beforeField('foo', 'bar');
+        $pm = PaletteManipulator::create()
+            ->addField('bar', 'foo', PaletteManipulator::POSITION_BEFORE)
+        ;
 
         static::assertEquals(
             '{config_legend},bar,foo',
-            $pm->applyTo('{config_legend},foo')
+            $pm->applyToString('{config_legend},foo')
         );
 
         static::assertEquals(
-            '{config_legend},baz;bar',
-            $pm->applyTo('{config_legend},baz')
+            '{config_legend},baz,bar',
+            $pm->applyToString('{config_legend},baz')
         );
     }
 
     public function testAfterField()
     {
-        $pm = PaletteManipulator::afterField('foo', 'bar');
+        $pm = PaletteManipulator::create()
+            ->addField('bar', 'foo', PaletteManipulator::POSITION_AFTER)
+        ;
 
         static::assertEquals(
-            '{config_legend},baz;bar',
-            $pm->applyTo('{config_legend},baz')
+            '{config_legend},foo,bar',
+            $pm->applyToString('{config_legend},foo')
         );
-    }
-
-    public function testFallback()
-    {
-        $pm = PaletteManipulator::beforeField('foo', 'bar');
-        $fallback = PaletteManipulator::prepend('config_legend', 'bar');
 
         static::assertEquals(
-            '{config_legend},bar,baz',
-            $pm->setFallback($fallback)->applyTo('{config_legend},baz')
+            '{config_legend},baz,bar',
+            $pm->applyToString('{config_legend},baz')
         );
     }
 }


### PR DESCRIPTION
`PaletteManipulator` is finally a helper tool to add fields in existing DCA palettes. It handles the following cases:
 - Add field after existing field
 - Add field before existing field
 - Append field to legend
 - Prepend field to legend
 - Add new legend and fields after existing legend
 - Add new legend and fields before existing legend


It is intentionally kept as simple as possible. I did not want to introduce object-oriented palettes, as I doubt that would be backwards compatible. The class is simply a helper to *string replace*.

I'm actually in need of such a tool to continue working on https://github.com/contao/core-bundle/pull/471. There's a field `tl_layout.calendarfeeds` and `tl_layout.newsfeeds` which should not be in `core-bundle` (see https://github.com/contao/core-bundle/blob/master/src/Resources/contao/dca/tl_layout.php#L100). 

**Example how to add `tl_layout.calendarfeeds` fields:**
```php
// CalendarBundle/Resources/contao/dca/tl_content.php
$GLOBALS['TL_DCA']['tl_layout']['palettes']['default'] = 
    PaletteManipulator::append('feed_legend', 'calendarfeeds')
    ->setFallback(
        PaletteManipulator::afterLegend('picturefill_legend', 'feed_legend', 'calendarfeeds')
    )
    ->applyTo($GLOBALS['TL_DCA']['tl_layout']['palettes']['default'])
````

What it does:
 1. Try to append field `calendarfeeds` (could also be an array of fields) to legend `feed_legend`.
 2. If 1. fails, add new legend `feed_legend` with new fields after `picturefill_legend`
 3. If 2. would fail (which it should not in core…), it would simply append the new legend at the end