### PR TITLE
Add the String::toAscii() method

### DIFF
--- a/src/Resources/contao/library/Contao/StringUtil.php
+++ b/src/Resources/contao/library/Contao/StringUtil.php
@@ -951,4 +951,27 @@ class StringUtil
 
 		return $arrFragments;
 	}
+
+
+	/**
+	 * Locale aware UTF-8 to ASCII string transliteration
+	 *
+	 * @param string       $strString
+	 * @param array|string $varLocale
+	 *
+	 * @return string
+	 */
+	public static function toAscii($strString, $varLocale)
+	{
+		$locale = setlocale(LC_ALL, $varLocale);
+		$strString = Utf8::toAscii($strString);
+
+		// Reset the locale
+		if ($locale)
+		{
+			setlocale(LC_ALL, $locale);
+		}
+
+		return $strString;
+	}
 }


### PR DESCRIPTION
This PR solves #560 by adding a locale aware version of `toAscii()`.

TODO

- [ ] Adjust all `Utf8::toAscii()` calls
