### PR TITLE
[RFC] Re-add title attribute for backend navigation group nodes.

### DIFF
--- a/src/Resources/contao/templates/backend/be_main.html5
+++ b/src/Resources/contao/templates/backend/be_main.html5
@@ -69,7 +69,7 @@
           <a href="<?= $this->request ?>#skipNavigation" class="invisible"><?= $this->skipNavigation ?></a>
           <ul class="tl_level_1">
             <?php foreach ($this->modules as $strGroup=>$arrModules): ?>
-              <li class="tl_level_1_group<?= $arrModules['class'] ?>"><a href="<?= $arrModules['href'] ?>" class="group-<?= $strGroup ?>" onclick="return AjaxRequest.toggleNavigation(this,'<?= $strGroup ?>')"><?= $arrModules['label'] ?></a></li>
+              <li class="tl_level_1_group<?= $arrModules['class'] ?>"><a href="<?= $arrModules['href'] ?>" title="<?= $arrModules['title']; ?>" class="group-<?= $strGroup ?>" onclick="return AjaxRequest.toggleNavigation(this,'<?= $strGroup ?>')"><?= $arrModules['label'] ?></a></li>
               <?php if ($arrModules['modules']): ?>
                 <li class="tl_parent" id="<?= $strGroup ?>">
                   <ul class="tl_level_2">


### PR DESCRIPTION
The title attribute is still assigned to the `modules` array but somehow it is currently not used in the template. This PR addresses this issue by re-adding the title attribute ("_Collapse node_") to the node link.

This was removed in 62f6d52968a05c7d496c864bc3bb97346f4245fc.
See https://github.com/contao/core-bundle/commit/62f6d52968a05c7d496c864bc3bb97346f4245fc#diff-72faeb98eda3b28ecf6dedf7ae2ced0cL76

Cc: @discordier 