### PR TITLE
[RFC] Make script combination optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.3.0-beta1 (2016-XX-XX)
 
- * Automatically find the template files. 
+ * Make script combination optional in case the website supports HTTP/2 (see #484).
+ * Automatically find the template files.
  * Make the legacy configuration files optional (see #521).
  * Move the analytics templates to the head section (see contao/core#8182).

--- a/src/Resources/contao/dca/tl_layout.php
+++ b/src/Resources/contao/dca/tl_layout.php
@@ -97,7 +97,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('rows', 'cols', 'addJQuery', 'addMooTools', 'static'),
-		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{webfonts_legend:hide},webfonts;{style_legend},framework,stylesheet,external,loadingOrder;{picturefill_legend:hide},picturefill;{modules_legend},modules;{jquery_legend:hide},addJQuery;{mootools_legend:hide},addMooTools;{script_legend},scripts,analytics,script;{static_legend:hide},static;{expert_legend:hide},template,doctype,viewport,titleTag,cssClass,onload,head'
+		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{webfonts_legend:hide},webfonts;{style_legend},framework,stylesheet,external,loadingOrder,combineScripts;{picturefill_legend:hide},picturefill;{modules_legend},modules;{jquery_legend:hide},addJQuery;{mootools_legend:hide},addMooTools;{script_legend},scripts,analytics,script;{static_legend:hide},static;{expert_legend:hide},template,doctype,viewport,titleTag,cssClass,onload,head'
 	),
 
 	// Subpalettes
@@ -272,7 +272,16 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'inputType'               => 'select',
 			'options'                 => array('external_first', 'internal_first'),
 			'reference'               => &$GLOBALS['TL_LANG']['tl_layout'],
+			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "varchar(16) NOT NULL default ''"
+		),
+		'combineScripts' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['combineScripts'],
+			'exclude'                 => true,
+			'inputType'               => 'checkbox',
+			'eval'                    => array('tl_class'=>'w50 m12'),
+			'sql'                     => "char(1) NOT NULL default ''"
 		),
 		'modules' => array
 		(

--- a/src/Resources/contao/languages/en/tl_layout.xlf
+++ b/src/Resources/contao/languages/en/tl_layout.xlf
@@ -176,6 +176,12 @@
       <trans-unit id="tl_layout.loadingOrder.1">
         <source>Here you can select the loading order of the style sheets.</source>
       </trans-unit>
+      <trans-unit id="tl_layout.combineScripts.0">
+        <source>Combine scripts</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.combineScripts.1">
+        <source>Combine the .css and .js files (do not enable for HTTP/2).</source>
+      </trans-unit>
       <trans-unit id="tl_layout.external_first">
         <source>Load external style sheets first</source>
       </trans-unit>

--- a/src/Resources/contao/library/Contao/Combiner.php
+++ b/src/Resources/contao/library/Contao/Combiner.php
@@ -183,6 +183,55 @@ class Combiner extends \System
 
 
 	/**
+	 * Generates the files and returns the URLs.
+	 *
+	 * @return array The file URLS
+	 */
+	public function getFileUrls()
+	{
+		$return = array();
+		$strTarget = substr($this->strMode, 1);
+
+		foreach ($this->arrFiles as $arrFile)
+		{
+			$content = file_get_contents(TL_ROOT . '/' . $arrFile['name']);
+
+			// Compile SCSS/LESS files into temporary files
+			if ($arrFile['extension'] == self::SCSS || $arrFile['extension'] == self::LESS)
+			{
+				$strPath = 'assets/' . $strTarget . '/' . str_replace('/', '_', $arrFile['name']) . $this->strMode;
+
+				$objFile = new \File($strPath);
+				$objFile->write($this->handleScssLess($content, $arrFile));
+				$objFile->close();
+
+				$return[] = $strPath;
+			}
+			else
+			{
+				$name = $arrFile['name'];
+
+				// Strip the web/ prefix (see #328)
+				if (strncmp($name, 'web/', 4) === 0)
+				{
+					$name = substr($name, 4);
+				}
+
+				// Add the media query (see #7070)
+				if ($arrFile['media'] != '' && $arrFile['media'] != 'all' && strpos($content, '@media') === false)
+				{
+					$name .= '" media="' . $arrFile['media'];
+				}
+
+				$return[] = $name;
+			}
+		}
+
+		return $return;
+	}
+
+
+	/**
 	 * Generate the combined file and return its path
 	 *
 	 * @param string $strUrl An optional URL to prepend
@@ -191,6 +240,44 @@ class Combiner extends \System
 	 */
 	public function getCombinedFile($strUrl=null)
 	{
+		if (\Config::get('debugMode'))
+		{
+			return $this->getDebugMarkup();
+		}
+
+		return $this->getCombinedFileUrl($strUrl);
+	}
+
+
+	/**
+	 * Generates the debug markup.
+	 *
+	 * @return string The debug markup
+	 */
+	protected function getDebugMarkup()
+	{
+		$return = $this->getFileUrls();
+
+		if ($this->strMode == self::JS)
+		{
+			return implode('"></script><script src="', $return);
+		}
+		else
+		{
+			return implode('"><link rel="stylesheet" href="', $return);
+		}
+	}
+
+
+	/**
+	 * Generate the combined file and return its path
+	 *
+	 * @param string $strUrl An optional URL to prepend
+	 *
+	 * @return string The path to the combined file
+	 */
+	protected function getCombinedFileUrl($strUrl=null)
+	{
 		if ($strUrl === null)
 		{
 			$strUrl = TL_ASSETS_URL;
@@ -198,56 +285,6 @@ class Combiner extends \System
 
 		$strTarget = substr($this->strMode, 1);
 		$strKey = substr(md5($this->strKey), 0, 12);
-
-		// Do not combine the files in debug mode (see #6450)
-		if (\Config::get('debugMode'))
-		{
-			$return = array();
-
-			foreach ($this->arrFiles as $arrFile)
-			{
-				$content = file_get_contents(TL_ROOT . '/' . $arrFile['name']);
-
-				// Compile SCSS/LESS files into temporary files
-				if ($arrFile['extension'] == self::SCSS || $arrFile['extension'] == self::LESS)
-				{
-					$strPath = 'assets/' . $strTarget . '/' . str_replace('/', '_', $arrFile['name']) . $this->strMode;
-
-					$objFile = new \File($strPath);
-					$objFile->write($this->handleScssLess($content, $arrFile));
-					$objFile->close();
-
-					$return[] = $strPath;
-				}
-				else
-				{
-					$name = $arrFile['name'];
-
-					// Strip the web/ prefix (see #328)
-					if (strncmp($name, 'web/', 4) === 0)
-					{
-						$name = substr($name, 4);
-					}
-
-					// Add the media query (see #7070)
-					if ($arrFile['media'] != '' && $arrFile['media'] != 'all' && strpos($content, '@media') === false)
-					{
-						$name .= '" media="' . $arrFile['media'];
-					}
-
-					$return[] = $name;
-				}
-			}
-
-			if ($this->strMode == self::JS)
-			{
-				return implode('"></script><script src="', $return);
-			}
-			else
-			{
-				return implode('"><link rel="stylesheet" href="', $return);
-			}
-		}
 
 		// Load the existing file
 		if (file_exists(TL_ROOT . '/assets/' . $strTarget . '/' . $strKey . $this->strMode))

--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -745,6 +745,11 @@ abstract class Controller extends \System
 			}
 		}
 
+		global $objPage;
+
+		$objLayout = \LayoutModel::findByPk($objPage->layoutId);
+		$blnCombineScripts = ($objLayout === null) ? false : $objLayout->combineScripts;
+
 		$arrReplace['[[TL_BODY]]'] = $strScripts;
 		$strScripts = '';
 
@@ -803,7 +808,17 @@ abstract class Controller extends \System
 		// Create the aggregated style sheet
 		if ($objCombiner->hasEntries())
 		{
-			$strScripts .= \Template::generateStyleTag($objCombiner->getCombinedFile(), 'all') . "\n";
+			if ($blnCombineScripts)
+			{
+				$strScripts .= \Template::generateStyleTag($objCombiner->getCombinedFile(), 'all') . "\n";
+			}
+			else
+			{
+				foreach ($objCombiner->getFileUrls() as $strUrl)
+				{
+					$strScripts .= \Template::generateStyleTag($strUrl, 'all') . "\n";
+				}
+			}
 		}
 
 		$arrReplace['[[TL_CSS]]'] = $strScripts;
@@ -837,12 +852,36 @@ abstract class Controller extends \System
 			// Create the aggregated script and add it before the non-static scripts (see #4890)
 			if ($objCombiner->hasEntries())
 			{
-				$strScripts = \Template::generateScriptTag($objCombiner->getCombinedFile()) . "\n" . $strScripts;
+				if ($blnCombineScripts)
+				{
+					$strScripts = \Template::generateScriptTag($objCombiner->getCombinedFile()) . "\n" . $strScripts;
+				}
+				else
+				{
+					$arrReversed = array_reverse($objCombiner->getFileUrls());
+
+					foreach ($arrReversed as $strUrl)
+					{
+						$strScripts = \Template::generateScriptTag($strUrl) . "\n" . $strScripts;
+					}
+				}
 			}
 
 			if ($objCombinerAsync->hasEntries())
 			{
-				$strScripts = \Template::generateScriptTag($objCombinerAsync->getCombinedFile(), true) . "\n" . $strScripts;
+				if ($blnCombineScripts)
+				{
+					$strScripts = \Template::generateScriptTag($objCombinerAsync->getCombinedFile(), true) . "\n" . $strScripts;
+				}
+				else
+				{
+					$arrReversed = array_reverse($objCombinerAsync->getFileUrls());
+
+					foreach ($arrReversed as $strUrl)
+					{
+						$strScripts = \Template::generateScriptTag($strUrl, true) . "\n" . $strScripts;
+					}
+				}
 			}
 		}
 

--- a/src/Resources/contao/models/LayoutModel.php
+++ b/src/Resources/contao/models/LayoutModel.php
@@ -31,6 +31,7 @@ namespace Contao;
  * @property string  $external
  * @property string  $orderExt
  * @property string  $loadingOrder
+ * @property boolean $combineScripts
  * @property string  $modules
  * @property string  $template
  * @property string  $doctype
@@ -74,6 +75,7 @@ namespace Contao;
  * @method static LayoutModel|null findOneByExternal($val, $opt=array())
  * @method static LayoutModel|null findOneByOrderExt($val, $opt=array())
  * @method static LayoutModel|null findOneByLoadingOrder($val, $opt=array())
+ * @method static LayoutModel|null findOneByCombineScripts($val, $opt=array())
  * @method static LayoutModel|null findOneByModules($val, $opt=array())
  * @method static LayoutModel|null findOneByTemplate($val, $opt=array())
  * @method static LayoutModel|null findOneByDoctype($val, $opt=array())
@@ -113,6 +115,7 @@ namespace Contao;
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByExternal($val, $opt=array())
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByOrderExt($val, $opt=array())
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByLoadingOrder($val, $opt=array())
+ * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByCombineScripts($val, $opt=array())
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByModules($val, $opt=array())
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByTemplate($val, $opt=array())
  * @method static Model\Collection|LayoutModel[]|LayoutModel|null findByDoctype($val, $opt=array())
@@ -156,6 +159,7 @@ namespace Contao;
  * @method static integer countByExternal($val, $opt=array())
  * @method static integer countByOrderExt($val, $opt=array())
  * @method static integer countByLoadingOrder($val, $opt=array())
+ * @method static integer countByCombineScripts($val, $opt=array())
  * @method static integer countByModules($val, $opt=array())
  * @method static integer countByTemplate($val, $opt=array())
  * @method static integer countByDoctype($val, $opt=array())

--- a/src/Resources/contao/models/PageModel.php
+++ b/src/Resources/contao/models/PageModel.php
@@ -87,6 +87,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @property array   $subpages
  * @property string  $outputFormat
  * @property string  $outputVariant
+ * @property integer $layoutId
  * @property boolean $hasJQuery
  * @property boolean $hasMooTools
  * @property boolean $isMobile

--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -89,6 +89,9 @@ class PageRegular extends \Frontend
 		/** @var ThemeModel $objTheme */
 		$objTheme = $objLayout->getRelated('pid');
 
+		// Store the layout ID
+		$objPage->layoutId = $objLayout->id;
+
 		// Set the layout template and template group
 		$objPage->template = $objLayout->template ?: 'fe_page';
 		$objPage->templateGroup = $objTheme->templates;

--- a/src/Resources/contao/templates/backend/be_alerts.html5
+++ b/src/Resources/contao/templates/backend/be_alerts.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/main.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/main.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_confirm.html5
+++ b/src/Resources/contao/templates/backend/be_confirm.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/confirm.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/confirm.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_diff.html5
+++ b/src/Resources/contao/templates/backend/be_diff.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/stylect/css/stylect.min.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/diff.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/stylect/css/stylect.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/diff.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/stylect/js/stylect.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/stylect/js/stylect.min.js"></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->
 

--- a/src/Resources/contao/templates/backend/be_help.html5
+++ b/src/Resources/contao/templates/backend/be_help.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/help.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/help.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_login.html5
+++ b/src/Resources/contao/templates/backend/be_login.html5
@@ -11,25 +11,17 @@
   <meta name="robots" content="noindex,follow">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/stylect/css/stylect.min.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/login.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/stylect/css/stylect.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/login.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/stylect/js/stylect.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/stylect/js/stylect.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_main.html5
+++ b/src/Resources/contao/templates/backend/be_main.html5
@@ -10,34 +10,26 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/colorpicker/css/mooRainbow.min.css');
-    $objCombiner->add('assets/chosen/css/chosen.min.css');
-    $objCombiner->add('assets/stylect/css/stylect.min.css');
-    $objCombiner->add('assets/simplemodal/css/simplemodal.min.css');
-    $objCombiner->add('assets/datepicker/css/datepicker.min.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/main.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/colorpicker/css/mooRainbow.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/chosen/css/chosen.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/stylect/css/stylect.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/simplemodal/css/simplemodal.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/datepicker/css/datepicker.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/main.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/colorpicker/js/mooRainbow.min.js');
-    $objCombiner->add('assets/chosen/js/chosen.min.js');
-    $objCombiner->add('assets/stylect/js/stylect.min.js');
-    $objCombiner->add('assets/simplemodal/js/simplemodal.min.js');
-    $objCombiner->add('assets/datepicker/js/datepicker.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    $objCombiner->add('system/themes/'. $this->theme .'/hover.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/colorpicker/js/mooRainbow.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/chosen/js/chosen.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/stylect/js/stylect.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/simplemodal/js/simplemodal.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/datepicker/js/datepicker.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/hover.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_password.html5
+++ b/src/Resources/contao/templates/backend/be_password.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/login.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/login.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_picker.html5
+++ b/src/Resources/contao/templates/backend/be_picker.html5
@@ -10,24 +10,16 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/main.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/main.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    $objCombiner->add('system/themes/'. $this->theme .'/hover.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/hover.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_popup.html5
+++ b/src/Resources/contao/templates/backend/be_popup.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/popup.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/popup.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/contao/js/mootao.min.js');
-    $objCombiner->add('assets/contao/js/core.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/mootao.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/contao/js/core.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/backend/be_switch.html5
+++ b/src/Resources/contao/templates/backend/be_switch.html5
@@ -10,23 +10,15 @@
   <meta name="referrer" content="origin">
 
   <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/fonts.css">
-  <link rel="stylesheet" href="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/stylect/css/stylect.min.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
-    $objCombiner->add('system/themes/'. $this->theme .'/switch.css');
-    echo $objCombiner->getCombinedFile();
-  ?>">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>assets/stylect/css/stylect.min.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/basic.css">
+  <link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/switch.css">
   <!--[if IE]><link rel="stylesheet" href="<?= TL_ASSETS_URL ?>system/themes/<?= $this->theme ?>/iefixes.css"><![endif]-->
   <?= $this->stylesheets ?>
 
   <script><?= $this->getLocaleString() ?></script>
-  <script src="<?php
-    $objCombiner = new Combiner();
-    $objCombiner->add('assets/mootools/js/mootools.min.js');
-    $objCombiner->add('assets/stylect/js/stylect.min.js');
-    echo $objCombiner->getCombinedFile();
-  ?>"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/mootools/js/mootools.min.js"></script>
+  <script src="<?= TL_ASSETS_URL ?>assets/stylect/js/stylect.min.js"></script>
   <script><?= $this->getDateString() ?></script>
   <?= $this->javascripts ?>
   <!--[if lt IE 9]><script src="<?= TL_ASSETS_URL ?>assets/html5shiv/js/html5shiv.min.js"></script><![endif]-->

--- a/src/Resources/contao/templates/mootools/moo_chosen.html5
+++ b/src/Resources/contao/templates/mootools/moo_chosen.html5
@@ -4,14 +4,10 @@
 $GLOBALS['TL_CSS'][] = 'assets/chosen/css/chosen.min.css|static';
 $GLOBALS['TL_CSS'][] = 'assets/stylect/css/stylect.min.css|static';
 
-// JavaScript files
-$objCombiner = new Combiner();
-$objCombiner->add('assets/chosen/js/chosen.min.js');
-$objCombiner->add('assets/stylect/js/stylect.min.js');
-
 ?>
 
-<script src="<?= $objCombiner->getCombinedFile() ?>"></script>
+<script src="<?= TL_ASSETS_URL ?>assets/chosen/js/chosen.min.js"></script>
+<script src="<?= TL_ASSETS_URL ?>assets/stylect/js/stylect.min.js"></script>
 <script>
   window.addEvent('domready', function() {
     $$('select.tl_chosen').chosen();


### PR DESCRIPTION
Make script combination optional in case the website supports HTTP/2 (see #484). There is a [related PR for the installation bundle](https://github.com/contao/installation-bundle/pull/23), which also needs to be merged when merging this PR.

@contao/developers /cc