### PR TITLE
Fix Content-Dispositon Header for downloads

### DIFF
--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -755,7 +755,7 @@ class File extends \System
 	 *
 	 * @throws ResponseException
 	 */
-	public function sendToBrowser($filename=null)
+	public function sendToBrowser($filename='')
 	{
 		$response = new BinaryFileResponse(TL_ROOT . '/' . $this->strFile);
 


### PR DESCRIPTION
When set to null, the filename will not be passed in the content disposition.
Seems like Internet Explorer can't handle an empty filename and sets the filename to the last page parameter (on download.html it would be download.pdf instead of file_a.pdf)