### PR TITLE
[RTM] Allow Model::find() to return arrays instead of collections

### DIFF
--- a/src/Resources/contao/library/Contao/Model.php
+++ b/src/Resources/contao/library/Contao/Model.php
@@ -1083,7 +1083,7 @@ abstract class Model
 
 		if ($objResult->numRows < 1)
 		{
-			return $arrOptions['return'] == 'Array' ? [] : null;
+			return $arrOptions['return'] == 'Array' ? array() : null;
 		}
 
 		$objResult = static::postFind($objResult);

--- a/src/Resources/contao/library/Contao/Model.php
+++ b/src/Resources/contao/library/Contao/Model.php
@@ -1083,7 +1083,7 @@ abstract class Model
 
 		if ($objResult->numRows < 1)
 		{
-			return null;
+			return $arrOptions['return'] == 'Array' ? [] : null;
 		}
 
 		$objResult = static::postFind($objResult);
@@ -1099,6 +1099,12 @@ abstract class Model
 			}
 
 			return static::createModelFromDbResult($objResult);
+		}
+		else if ($arrOptions['return'] == 'Array')
+		{
+			$objCollection = static::createCollectionFromDbResult($objResult, static::$strTable);
+
+			return $objCollection->getModels();
 		}
 		else
 		{

--- a/src/Resources/contao/library/Contao/Model.php
+++ b/src/Resources/contao/library/Contao/Model.php
@@ -1102,9 +1102,7 @@ abstract class Model
 		}
 		else if ($arrOptions['return'] == 'Array')
 		{
-			$objCollection = static::createCollectionFromDbResult($objResult, static::$strTable);
-
-			return $objCollection->getModels();
+			return static::createCollectionFromDbResult($objResult, static::$strTable)->getModels();
 		}
 		else
 		{


### PR DESCRIPTION
this will make developer live soooo much easier by simply opting-in on arrays 😎 

Also solves https://github.com/contao/core/issues/6147