### PR TITLE
Local exceptions for PaletteManipulator

### DIFF
--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -10,6 +10,8 @@
 
 namespace Contao\CoreBundle\DataContainer;
 
+use Contao\CoreBundle\Exception\PalettePositionException;
+use Contao\CoreBundle\Exception\PaletteNotFoundException;
 use Contao\StringUtil;
 
 /**
@@ -84,7 +86,7 @@ class PaletteManipulator
      *
      * @return static The object instance
      *
-     * @throws \InvalidArgumentException If $position or $fallbackPosition is invalid
+     * @throws PalettePositionException If $position or $fallbackPosition is invalid
      */
     public function addField(
         $name,
@@ -96,7 +98,7 @@ class PaletteManipulator
         $this->validatePosition($position);
 
         if (self::POSITION_BEFORE === $fallbackPosition || self::POSITION_AFTER === $fallbackPosition) {
-            throw new \InvalidArgumentException('Fallback legend position can only be PREPEND or APPEND');
+            throw new PalettePositionException('Fallback legend position can only be PREPEND or APPEND');
         }
 
         $this->fields[] = [
@@ -123,7 +125,7 @@ class PaletteManipulator
         $palettes = &$GLOBALS['TL_DCA'][$table]['palettes'];
 
         if (!isset($palettes[$name])) {
-            throw new \InvalidArgumentException(sprintf('Palette "%s" not found in table "%s"', $name, $table));
+            throw new PaletteNotFoundException(sprintf('Palette "%s" not found in table "%s"', $name, $table));
         }
 
         $palettes[$name] = $this->applyToString($palettes[$name]);
@@ -144,7 +146,7 @@ class PaletteManipulator
         $subpalettes = &$GLOBALS['TL_DCA'][$table]['subpalettes'];
 
         if (!isset($subpalettes[$name])) {
-            throw new \InvalidArgumentException(sprintf('Subpalette "%s" not found in table "%s"', $name, $table));
+            throw new PaletteNotFoundException(sprintf('Subpalette "%s" not found in table "%s"', $name, $table));
         }
 
         $subpalettes[$name] = $this->applyToString($subpalettes[$name], true);
@@ -187,7 +189,7 @@ class PaletteManipulator
      *
      * @param string $position The position
      *
-     * @throws \InvalidArgumentException If the position is not valid
+     * @throws PalettePositionException If the position is not valid
      */
     private function validatePosition($position)
     {
@@ -199,7 +201,7 @@ class PaletteManipulator
         ];
 
         if (!in_array($position, $positions, true)) {
-            throw new \InvalidArgumentException('Invalid legend position');
+            throw new PalettePositionException('Invalid legend position');
         }
     }
 

--- a/src/Exception/PaletteNotFoundException.php
+++ b/src/Exception/PaletteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Exception;
+
+/**
+ * Class PaletteNotFoundException
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class PaletteNotFoundException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/PalettePositionException.php
+++ b/src/Exception/PalettePositionException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Exception;
+
+/**
+ * Class PalettePositionException
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ */
+class PalettePositionException extends \InvalidArgumentException
+{
+}

--- a/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/src/Resources/contao/library/Contao/DcaLoader.php
@@ -85,7 +85,10 @@ class DcaLoader extends \Controller
 					include $file;
 				}
 			}
-			catch (\InvalidArgumentException $e) {}
+			catch (\InvalidArgumentException $e)
+			{
+				\System::getContainer()->get('monolog.logger.contao')->notice($e->getMessage(), ['exception' => $e]);
+			}
 		}
 
 		// HOOK: allow to load custom settings


### PR DESCRIPTION
I've run into the problem that DcaManipulator throws an `InvalidArgumentException`, which is catched by the `DcaLoader` because `FileLocator` throws the same.

1. we should always use local exceptions
2. Added logging if an exception is catched