### PR TITLE
Use debug value to toggle pretty error screens

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -75,7 +75,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('contao_csrf_token')
                 ->end()
                 ->booleanNode('pretty_error_screens')
-                    ->defaultTrue()
+                    ->defaultValue(!$this->debug)
                 ->end()
                 ->integerNode('error_level')
                     ->min(-1)


### PR DESCRIPTION
With this change we can remove the `pretty_error_screens` configuration from `config_dev.yml` in standard-edition (https://github.com/contao/standard-edition/blob/master/app/config/config_dev.yml#L13)