### PR TITLE
Fix twig runtime error

### DIFF
--- a/src/Resources/views/Error/layout.html.twig
+++ b/src/Resources/views/Error/layout.html.twig
@@ -159,7 +159,11 @@
     </div>
     <div id="footer">
         <div class="wrap">
-            {% block hint %}{{ error.hint|format(template)|raw }}{% endblock %}
+            {% block hint %}
+                {% if error.hint is defined %}
+                    {{ error.hint|format(template)|raw }}
+                {% endif %}
+            {% endblock %}
         </div>
     </div>
 </body>


### PR DESCRIPTION
This commit fixes a twig runtime error. This error gets displayed instead of the contao pretty error view:

`Key "hint" for array with keys "error, matter, errorOccurred, howToFix, errorFixOne, more, errorExplain" does not exist in "@ContaoCore/Error/layout.html.twig" at line 162`