### PR TITLE
[RTM] Add default image densities to theme settings

### DIFF
--- a/src/Image/ImageFactory.php
+++ b/src/Image/ImageFactory.php
@@ -16,6 +16,7 @@ use Contao\ImageSizeModel;
 use Contao\Image\Image;
 use Contao\Image\ImageInterface;
 use Contao\Image\ImportantPart;
+use Contao\Image\ImportantPartInterface;
 use Contao\Image\ResizeConfiguration;
 use Contao\Image\ResizeConfigurationInterface;
 use Contao\Image\ResizeOptions;
@@ -142,6 +143,44 @@ class ImageFactory implements ImageFactoryInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getImportantPartFromLegacyMode(ImageInterface $image, $mode)
+    {
+        if (1 !== substr_count($mode, '_')) {
+            throw new \InvalidArgumentException('$mode is not a legacy resize mode "' . $mode . '"');
+        }
+
+        $importantPart = [
+            0,
+            0,
+            $image->getDimensions()->getSize()->getWidth(),
+            $image->getDimensions()->getSize()->getHeight(),
+        ];
+
+        list($modeX, $modeY) = explode('_', $mode);
+
+        if ('left' === $modeX) {
+            $importantPart[2] = 1;
+        } elseif ('right' === $modeX) {
+            $importantPart[0] = $importantPart[2] - 1;
+            $importantPart[2] = 1;
+        }
+
+        if ('top' === $modeY) {
+            $importantPart[3] = 1;
+        } elseif ('bottom' === $modeY) {
+            $importantPart[1] = $importantPart[3] - 1;
+            $importantPart[3] = 1;
+        }
+
+        return new ImportantPart(
+            new Point($importantPart[0], $importantPart[1]),
+            new Box($importantPart[2], $importantPart[3])
+        );
+    }
+
+    /**
      * Creates a resize configuration object.
      *
      * @param int|array|null $size  An image size or an array with width, height and resize mode
@@ -189,38 +228,9 @@ class ImageFactory implements ImageFactoryInterface
             return [$config, null];
         }
 
-        $importantPart = [
-            0,
-            0,
-            $image->getDimensions()->getSize()->getWidth(),
-            $image->getDimensions()->getSize()->getHeight(),
-        ];
-
-        list($modeX, $modeY) = explode('_', $size[2]);
-
-        if ('left' === $modeX) {
-            $importantPart[2] = 1;
-        } elseif ('right' === $modeX) {
-            $importantPart[0] = $importantPart[2] - 1;
-            $importantPart[2] = 1;
-        }
-
-        if ('top' === $modeY) {
-            $importantPart[3] = 1;
-        } elseif ('bottom' === $modeY) {
-            $importantPart[1] = $importantPart[3] - 1;
-            $importantPart[3] = 1;
-        }
-
         $config->setMode(ResizeConfigurationInterface::MODE_CROP);
 
-        return [
-            $config,
-            new ImportantPart(
-                new Point($importantPart[0], $importantPart[1]),
-                new Box($importantPart[2], $importantPart[3])
-            ),
-        ];
+        return [$config, $this->getImportantPartFromLegacyMode($image, $size[2])];
     }
 
     /**

--- a/src/Image/ImageFactoryInterface.php
+++ b/src/Image/ImageFactoryInterface.php
@@ -12,6 +12,7 @@ namespace Contao\CoreBundle\Image;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Image\ImageInterface;
+use Contao\Image\ImportantPartInterface;
 use Contao\Image\ResizeConfigurationInterface;
 use Contao\Image\ResizerInterface;
 use Imagine\Image\ImagineInterface;
@@ -49,4 +50,14 @@ interface ImageFactoryInterface
      * @return ImageInterface
      */
     public function create($path, $size = null, $targetPath = null);
+
+    /**
+     * Get the equivalent important part from a legacy resize mode
+     *
+     * @param  ImageInterface $image
+     * @param  string         $mode  One of left_top, center_top, right_top, left_center, center_center,
+     *                               right_center, left_bottom, center_bottom, right_bottom
+     * @return ImportantPartInterface
+     */
+    public function getImportantPartFromLegacyMode(ImageInterface $image, $mode);
 }

--- a/src/Image/PictureFactory.php
+++ b/src/Image/PictureFactory.php
@@ -90,7 +90,7 @@ class PictureFactory implements PictureFactoryInterface
     {
         $attributes = [];
 
-        if (is_object($path) && $path instanceof ImageInterface) {
+        if ($path instanceof ImageInterface) {
             $image = $path;
         } else {
             $image = $this->imageFactory->create($path);
@@ -101,7 +101,7 @@ class PictureFactory implements PictureFactoryInterface
             $size[2] = ResizeConfigurationInterface::MODE_CROP;
         }
 
-        if (is_object($size) && $size instanceof PictureConfigurationInterface) {
+        if ($size instanceof PictureConfigurationInterface) {
             $config = $size;
         } else {
             list($config, $attributes) = $this->createConfig($size);

--- a/src/Image/PictureFactory.php
+++ b/src/Image/PictureFactory.php
@@ -21,6 +21,7 @@ use Contao\Image\PictureConfigurationItem;
 use Contao\Image\PictureGeneratorInterface;
 use Contao\Image\PictureInterface;
 use Contao\Image\ResizeConfiguration;
+use Contao\Image\ResizeConfigurationInterface;
 use Contao\Image\ResizeOptions;
 
 /**
@@ -56,6 +57,11 @@ class PictureFactory implements PictureFactoryInterface
     private $imagineOptions;
 
     /**
+     * @var string
+     */
+    private $defaultDensities = '';
+
+    /**
      * {@inheritdoc}
      */
     public function __construct(PictureGeneratorInterface $pictureGenerator, ImageFactoryInterface $imageFactory, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions)
@@ -70,25 +76,35 @@ class PictureFactory implements PictureFactoryInterface
     /**
      * {@inheritdoc}
      */
+    public function setDefaultDensities($densities)
+    {
+        $this->defaultDensities = (string) $densities;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function create($path, $size = null)
     {
         $attributes = [];
 
-        if (is_array($size) && isset($size[2]) && 1 === substr_count($size[2], '_')) {
-            $image = $this->imageFactory->create($path, $size);
-            $config = new PictureConfiguration();
+        if (is_object($path) && $path instanceof ImageInterface) {
+            $image = $path;
         } else {
-            if ($path instanceof ImageInterface) {
-                $image = $path;
-            } else {
-                $image = $this->imageFactory->create($path);
-            }
+            $image = $this->imageFactory->create($path);
+        }
 
-            if ($size instanceof PictureConfigurationInterface) {
-                $config = $size;
-            } else {
-                list($config, $attributes) = $this->createConfig($size);
-            }
+        if (is_array($size) && isset($size[2]) && 1 === substr_count($size[2], '_')) {
+            $image->setImportantPart($this->imageFactory->getImportantPartFromLegacyMode($image, $size[2]));
+            $size[2] = ResizeConfigurationInterface::MODE_CROP;
+        }
+
+        if (is_object($size) && $size instanceof PictureConfigurationInterface) {
+            $config = $size;
+        } else {
+            list($config, $attributes) = $this->createConfig($size);
         }
 
         $picture = $this->pictureGenerator->generate(
@@ -135,6 +151,10 @@ class PictureFactory implements PictureFactoryInterface
 
             $configItem = new PictureConfigurationItem();
             $configItem->setResizeConfig($resizeConfig);
+
+            if ($this->defaultDensities) {
+                $configItem->setDensities($this->defaultDensities);
+            }
 
             $config->setSize($configItem);
 

--- a/src/Image/PictureFactoryInterface.php
+++ b/src/Image/PictureFactoryInterface.php
@@ -35,6 +35,15 @@ interface PictureFactoryInterface
     public function __construct(PictureGeneratorInterface $pictureGenerator, ImageFactoryInterface $imageFactory, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions);
 
     /**
+     * Set the default densities for generating pictures
+     *
+     * @param string $densities Densities for PictureConfigurationItemInterface::setDensities()
+     *
+     * @return self
+     */
+    public function setDefaultDensities($densities);
+
+    /**
      * Creates a Picture object.
      *
      * @param string|ImageInterface                        $path

--- a/src/Resources/contao/dca/tl_theme.php
+++ b/src/Resources/contao/dca/tl_theme.php
@@ -146,7 +146,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{title_legend},name,author;{config_legend},folders,screenshot,templates;{vars_legend},vars'
+		'default'                     => '{title_legend},name,author;{config_legend},folders,screenshot,templates;{vars_legend},vars,defaultImageDensities'
 	),
 
 	// Fields
@@ -213,6 +213,15 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 			'inputType'               => 'keyValueWizard',
 			'exclude'                 => true,
 			'sql'                     => "text NULL"
+		),
+		'defaultImageDensities' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_theme']['defaultImageDensities'],
+			'inputType'               => 'text',
+			'explanation'             => 'imageSizeDensities',
+			'exclude'                 => true,
+			'eval'                    => array('helpwizard'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'sql'                     => "varchar(255) NOT NULL default ''"
 		)
 	)
 );

--- a/src/Resources/contao/languages/en/tl_theme.xlf
+++ b/src/Resources/contao/languages/en/tl_theme.xlf
@@ -38,6 +38,12 @@
       <trans-unit id="tl_theme.vars.1">
         <source>Here you can define global variables for the style sheets of the theme (e.g. &lt;em&gt;$red&lt;/em&gt; -&gt; &lt;em&gt;c00&lt;/em&gt; or &lt;em&gt;$margin&lt;/em&gt; -&gt; &lt;em&gt;12px&lt;/em&gt;).</source>
       </trans-unit>
+      <trans-unit id="tl_theme.defaultImageDensities.0">
+        <source>Default image pixel densities</source>
+      </trans-unit>
+      <trans-unit id="tl_theme.defaultImageDensities.1">
+        <source>Here you can define the default pixel densities, e.g. &lt;em&gt;1x, 1.5x, 2x&lt;/em&gt;.</source>
+      </trans-unit>
       <trans-unit id="tl_theme.source.0">
         <source>Source files</source>
       </trans-unit>

--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -88,6 +88,7 @@ class PageRegular extends \Frontend
 
 		/** @var ThemeModel $objTheme */
 		$objTheme = $objLayout->getRelated('pid');
+		\System::getContainer()->get('contao.image.picture_factory')->setDefaultDensities($objTheme->defaultImageDensities);
 
 		// Store the layout ID
 		$objPage->layoutId = $objLayout->id;

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -562,6 +562,53 @@ class ImageFactoryTest extends TestCase
     }
 
     /**
+     * Tests the getImportantPartFromLegacyMode() method.
+     *
+     * @dataProvider getCreateWithLegacyMode
+     */
+    public function testGetImportantPartFromLegacyMode($mode, $expected)
+    {
+        $path = $this->getRootDir().'/images/none.jpg';
+
+        $dimensionsMock = $this->getMock('Contao\Image\ImageDimensionsInterface');
+
+        $dimensionsMock
+            ->expects($this->any())
+            ->method('getSize')
+            ->willReturn(new Box(100, 100))
+        ;
+
+        $imageMock = $this->getMock('Contao\Image\ImageInterface');
+
+        $imageMock
+            ->expects($this->any())
+            ->method('getDimensions')
+            ->willReturn($dimensionsMock)
+        ;
+
+        $imageFactory = $this->createImageFactory();
+
+        $this->assertEquals(
+            new ImportantPart(new Point($expected[0], $expected[1]), new Box($expected[2], $expected[3])),
+            $imageFactory->getImportantPartFromLegacyMode($imageMock, $mode)
+        );
+    }
+
+    /**
+     * Tests the getImportantPartFromLegacyMode() method throws an exception for
+     * invalid resize modes.
+     */
+    public function testGetImportantPartFromLegacyModeInvalidMode()
+    {
+        $imageMock = $this->getMock('Contao\Image\ImageInterface');
+        $imageFactory = $this->createImageFactory();
+
+        $this->setExpectedException('InvalidArgumentException', 'not a legacy resize mode');
+
+        $imageFactory->getImportantPartFromLegacyMode($imageMock, 'invalid');
+    }
+
+    /**
      * Provides the data for the testCreateWithLegacyMode() method.
      *
      * @return array

--- a/tests/Image/PictureFactoryTest.php
+++ b/tests/Image/PictureFactoryTest.php
@@ -15,11 +15,15 @@ use Contao\CoreBundle\Test\TestCase;
 use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Image\Image;
+use Contao\Image\ImageInterface;
 use Contao\Image\Picture;
 use Contao\Image\PictureConfiguration;
+use Contao\Image\PictureConfigurationInterface;
 use Contao\Image\PictureConfigurationItem;
 use Contao\Image\PictureGenerator;
 use Contao\Image\ResizeConfiguration;
+use Contao\Image\ResizeConfigurationInterface;
+use Contao\Image\ResizeOptionsInterface;
 use Contao\Model\Collection;
 
 /**
@@ -320,8 +324,27 @@ class PictureFactoryTest extends TestCase
         ;
 
         $pictureGenerator
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('generate')
+            ->with(
+                $this->callback(function (ImageInterface $image) {
+                    return true;
+                }),
+                $this->callback(function (PictureConfigurationInterface $config) {
+                    $this->assertEquals($config->getSizeItems(), []);
+                    $this->assertEquals(
+                        ResizeConfigurationInterface::MODE_CROP,
+                        $config->getSize()->getResizeConfig()->getMode()
+                    );
+                    $this->assertEquals(100, $config->getSize()->getResizeConfig()->getWidth());
+                    $this->assertEquals(200, $config->getSize()->getResizeConfig()->getHeight());
+
+                    return true;
+                }),
+                $this->callback(function (ResizeOptionsInterface $options) {
+                    return true;
+                })
+            )
             ->willReturn($pictureMock)
         ;
 
@@ -338,7 +361,7 @@ class PictureFactoryTest extends TestCase
         ;
 
         $imageFactory
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('create')
             ->with(
                 $this->callback(
@@ -347,16 +370,28 @@ class PictureFactoryTest extends TestCase
 
                         return true;
                     }
+                )
+            )
+            ->willReturn($imageMock)
+        ;
+
+        $imageFactory
+            ->expects($this->once())
+            ->method('getImportantPartFromLegacyMode')
+            ->with(
+                $this->callback(
+                    function (ImageInterface $image) {
+                        return true;
+                    }
                 ),
                 $this->callback(
-                    function ($size) {
-                        $this->assertEquals([100, 200, 'left_top'], $size);
+                    function ($mode) {
+                        $this->assertEquals('left_top', $mode);
 
                         return true;
                     }
                 )
             )
-            ->willReturn($imageMock)
         ;
 
         $pictureFactory = $this->createPictureFactory($pictureGenerator, $imageFactory);
@@ -368,8 +403,10 @@ class PictureFactoryTest extends TestCase
     /**
      * Tests the create() method.
      */
-    public function testCreateWithoutMode()
+    public function testCreateWithoutModel()
     {
+        $defaultDensities = '';
+
         $path = $this->getRootDir().'/images/dummy.jpg';
 
         $imageMock = $this
@@ -402,7 +439,7 @@ class PictureFactoryTest extends TestCase
                     }
                 ),
                 $this->callback(
-                    function (PictureConfiguration $pictureConfig) {
+                    function (PictureConfiguration $pictureConfig) use (&$defaultDensities) {
                         $this->assertEquals(100, $pictureConfig->getSize()->getResizeConfig()->getWidth());
                         $this->assertEquals(200, $pictureConfig->getSize()->getResizeConfig()->getHeight());
 
@@ -412,7 +449,7 @@ class PictureFactoryTest extends TestCase
                         );
 
                         $this->assertEquals(0, $pictureConfig->getSize()->getResizeConfig()->getZoomLevel());
-                        $this->assertEquals('', $pictureConfig->getSize()->getDensities());
+                        $this->assertEquals($defaultDensities, $pictureConfig->getSize()->getDensities());
                         $this->assertEquals('', $pictureConfig->getSize()->getSizes());
 
                         return true;
@@ -451,6 +488,10 @@ class PictureFactoryTest extends TestCase
         ;
 
         $pictureFactory = $this->createPictureFactory($pictureGenerator, $imageFactory);
+        $picture = $pictureFactory->create($path, [100, 200, ResizeConfiguration::MODE_BOX]);
+
+        $defaultDensities = '1x, 2x';
+        $pictureFactory->setDefaultDensities($defaultDensities);
         $picture = $pictureFactory->create($path, [100, 200, ResizeConfiguration::MODE_BOX]);
 
         $this->assertSame($pictureMock, $picture);

--- a/tests/Image/PictureFactoryTest.php
+++ b/tests/Image/PictureFactoryTest.php
@@ -327,23 +327,29 @@ class PictureFactoryTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with(
-                $this->callback(function (ImageInterface $image) {
-                    return true;
-                }),
-                $this->callback(function (PictureConfigurationInterface $config) {
-                    $this->assertEquals($config->getSizeItems(), []);
-                    $this->assertEquals(
-                        ResizeConfigurationInterface::MODE_CROP,
-                        $config->getSize()->getResizeConfig()->getMode()
-                    );
-                    $this->assertEquals(100, $config->getSize()->getResizeConfig()->getWidth());
-                    $this->assertEquals(200, $config->getSize()->getResizeConfig()->getHeight());
+                $this->callback(
+                    function (ImageInterface $image) {
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (PictureConfigurationInterface $config) {
+                        $this->assertEquals($config->getSizeItems(), []);
+                        $this->assertEquals(
+                            ResizeConfigurationInterface::MODE_CROP,
+                            $config->getSize()->getResizeConfig()->getMode()
+                        );
+                        $this->assertEquals(100, $config->getSize()->getResizeConfig()->getWidth());
+                        $this->assertEquals(200, $config->getSize()->getResizeConfig()->getHeight());
 
-                    return true;
-                }),
-                $this->callback(function (ResizeOptionsInterface $options) {
-                    return true;
-                })
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (ResizeOptionsInterface $options) {
+                        return true;
+                    }
+                )
             )
             ->willReturn($pictureMock)
         ;


### PR DESCRIPTION
This pull request depends on #342 and adds a default image densities field to the theme settings.

See contao/core#8171