### PR TITLE
[RTM] Only use ANSI when current tty is decorated

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -79,7 +79,12 @@ class ScriptHandler
             throw new \RuntimeException('The php executable could not be found.');
         }
 
-        $process = new Process(sprintf('%s app/console --ansi %s', $phpPath, $cmd));
+        $ansi = '';
+        if ($event->getIO()->isDecorated()) {
+            $ansi = '--ansi';
+        }
+
+        $process = new Process(sprintf('%s app/console %s %s', $phpPath, $ansi, $cmd));
 
         $process->run(
             function ($type, $buffer) use ($event) {


### PR DESCRIPTION
The composer script handler MUST NOT use ansi mode when not decorated.
This causes broken output in the console otherwise.

How to reproduce: `$ composer run-script post-update-cmd --no-ansi > foo.txt`
The contents of `foo.txt` will be including ANSI escape sequences (have a look at the Contao symlink creation):
```
Updating the "app/config/parameters.yml" file

 // Clearing the cache for the dev environment with debug true                                                          

 [OK] Cache for the "dev" environment (debug=true) was successfully cleared.                                            


 Trying to install assets as relative symbolic links.

 --- ------------------------ ------------------ 
      Bundle                   Method / Error    
 --- ------------------------ ------------------ 
  ✔   FrameworkBundle          relative symlink  
  ✔   ContaoCommentsBundle     relative symlink  
  ✔   ContaoNewsletterBundle   relative symlink  
 --- ------------------------ ------------------ 

 [OK] All assets were successfully installed.                                                                           


 --- ------------------------ ---------------------------------------------------------------- 
      ESC[32mSymlinkESC[39m                  ESC[32mTarget / ErrorESC[39m                                                  
 --- ------------------------ ---------------------------------------------------------------- 
  ESC[32;1m✔ESC[39;22m   system/themes/flexible   vendor/contao/core-bundle/src/Resources/contao/themes/flexible  
  ESC[32;1m✔ESC[39;22m   web/assets               assets                                                          
  ESC[32;1m✔ESC[39;22m   web/system/themes        system/themes                                                   
  ESC[32;1m✔ESC[39;22m   system/logs              app/logs                                                        
 --- ------------------------ ---------------------------------------------------------------- 
```