### PR TITLE
[RFC] Url generator

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -83,6 +83,12 @@ services:
         tags:
             - { name: routing.loader }
 
+    contao.routing.url_generator:
+        class: Contao\CoreBundle\Routing\UrlGenerator
+        arguments:
+            - "@router"
+            - "%contao.prepend_locale%"
+
     contao.security.authenticator:
         class: Contao\CoreBundle\Security\ContaoAuthenticator
         public: false

--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -1078,19 +1078,9 @@ abstract class Controller extends \System
 			}
 		}
 
-		$objRouter = \System::getContainer()->get('router');
+		$objUrlGenerator = \System::getContainer()->get('contao.routing.url_generator');
 		$arrParams = [];
-		$strRoute = 'contao_frontend';
-
-		// Correctly handle the "index" alias (see #3961)
-		if ($arrRow['alias'] == 'index' && $strParams == '')
-		{
-			$strRoute = 'contao_index';
-		}
-		else
-		{
-			$arrParams['alias'] = ($arrRow['alias'] ?: $arrRow['id']) . $strParams;
-		}
+		$strAlias = ($arrRow['alias'] ?: $arrRow['id']) . $strParams;
 
 		// Set the language
 		if ($strForceLang != '')
@@ -1113,7 +1103,7 @@ abstract class Controller extends \System
 			$arrParams['_locale'] = $objPage->rootLanguage;
 		}
 
-		$strUrl = $objRouter->generate($strRoute, $arrParams);
+		$strUrl = $objUrlGenerator->generate($strAlias, $arrParams);
 		$strUrl = substr($strUrl, strlen(\Environment::get('path')) + 1);
 
 		// Decode sprintf placeholders

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -4,7 +4,6 @@ namespace Contao\CoreBundle\Routing;
 
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 
 /**
@@ -27,8 +26,8 @@ class UrlGenerator implements UrlGeneratorInterface
     /**
      * Constructor.
      *
-     * @param UrlMatcherInterface $router
-     * @param bool                $prependLocale
+     * @param UrlGeneratorInterface $router
+     * @param bool                  $prependLocale
      */
     public function __construct(UrlGeneratorInterface $router, $prependLocale)
     {

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -2,9 +2,7 @@
 
 namespace Contao\CoreBundle\Routing;
 
-use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -88,8 +86,7 @@ class UrlGenerator implements UrlGeneratorInterface
     private function prepareParameters($alias, array $parameters)
     {
         $hasAutoItem = false;
-        $autoItem = (isset($GLOBALS['TL_AUTO_ITEM']) && is_array($GLOBALS['TL_AUTO_ITEM'])) ? $GLOBALS['TL_AUTO_ITEM'] : [];
-        $autoItem = array_key_exists('auto_item', $parameters) ? [$parameters['auto_item']] : $autoItem;
+        $autoItem = $this->getAutoItems($parameters);
 
         $parameters['alias'] = preg_replace_callback(
             '/\{([^\}]+)\}/',
@@ -117,5 +114,23 @@ class UrlGenerator implements UrlGeneratorInterface
         );
 
         return $parameters;
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return array
+     */
+    private function getAutoItems(array $parameters)
+    {
+        if (array_key_exists('auto_item', $parameters)) {
+            return [$parameters['auto_item']];
+        }
+
+        if ((isset($GLOBALS['TL_AUTO_ITEM']) && is_array($GLOBALS['TL_AUTO_ITEM']))) {
+            return $GLOBALS['TL_AUTO_ITEM'];
+        }
+
+        return [];
     }
 }

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Contao\CoreBundle\Routing;
+
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * UrlGenerator
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class UrlGenerator implements UrlGeneratorInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
+     * @var bool
+     */
+    private $prependLocale;
+
+    /**
+     * Constructor.
+     *
+     * @param UrlMatcherInterface $router
+     * @param bool                $prependLocale
+     */
+    public function __construct(UrlGeneratorInterface $router, $prependLocale)
+    {
+        $this->router = $router;
+        $this->prependLocale = $prependLocale;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->router->setContext($context);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getContext()
+    {
+        return $this->router->getContext();
+    }
+
+    /**
+     * @todo write explanation
+     *
+     * @param string $name
+     * @param array  $parameters
+     * @param int    $referenceType
+     *
+     * @return string
+     */
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    {
+        $route = 'index' === $name ? 'contao_index' : 'contao_frontend';
+        $parameters = is_array($parameters) ? $parameters : [];
+
+        if (!$this->prependLocale && array_key_exists('_locale', $parameters)) {
+            unset($parameters['_locale']);
+        }
+
+        $parameters = $this->prepareParameters($name, $parameters);
+
+        return $this->router->generate($route, $parameters, $referenceType);
+    }
+
+    /**
+     * @param string $alias
+     * @param array  $parameters
+     *
+     * @return array
+     *
+     * @throws MissingMandatoryParametersException
+     */
+    private function prepareParameters($alias, array $parameters)
+    {
+        $hasAutoItem = false;
+        $autoItem = array_key_exists('auto_item', $parameters) ? [$parameters['auto_item']] : $GLOBALS['TL_AUTO_ITEM'];
+
+        $parameters['alias'] = preg_replace_callback(
+            '/\{([^\}])\}/',
+            function ($matches) use ($alias, $parameters, $autoItem, &$hasAutoItem) {
+                $param = $matches[1];
+
+                if (!isset($parameters[$param])) {
+                    throw new MissingMandatoryParametersException(
+                        sprintf('Parameters "%s" is missing to generate a URL for "%s"', $param, $alias)
+                    );
+                }
+
+                if (!$hasAutoItem && in_array($param, $autoItem, true)) {
+                    $hasAutoItem = true;
+
+                    return $parameters[$param];
+                }
+
+                return $param . '/' . $parameters[$param];
+            },
+            $alias
+        );
+
+        return $parameters;
+    }
+}

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -112,11 +112,11 @@ class UrlGenerator implements UrlGeneratorInterface
     private function prepareAlias($alias, array &$parameters)
     {
         $hasAutoItem = false;
-        $autoItem = $this->getAutoItems($parameters);
+        $autoItems = $this->getAutoItems($parameters);
 
         $parameters['alias'] = preg_replace_callback(
             '/\{([^\}]+)\}/',
-            function ($matches) use ($alias, &$parameters, $autoItem, &$hasAutoItem) {
+            function ($matches) use ($alias, &$parameters, $autoItems, &$hasAutoItem) {
                 $param = $matches[1];
 
                 if (!isset($parameters[$param])) {
@@ -128,7 +128,7 @@ class UrlGenerator implements UrlGeneratorInterface
                 $value = $parameters[$param];
                 unset($parameters[$param]);
 
-                if (!$hasAutoItem && in_array($param, $autoItem, true)) {
+                if (!$hasAutoItem && in_array($param, $autoItems, true)) {
                     $hasAutoItem = true;
 
                     return $value;

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -111,6 +111,10 @@ class UrlGenerator implements UrlGeneratorInterface
      */
     private function prepareAlias($alias, array &$parameters)
     {
+        if ('index' === $alias) {
+            return;
+        }
+
         $hasAutoItem = false;
         $autoItems = $this->getAutoItems($parameters);
 

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -88,11 +88,12 @@ class UrlGenerator implements UrlGeneratorInterface
     private function prepareParameters($alias, array $parameters)
     {
         $hasAutoItem = false;
-        $autoItem = array_key_exists('auto_item', $parameters) ? [$parameters['auto_item']] : $GLOBALS['TL_AUTO_ITEM'];
+        $autoItem = (isset($GLOBALS['TL_AUTO_ITEM']) && is_array($GLOBALS['TL_AUTO_ITEM'])) ? $GLOBALS['TL_AUTO_ITEM'] : [];
+        $autoItem = array_key_exists('auto_item', $parameters) ? [$parameters['auto_item']] : $autoItem;
 
         $parameters['alias'] = preg_replace_callback(
-            '/\{([^\}])\}/',
-            function ($matches) use ($alias, $parameters, $autoItem, &$hasAutoItem) {
+            '/\{([^\}]+)\}/',
+            function ($matches) use ($alias, &$parameters, $autoItem, &$hasAutoItem) {
                 $param = $matches[1];
 
                 if (!isset($parameters[$param])) {
@@ -101,13 +102,16 @@ class UrlGenerator implements UrlGeneratorInterface
                     );
                 }
 
+                $value = $parameters[$param];
+                unset($parameters[$param]);
+
                 if (!$hasAutoItem && in_array($param, $autoItem, true)) {
                     $hasAutoItem = true;
 
-                    return $parameters[$param];
+                    return $value;
                 }
 
-                return $param . '/' . $parameters[$param];
+                return $param . '/' . $value;
             },
             $alias
         );

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -35,8 +35,6 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testRoute()
     {
-        $this->assertEquals('contao_index', $this->generator(false, 0)->generate('index'));
-        $this->assertEquals('contao_index', $this->generator(true, 0)->generate('index'));
         $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('foobar'));
         $this->assertEquals('contao_frontend', $this->generator(true, 0)->generate('foobar'));
         $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('foobar/test'));
@@ -47,6 +45,20 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $this->generator()->generate('foobar')['alias']);
         $this->assertEquals('foobar/test', $this->generator()->generate('foobar/test')['alias']);
         $this->assertEquals('foobar/article/test', $this->generator()->generate('foobar/article/test')['alias']);
+    }
+
+    public function testIndex()
+    {
+        $this->assertEquals('contao_index', $this->generator(false, 0)->generate('index'));
+        $this->assertEquals('contao_index', $this->generator(true, 0)->generate('index'));
+        $this->assertArrayNotHasKey('alias', $this->generator()->generate('index'));
+
+        $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('index/foobar'));
+        $this->assertArrayHasKey('alias', $this->generator()->generate('index/foobar'));
+
+        $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('index/{foo}', ['foo' => 'bar']));
+        $this->assertArrayHasKey('alias', $this->generator()->generate('index/{foo}', ['foo' => 'bar']));
+        $this->assertEquals('index/foo/bar', $this->generator()->generate('index/{foo}', ['foo' => 'bar'])['alias']);
     }
 
     public function testRemovesLocale()

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -90,7 +90,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
                 'foo/{items}/{article}',
                 ['items' => 'bar', 'article' => 'test', 'auto_item' => 'items']
             )['alias']
-        );q
+        );
     }
 
     /**

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -19,6 +19,10 @@ use Contao\CoreBundle\Routing\UrlGenerator;
  */
 class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        unset($GLOBALS['TL_AUTO_ITEM']);
+    }
 
     /**
      * Tests the object instantiation.
@@ -80,10 +84,19 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->generator()->generate('foo/{items}', ['items' => 'bar', 'auto_item' => 'items'])['alias']
         );
 
+        $this->assertEquals(
+            'foo/bar/article/test',
+            $this->generator()->generate(
+                'foo/{items}/{article}',
+                ['items' => 'bar', 'article' => 'test', 'auto_item' => 'items']
+            )['alias']
+        );
+
         $GLOBALS['TL_AUTO_ITEM'] = ['items'];
         $this->assertEquals('foo/bar', $this->generator()->generate('foo/{items}', ['items' => 'bar'])['alias']);
-        unset($GLOBALS['TL_AUTO_ITEM']);
 
+        $GLOBALS['TL_AUTO_ITEM'] = ['items', 'article'];
+        $this->assertEquals('foo/bar', $this->generator()->generate('foo/{items}', ['items' => 'bar'])['alias']);
         $this->assertEquals(
             'foo/bar/article/test',
             $this->generator()->generate(

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\Test\Routing;
 
 use Contao\CoreBundle\Routing\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
 
 /**
  * Tests the UrlGenerator class.
@@ -122,9 +123,12 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     private function mockRouter($returnArgument = 0)
     {
-        $mock = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
-        $mock->method('generate')->willReturnArgument($returnArgument);
+        $router = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $router->method('generate')->willReturnArgument($returnArgument);
 
-        return $mock;
+        $context = new RequestContext();
+        $router->method('getContext')->willReturn($context);
+
+        return $router;
     }
 }

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Routing;
+
+use Contao\CoreBundle\Routing\UrlGenerator;
+
+/**
+ * Tests the UrlGenerator class.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\CoreBundle\Routing\UrlGenerator', $this->generator());
+    }
+
+    public function testRoute()
+    {
+        $this->assertEquals('contao_index', $this->generator(false, 0)->generate('index'));
+        $this->assertEquals('contao_index', $this->generator(true, 0)->generate('index'));
+        $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('foobar'));
+        $this->assertEquals('contao_frontend', $this->generator(true, 0)->generate('foobar'));
+        $this->assertEquals('contao_frontend', $this->generator(false, 0)->generate('foobar/test'));
+    }
+
+    public function testWithoutParameters()
+    {
+        $this->assertEquals('foobar', $this->generator()->generate('foobar')['alias']);
+        $this->assertEquals('foobar/test', $this->generator()->generate('foobar/test')['alias']);
+        $this->assertEquals('foobar/article/test', $this->generator()->generate('foobar/article/test')['alias']);
+    }
+
+    public function testRemovesLocale()
+    {
+        $params = $this->generator(false)->generate('foobar', ['_locale' => 'en']);
+
+        $this->assertArrayNotHasKey('_locale', $params);
+
+        $params = $this->generator(true)->generate('foobar', ['_locale' => 'en']);
+
+        $this->assertArrayHasKey('_locale', $params);
+    }
+
+    public function testReplaceParameters()
+    {
+        $params = ['items' => 'bar', 'article' => 'test'];
+
+        $result = $this->generator()->generate('foo/{article}', $params);
+
+        $this->assertEquals('foo/article/test', $result['alias']);
+        $this->assertArrayNotHasKey('article', $result);
+        $this->assertArrayHasKey('items', $result);
+
+
+        $result = $this->generator()->generate('foo/{items}/{article}', $params);
+
+        $this->assertEquals('foo/items/bar/article/test', $result['alias']);
+        $this->assertArrayNotHasKey('article', $result);
+        $this->assertArrayNotHasKey('items', $result);
+    }
+
+    public function testAutoItem()
+    {
+        $this->assertEquals(
+            'foo/bar',
+            $this->generator()->generate('foo/{items}', ['items' => 'bar', 'auto_item' => 'items'])['alias']
+        );
+
+        $GLOBALS['TL_AUTO_ITEM'] = ['items'];
+        $this->assertEquals('foo/bar', $this->generator()->generate('foo/{items}', ['items' => 'bar'])['alias']);
+        unset($GLOBALS['TL_AUTO_ITEM']);
+
+        $this->assertEquals(
+            'foo/bar/article/test',
+            $this->generator()->generate(
+                'foo/{items}/{article}',
+                ['items' => 'bar', 'article' => 'test', 'auto_item' => 'items']
+            )['alias']
+        );q
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\MissingMandatoryParametersException
+     */
+    public function testThrowsExceptionOnMissingParameter()
+    {
+        $this->generator()->generate('foo/{article}');
+    }
+
+
+    private function generator($prependLocale = false, $returnArgument = 1)
+    {
+        return new UrlGenerator($this->mockRouter($returnArgument), $prependLocale);
+    }
+
+    private function mockRouter($returnArgument = 0)
+    {
+        $mock = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $mock->method('generate')->willReturnArgument($returnArgument);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
Per our discussion, the `UrlGenerator` is supposed to replace `Controller::generateFrontendUrl`.

It allows for simple but flexible use of Contao urls (or pages actually).

 1. `$urlGenerator->generate('foo');`

    > Result: `/foo.html`

 2. `$urlGenerator->generate('index');`

    > Result: `/`

 3. `$urlGenerator->generate('foo/{items}', ['items' => 'bar']);`

    > Result: `/foo/items/bar.html` if `items` **is not** in `$GLOBALS['TL_AUTO_ITEM']`
    > Result: `/foo/bar.html` if `items` **is** in `$GLOBALS['TL_AUTO_ITEM']`

 4. `$urlGenerator->generate('foo/{items}', ['items' => 'bar', 'auto_item' => 'items']);`

    > Result: `/foo/bar.html` (regardless of `$GLOBALS['TL_AUTO_ITEM']`)

 5. `$urlGenerator->generate('foo/{items}/{article}', ['items' => 'bar', 'article' => 'test');`

    > Result: `/foo/bar/article/test.html` (assuming `items` **is** in `$GLOBALS['TL_AUTO_ITEM']`)

 6. `$urlGenerator->generate('foo/{items}.html', ['items' => 'bar', 'article' => 'test');`

    > Result: `/foo/bar.html?article=test` (assuming `items` **is** in `$GLOBALS['TL_AUTO_ITEM']`)

 7. Example with `PageModel`
     ```php
    $page = \Contao\PageModel::findWithDetails(/* ... */);

    $urlGenerator->generate(
        $page->alias ?: $page->id, 
        [
            '_locale' => $page->rootLanguage,
            '_domain' => $page->domain,
            '_ssl' => (bool) $page->rootUseSSL,
        ]
    );
    ```

**ToDo**
 - [x] Handle host and schema
 - [ ] Add docblocks with extensive info 
 - [ ] More unit tests ?