### PR TITLE
[WIP] ESI

### DIFF
--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle;
 
+use Contao\CoreBundle\DependencyInjection\Compiler\AddFrontendModuleControllersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
@@ -58,5 +59,6 @@ class ContaoCoreBundle extends Bundle
 
         $container->addCompilerPass(new AddSessionBagsPass());
         $container->addCompilerPass(new AddResourcesPathsPass());
+        $container->addCompilerPass(new AddFrontendModuleControllersPass());
     }
 }

--- a/src/Controller/ArgumentConverterInterface.php
+++ b/src/Controller/ArgumentConverterInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Interface ArgumentConverterInterface
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+interface ArgumentConverterInterface
+{
+    /**
+     * Convert arguments on the request.
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function convertArguments(Request $request);
+}

--- a/src/Controller/FrontendModule/HtmlModuleController.php
+++ b/src/Controller/FrontendModule/HtmlModuleController.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Controller\FrontendModule;
+
+use Contao\CoreBundle\Controller\FrontendModuleController;
+use Contao\ModuleModel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class HtmlModuleController
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class HtmlModuleController extends FrontendModuleController
+{
+    /**
+     * @param Request      $request
+     * @param \ModuleModel $moduleModel
+     *
+     * @return Response
+     */
+    public function indexAction(Request $request, ModuleModel $moduleModel)
+    {
+        // TODO: How to handle back end rendering?
+        $response = new Response($moduleModel->html);
+
+        // TODO: General caching helpers in Contao?
+        $expire = new \DateTime();
+        $expire->add(new \DateInterval('PT1M'));
+        $response->setExpires($expire);
+
+        $response->setPublic();
+
+        return $response;
+    }
+}

--- a/src/Controller/FrontendModule/LegacyModuleController.php
+++ b/src/Controller/FrontendModule/LegacyModuleController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Controller\FrontendModule;
+
+use Contao\CoreBundle\Controller\FrontendModuleController;
+use Contao\CoreBundle\Exception\ResponseException;
+use Contao\ModuleModel;
+use Symfony\Component\HttpFoundation\Response;
+
+class LegacyModuleController extends FrontendModuleController
+{
+    /**
+     * Render a legacy module as a controller.
+     *
+     * @param ModuleModel $moduleModel
+     * @param string      $inColumn
+     *
+     * @return Response
+     */
+    public function indexAction(ModuleModel $moduleModel, $inColumn)
+    {
+        try {
+            $this->framework->initialize();
+
+            $legacy = $this->framework->getAdapter('Contao\Controller')
+                        ->getFrontendModule($moduleModel->id, $inColumn, true);
+
+            // Make sure reponse is never cached for legacy modules
+            $response = new Response($legacy);
+            $response->setPrivate();
+
+            return $response;
+
+        } catch (ResponseException $e) {
+
+            return $e->getResponse();
+        }
+    }
+}

--- a/src/Controller/FrontendModuleController.php
+++ b/src/Controller/FrontendModuleController.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\ModuleModel;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class FrontendModuleController
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ *
+ * @Route(defaults={"_scope" = "frontend", "_token_check" = true})
+ */
+class FrontendModuleController extends Controller implements ArgumentConverterInterface
+{
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    protected $framework;
+
+    /**
+     * @var ControllerReference[]
+     */
+    private $controllers = [];
+
+    /**
+     * FrontendModuleController constructor.
+     *
+     * @param ContaoFrameworkInterface $framework
+     */
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * @return ControllerReference[]
+     */
+    public function getControllers()
+    {
+        return $this->controllers;
+    }
+
+    /**
+     * @return ControllerReference[]|null
+     */
+    public function getController($type)
+    {
+        return $this->controllers[$type];
+    }
+
+    /**
+     * @param string              $type
+     * @param ControllerReference $controller
+     *
+     * @return FrontendModuleController
+     */
+    public function setController($type, ControllerReference $controller)
+    {
+        $this->controllers[$type] = $controller;
+
+        return $this;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @Route("/_contao/frontend_module", name="contao_frontend_module")
+     */
+    public function forwardAction(ModuleModel $moduleModel)
+    {
+        // Legacy support
+        foreach ($GLOBALS['FE_MOD'] as $groupName => $group) {
+            foreach ($group as $moduleType => $moduleClass) {
+                // Controllers are always more important than legacy
+                if (null === $this->getController($moduleType)) {
+                    // TODO: Trigger deprecated notice
+                    $this->setController($moduleType,
+                        new ControllerReference('contao.controller.frontend_module.legacy:indexAction')
+                    );
+                }
+            }
+        }
+
+        if (!isset($this->controllers[$moduleModel->type])) {
+            throw new NotFoundHttpException(sprintf(
+                'There\'s no controller for front end module type "%s".',
+                $moduleModel->type
+            ));
+        }
+
+        /** @var ControllerReference $controllerRef */
+        $controllerRef = $this->controllers[$moduleModel->type];
+
+        // Pass on the module id
+        $controllerRef->query['feModId'] = $moduleModel->id;
+
+        return $this->forward(
+            $controllerRef->controller,
+            [],
+            $controllerRef->query
+        );
+    }
+
+    /**
+     * Convert arguments on the request.
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function convertArguments(Request $request)
+    {
+        if (!$request->query->has('feModId')) {
+            return;
+        }
+
+        // Set inColumn which is "main" by default.
+        $request->attributes->set('inColumn', $request->query->get('inColumn', 'main'));
+
+        $moduleModel = $this->framework->getAdapter('Contao\ModuleModel')
+                            ->findByPk($request->query->getInt('feModId'));
+
+        if (null !== $moduleModel) {
+            $request->attributes->set('moduleModel', $moduleModel);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/AddFrontendModuleControllersPass.php
+++ b/src/DependencyInjection/Compiler/AddFrontendModuleControllersPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Registers the Contao front end module controllers.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class AddFrontendModuleControllersPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $feController     = $container->getDefinition('contao.controller.frontend_module');
+        $feModControllers = $container->findTaggedServiceIds('contao.frontend_module');
+
+        foreach ($feModControllers as $id => $tagAttributes) {
+
+            if (!isset($tagAttributes[0]['type']) && !isset($tagAttributes[0]['method'])) {
+                throw new InvalidArgumentException('A "contao.frontend_module" controller has to provide "type" and "method" attributes.');
+            }
+
+            $feController->addMethodCall('setController', [
+                    $tagAttributes[0]['type'],
+                    new Definition(
+                        'Symfony\Component\HttpKernel\Controller\ControllerReference',
+                        [$id . ':' . $tagAttributes[0]['method']]
+                    )
+                ]
+            );
+        }
+    }
+}

--- a/src/EventListener/ControllerArgumentListener.php
+++ b/src/EventListener/ControllerArgumentListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Controller\ArgumentConverterInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * Allows arbitrary controllers to easily convert attributes on the current
+ * request for their own actions.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class ControllerArgumentListener
+{
+    /**
+     * Convert arguments.
+     *
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController()[0];
+
+        if (!$controller instanceof ArgumentConverterInterface) {
+            return;
+        }
+
+        $controller->convertArguments($event->getRequest());
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -83,6 +83,11 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 256 }
 
+    contao.listener.controller_argument:
+        class: Contao\CoreBundle\EventListener\ControllerArgumentListener
+        tags:
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
+
     contao.listener.output_from_cache:
         class: Contao\CoreBundle\EventListener\OutputFromCacheListener
         arguments:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -27,6 +27,13 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
+    contao.controller.frontend_module:
+        class: Contao\CoreBundle\Controller\FrontendModuleController
+        arguments:
+            - "@contao.framework"
+        calls:
+            - ["setContainer", ["@service_container"]]
+
     contao.data_collector:
         class: Contao\CoreBundle\DataCollector\ContaoDataCollector
         public: false

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -34,6 +34,12 @@ services:
         calls:
             - ["setContainer", ["@service_container"]]
 
+    contao.controller.frontend_module.html:
+        class: Contao\CoreBundle\Controller\FrontendModule\HtmlModuleController
+        parent: 'contao.controller.frontend_module'
+        tags:
+            - { name: contao.frontend_module, type: html, method: indexAction }
+
     contao.data_collector:
         class: Contao\CoreBundle\DataCollector\ContaoDataCollector
         public: false

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -34,6 +34,10 @@ services:
         calls:
             - ["setContainer", ["@service_container"]]
 
+    contao.controller.frontend_module.legacy:
+        class: Contao\CoreBundle\Controller\FrontendModule\LegacyModuleController
+        parent: 'contao.controller.frontend_module'
+
     contao.controller.frontend_module.html:
         class: Contao\CoreBundle\Controller\FrontendModule\HtmlModuleController
         parent: 'contao.controller.frontend_module'

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -394,6 +394,10 @@ $GLOBALS['TL_HOOKS'] = array
 		array('Messages', 'versionCheck'),
 		array('Messages', 'maintenanceCheck'),
 		array('Messages', 'languageFallback')
+	),
+	'initializeSystem' => array
+	(
+		array('FrontendIndex', 'mapLegacyModuleControllers')
 	)
 );
 

--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\FrontendModuleController;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -307,5 +308,20 @@ class FrontendIndex extends \Frontend
 	protected function outputFromCache()
 	{
 		@trigger_error('Using FrontendIndex::outputFromCache() has been deprecated and will no longer work in Contao 5.0. Use the kernel.request event instead.', E_USER_DEPRECATED);
+	}
+
+
+
+	/**
+	 * Map the new controller stuff to legacy modules array for BC reasons.
+	 */
+	public function mapLegacyModuleControllers()
+	{
+		/** @var FrontendModuleController $feController */
+		$feController = \System::getContainer()->get('contao.controller.frontend_module');
+
+		foreach ($feController->getControllers() as $type => $controllerReference) {
+			$GLOBALS['FE_MOD']['routes'][$type] = 'Contao\ModuleProxy';
+		}
 	}
 }

--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -15,6 +15,9 @@ use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use League\Uri\Components\Query;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 
 
 /**
@@ -174,12 +177,13 @@ abstract class Controller extends \System
 	/**
 	 * Generate a front end module and return it as string
 	 *
-	 * @param mixed  $intId     A module ID or a Model object
-	 * @param string $strColumn The name of the column
+	 * @param mixed  $intId         A module ID or a Model object
+	 * @param string $strColumn     The name of the column
+	 * @param bool   $forceLegacy   Forces legacy rendering
 	 *
 	 * @return string The module HTML markup
 	 */
-	public static function getFrontendModule($intId, $strColumn='main')
+	public static function getFrontendModule($intId, $strColumn='main', $forceLegacy=false)
 	{
 		if (!is_object($intId) && !strlen($intId))
 		{
@@ -298,6 +302,18 @@ abstract class Controller extends \System
 				{
 					return '';
 				}
+			}
+
+			if (true !== $forceLegacy) {
+				/** @var FragmentHandler $fragmentHandler */
+				$fragmentHandler = \System::getContainer()->get('fragment.handler');
+
+				// TODO: Implement fragmentRegistry service to support different rendering modes per controller?
+				return $fragmentHandler->render(new ControllerReference(
+					'contao.controller.frontend_module:forwardAction',
+					[],
+					['feModId' => $objRow->id]
+				), 'esi');
 			}
 
 			// Check the visibility (see #6311)

--- a/src/Resources/contao/modules/ModuleProxy.php
+++ b/src/Resources/contao/modules/ModuleProxy.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao;
+
+/**
+ * Front end module "proxy".
+ * Proxies new Symfony controllers for the Contao legacy module system.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class ModuleProxy extends \Module
+{
+	/**
+	 * Do not display the module if there are no articles
+	 *
+	 * @return string
+	 */
+	public function generate()
+	{
+		return \Controller::getFrontendModule($this->id, $this->inColumn);
+	}
+
+	/**
+	 * Compile the current element
+	 */
+	protected function compile()
+	{
+		// noop
+	}
+}


### PR DESCRIPTION
Here we go with ESI support!
The diff is currently a bit confusing because I need changes of the 4.2.2 hotfix branch that are not part of the develop branch yet.

Adjustments needed in the standard-edition:

``` diff
# config.yml
framework:
+    esi: ~
+    fragments: { path: /_fragment }
```

Things to clarify:
- General approach? Shall I go on for CE's, articles and insert tags and page types?
- What about legacy stuff, needed? `$GLOBALS` difficulties etc.
- FragmentRegistry? Naming?

Not part of this PR and to talk about in a future PR:
- Out of the box caching support for start/stop definitions, settings etc.

ToDos:
- [ ] Unit Tests
