### PR TITLE
[RFC] Always use the production URL to rebuild the search index

### DIFF
--- a/src/Resources/contao/classes/RebuildIndex.php
+++ b/src/Resources/contao/classes/RebuildIndex.php
@@ -130,7 +130,8 @@ class RebuildIndex extends \Backend implements \executable
 			// Display the pages
 			for ($i=0, $c=count($arrPages); $i<$c; $i++)
 			{
-				$strBuffer .= '<span class="page_url" data-url="' . $arrPages[$i] . '#' . $rand . $i . '">' . \StringUtil::substr($arrPages[$i], 100) . '</span><br>';
+				$strUrl = str_replace('app_dev.php/', '', $arrPages[$i]);
+				$strBuffer .= '<span class="page_url" data-url="' . $strUrl . '#' . $rand . $i . '">' . \StringUtil::substr($strUrl, 100) . '</span><br>';
 				unset($arrPages[$i]); // see #5681
 			}
 


### PR DESCRIPTION
I have noticed that rebuilding the search index adds the `app_dev.php/` fragment when I am in debug mode. This makes the process very slow, because all front end pages are also opened in debug mode.

This PR simply removes the `app_dev.php/` fragment from the search URLs, however, it might also be a good idea to always strip the fragment from `findSearchablePages()`? @contao/developers