### PR TITLE
[RFC] Store the full URI in the search results

### DIFF
--- a/src/Resources/contao/classes/Frontend.php
+++ b/src/Resources/contao/classes/Frontend.php
@@ -627,7 +627,7 @@ abstract class Frontend extends \Controller
 				if ($blnIndex)
 				{
 					$arrData = array(
-						'url'       => \Environment::get('relativeRequest'),
+						'url'       => \Environment::get('base') . \Environment::get('relativeRequest'),
 						'content'   => $objResponse->getContent(),
 						'title'     => $objPage->pageTitle ?: $objPage->title,
 						'protected' => ($objPage->protected ? '1' : ''),

--- a/src/Resources/contao/pages/PageError404.php
+++ b/src/Resources/contao/pages/PageError404.php
@@ -72,7 +72,7 @@ class PageError404 extends \Frontend
 	protected function prepare()
 	{
 		// Check the search index (see #3761)
-		\Search::removeEntry(\Environment::get('relativeRequest'));
+		\Search::removeEntry(\Environment::get('base') . \Environment::get('relativeRequest'));
 
 		// Find the matching root page
 		$objRootPage = $this->getRootPageFromUrl();


### PR DESCRIPTION
This is the follow-up PR to contao/core#8331.

@fritzmg Does it solve your issue?

@Toflar Is `varchar(255)` long enough to store the full URI?
