### PR TITLE
[RTM] PHP Toolbox support

### DIFF
--- a/.ide-toolbox.metadata.json
+++ b/.ide-toolbox.metadata.json
@@ -160,7 +160,32 @@
         },
         {
             "name": "contao_languagefiles",
-            "lookup_strings": ["default", "explain"]
+            "lookup_strings": [
+                "default",
+                "explain",
+                "tl_article",
+                "tl_content",
+                "tl_cron",
+                "tl_files",
+                "tl_form",
+                "tl_form_field",
+                "tl_image_size",
+                "tl_image_size_item",
+                "tl_layout",
+                "tl_log",
+                "tl_member",
+                "tl_member_group",
+                "tl_module",
+                "tl_page",
+                "tl_settings",
+                "tl_style",
+                "tl_style_sheet",
+                "tl_templates",
+                "tl_theme",
+                "tl_undo",
+                "tl_user",
+                "tl_user_group"
+            ]
         },
         {
             "name": "contao_model_options",
@@ -174,7 +199,7 @@
                     "type_text": "string|array"
                 },
                 {
-                    "lookup_string": "sorting",
+                    "lookup_string": "order",
                     "type_text": "SQL"
                 },
                 {
@@ -188,6 +213,10 @@
                 {
                     "lookup_string": "return",
                     "type_text": "Model|Collection|Array"
+                },
+                {
+                    "lookup_string": "table",
+                    "type_text": "string"
                 }
             ]
         },

--- a/.ide-toolbox.metadata.json
+++ b/.ide-toolbox.metadata.json
@@ -1,0 +1,199 @@
+{
+    "registrar":[
+        {
+            "provider":"contao_system_classes",
+            "language":"php",
+            "signature":[
+                "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface:getAdapter",
+                "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface:createInstance"
+            ],
+            "signatures":[
+                {
+                    "class": "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface",
+                    "method": "getAdapter",
+                    "type": "type"
+                },
+                {
+                    "class": "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface",
+                    "method": "createInstance",
+                    "type": "type"
+                }
+            ]
+        },
+        {
+            "provider":"contao_model_classes",
+            "language":"php",
+            "signature":[
+                "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface:getAdapter"
+            ],
+            "signatures":[
+                {
+                    "class": "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface",
+                    "method": "getAdapter",
+                    "type": "type"
+                }
+            ]
+        },
+        {
+            "provider":"contao_framework_classes",
+            "language":"php",
+            "signature":[
+                "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface:getAdapter"
+            ],
+            "signatures":[
+                {
+                    "class": "Contao\\CoreBundle\\Framework\\ContaoFrameworkInterface",
+                    "method": "getAdapter",
+                    "type": "type"
+                }
+            ]
+        },
+        {
+            "provider": "contao_datacontainers",
+            "language": "php",
+            "signature": [
+                "Contao\\Controller:loadDataContainer",
+                "Contao\\DcaLoader:__construct",
+                "Contao\\System:loadLanguageFile"
+            ]
+        },
+        {
+            "provider": "contao_languagefiles",
+            "language": "php",
+            "signature": [
+                "Contao\\System:loadLanguageFile"
+            ]
+        },
+        {
+            "provider": "contao_model_options",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "\\Contao\\Model",
+                    "method": "findBy",
+                    "type": "array_key",
+                    "index": 2
+                },
+                {
+                    "class": "\\Contao\\Model",
+                    "method": "findOneBy",
+                    "type": "array_key",
+                    "index": 2
+                }
+            ]
+        },
+        {
+            "provider": "contao_model_return",
+            "language": "php",
+            "signatures": [
+                {
+                    "class": "\\Contao\\Model",
+                    "method": "findBy",
+                    "index": 2,
+                    "array": "return"
+                }
+            ]
+        }
+    ],
+    "providers": [
+        {
+            "name": "contao_system_classes",
+            "defaults": {
+                "icon": "com.jetbrains.php.PhpIcons.CLASS"
+            },
+            "source": {
+                "contributor": "sub_classes",
+                "parameter": "Contao\\System"
+            }
+        },
+        {
+            "name": "contao_model_classes",
+            "defaults": {
+                "icon": "com.jetbrains.php.PhpIcons.CLASS"
+            },
+            "source": {
+                "contributor": "sub_classes",
+                "parameter": "Contao\\Model"
+            }
+        },
+        {
+            "name": "contao_framework_classes",
+            "defaults": {
+                "icon": "com.jetbrains.php.PhpIcons.CLASS"
+            },
+            "items": [
+                {
+                    "lookup_string": "Contao\\System",
+                    "type": "Contao\\System"
+                }, {
+                    "lookup_string": "Contao\\Config",
+                    "type": "Contao\\Config"
+                }
+            ]
+        },
+        {
+            "name": "contao_datacontainers",
+            "lookup_strings": [
+                "tl_article",
+                "tl_content",
+                "tl_cron",
+                "tl_files",
+                "tl_form",
+                "tl_form_field",
+                "tl_image_size",
+                "tl_image_size_item",
+                "tl_layout",
+                "tl_log",
+                "tl_member",
+                "tl_member_group",
+                "tl_module",
+                "tl_page",
+                "tl_settings",
+                "tl_style",
+                "tl_style_sheet",
+                "tl_templates",
+                "tl_theme",
+                "tl_undo",
+                "tl_user",
+                "tl_user_group"
+            ]
+        },
+        {
+            "name": "contao_languagefiles",
+            "lookup_strings": ["default", "explain"]
+        },
+        {
+            "name": "contao_model_options",
+            "items": [
+                {
+                    "lookup_string": "column",
+                    "type_text": "string|array"
+                },
+                {
+                    "lookup_string": "value",
+                    "type_text": "string|array"
+                },
+                {
+                    "lookup_string": "sorting",
+                    "type_text": "SQL"
+                },
+                {
+                    "lookup_string": "limit",
+                    "type_text": "integer"
+                },
+                {
+                    "lookup_string": "offset",
+                    "type_text": "integer"
+                },
+                {
+                    "lookup_string": "return",
+                    "type_text": "Model|Collection|Array"
+                }
+            ]
+        },
+        {
+            "name": "contao_model_return",
+            "lookup_strings": ["Model", "Collection", "Array"]
+        }
+    ]
+}


### PR DESCRIPTION
The [PHP Toolbox](https://plugins.jetbrains.com/plugin/8133) plugin adds customizable autocomplete additions to PhpStorm. Here's a simple draft for Contao `core-bundle`.
- Autocomplete and type detection of `ContaoFrameworkInterface::getAdapter()`
  ![](https://cloud.githubusercontent.com/assets/1073273/17583464/753f8130-5fb1-11e6-8ad9-feed7b695281.gif)
- Autocomplete for DCA and languages (currently hardcoded)
  ![](https://cloud.githubusercontent.com/assets/1073273/17583666/5a8bdd9c-5fb2-11e6-97fb-25443169d101.gif)
- Autocomplete for model options
  ![](https://cloud.githubusercontent.com/assets/1073273/17583795/1926d81a-5fb3-11e6-976e-56df93769a71.gif)

These are just examples and if we come up with more ideas it's highly extendable 😎 
