### PR TITLE
[RFC] Do not spam the system log

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -135,9 +135,6 @@ class FrontendIndex extends \Frontend
 		// Throw a 404 error if the page could not be found
 		if ($objPage === null)
 		{
-			$this->User->authenticate();
-			$this->log('No active page for page ID "' . $pageId . '" (' . \Environment::get('base') . \Environment::get('request') . ')', __METHOD__, TL_GENERAL);
-
 			throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 		}
 
@@ -207,9 +204,6 @@ class FrontendIndex extends \Frontend
 		// Check wether the language matches the root page language
 		if (\Config::get('addLanguageToUrl') && \Input::get('language') != $objPage->rootLanguage)
 		{
-			$this->User->authenticate();
-			$this->log('No active page for page ID "' . $pageId . '" and language "' . \Input::get('language') . '" (' . \Environment::get('base') . \Environment::get('request') . ')', __METHOD__, TL_ERROR);
-
 			throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 		}
 
@@ -229,7 +223,6 @@ class FrontendIndex extends \Frontend
 		// Authenticate the user
 		if (!$this->User->authenticate() && $objPage->protected && !BE_USER_LOGGED_IN)
 		{
-			$this->log('Access to page ID "' . $pageId . '" denied (' . \Environment::get('base') . \Environment::get('request') . ')', __METHOD__, TL_ERROR);
 			throw new AccessDeniedException('Access denied: ' . \Environment::get('uri'));
 		}
 

--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -136,7 +136,7 @@ class FrontendIndex extends \Frontend
 		if ($objPage === null)
 		{
 			$this->User->authenticate();
-			$this->log('No active page for page ID "' . $pageId . '" (' . \Environment::get('base') . \Environment::get('request') . ')', __METHOD__, TL_ERROR);
+			$this->log('No active page for page ID "' . $pageId . '" (' . \Environment::get('base') . \Environment::get('request') . ')', __METHOD__, TL_GENERAL);
 
 			throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 		}

--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -133,8 +133,6 @@ class ModuleSearch extends \Module
 			// Return if there are no pages
 			if (!is_array($arrPages) || empty($arrPages))
 			{
-				$this->log('No searchable pages found', __METHOD__, TL_ERROR);
-
 				return;
 			}
 


### PR DESCRIPTION
This PR will change the log level of the "No active page for page ID" message from "error" to "general", which stops the app from logging them in the `app/logs/prod-*.log` file.

This is a security enhancement, which shall prevent storage overflow attacks.

@contao/developers Any objections?