### PR TITLE
Recreate system/tmp/.gitignore

### DIFF
--- a/src/Resources/contao/library/Contao/Automator.php
+++ b/src/Resources/contao/library/Contao/Automator.php
@@ -232,6 +232,10 @@ class Automator extends \System
 		$objFolder = new \Folder('system/tmp');
 		$objFolder->purge();
 
+		// Create deleted .gitignore file again
+		$objFile = new \File('system/tmp/.gitignore');
+		$objFile->close();
+
 		// Add a log entry
 		$this->log('Purged the temp folder', __METHOD__, TL_CRON);
 	}

--- a/src/Resources/contao/library/Contao/Automator.php
+++ b/src/Resources/contao/library/Contao/Automator.php
@@ -234,6 +234,7 @@ class Automator extends \System
 
 		// Create deleted .gitignore file again
 		$objFile = new \File('system/tmp/.gitignore');
+		$objFile->write('# Create the folder and ignore its content\n*\n!.gitignore');
 		$objFile->close();
 
 		// Add a log entry


### PR DESCRIPTION
Recreate `system/tmp/.gitignore` after purging the `system/tmp` folder.

Would it make sense to adapt [`rrdir`()](https://github.com/contao/core-bundle/blob/master/src/Resources/contao/library/Contao/Files.php#L117) to prevent deleting `.gitignore` files?