### PR TITLE
Do not append the sent headers to the response if they already exist

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -92,8 +92,10 @@ class MergeHttpHeadersListener
                 header_remove($name);
             }
 
-            // Do not replace existing headers as the response object has a higher priority
-            $response->headers->set($name, trim($content), false);
+            // Do not replace existing response headers
+            if (!$response->headers->has($name)) {
+                $response->headers->set($name, trim($content));
+            }
         }
 
         return $response;

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -127,10 +127,42 @@ class MergeHttpHeadersListenerTest extends TestCase
         $response = $responseEvent->getResponse();
 
         $this->assertTrue($response->headers->has('FOOBAR'));
+        $this->assertSame('content', $response->headers->get('FOOBAR', null, false)[0]);
+    }
 
-        $allHeaders = $response->headers->get('FOOBAR', null, false);
+    /**
+     * Tests that headers are not appended.
+     */
+    public function testHeadersAreNotAppendedIfAlreadyPresentInResponse()
+    {
+        $response = new Response();
+        $response->headers->set('FOOBAR', 'content');
 
-        $this->assertSame('content', $allHeaders[0]);
-        $this->assertSame('new-content', $allHeaders[1]);
+        $responseEvent = new FilterResponseEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+
+        /** @var ContaoFrameworkInterface|\PHPUnit_Framework_MockObject_MockObject $framework */
+        $framework = $this->getMock('Contao\CoreBundle\Framework\ContaoFrameworkInterface');
+
+        $framework
+            ->expects($this->once())
+            ->method('isInitialized')
+            ->willReturn(true)
+        ;
+
+        $headersCount = count($response->headers->get('FOOBAR', null, false));
+
+        $listener = new MergeHttpHeadersListener($framework);
+        $listener->setHeaders(['FOOBAR: new-content']);
+        $listener->onKernelResponse($responseEvent);
+
+        $response = $responseEvent->getResponse();
+
+        $this->assertTrue($response->headers->has('FOOBAR'));
+        $this->assertSame($headersCount, count($response->headers->get('FOOBAR', null, false)));
     }
 }


### PR DESCRIPTION
I have encountered that bug when using the [FineUploader](https://github.com/terminal42/contao-fineuploader) extension with Contao 4.2. It uses the ```JsonResponse``` from Haste in the backend AJAX call which recently started using Symfony ```Response``` class:

https://github.com/codefog/contao-haste/blob/master/library/Haste/Http/Response/Response.php#L252

The main problem is that the Contao ```Ajax``` class sends the header to be ```text/html``` for every callback, even the custom ones:

https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/Ajax.php#L181

However the ```JsonResponse``` sets the header content type to be ```application/json```. This causes a serious problem as the ```MergeHttpHeaderListener``` class will append the ```text/html``` content-type header to the response's existing one, which results in having two content-type headers. And that will cause the Apache to terminate with an error.