### PR TITLE
[WIP] Feature/no more superglobals

### DIFF
--- a/src/EventListener/AddToSearchIndexListener.php
+++ b/src/EventListener/AddToSearchIndexListener.php
@@ -12,7 +12,7 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Frontend;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 /**
  * Adds a page to the search index after the response has been sent.
@@ -48,9 +48,9 @@ class AddToSearchIndexListener
     /**
      * Forwards the request to the Frontend class if there is a page object.
      *
-     * @param PostResponseEvent $event
+     * @param FilterResponseEvent $event
      */
-    public function onKernelTerminate(PostResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event)
     {
         if (!$this->framework->isInitialized()) {
             return;

--- a/src/EventListener/LegacyRequestValueSynchronizingListener.php
+++ b/src/EventListener/LegacyRequestValueSynchronizingListener.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Request\ValueAdapter;
+use Contao\Environment;
+use Contao\Input;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sets the current request on the \Input and \Environment classes.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ *
+ * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
+ *             Use the request or request stack instead.
+ */
+class LegacyRequestValueSynchronizingListener implements EventSubscriberInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * Constructor.
+     *
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => array('startRequest', 10),
+            KernelEvents::FINISH_REQUEST => array('finishRequest', -10)
+        ];
+    }
+
+    /**
+     * Store the request in the Contao 3 classes.
+     *
+     * @return void
+     */
+    public function startRequest()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request->attributes->has('_contao_value_adapter')) {
+            $request->attributes->set('_contao_value_adapter', new ValueAdapter($request));
+        }
+
+        $this->handleForRequest($request);
+    }
+
+    /**
+     * Restore the request in the Contao 3 classes.
+     *
+     * @return void
+     */
+    public function finishRequest()
+    {
+        $request = $this->requestStack->getParentRequest();
+
+        $this->handleForRequest($request);
+    }
+
+    /**
+     * Set the passed request in the Environment and Input classes.
+     *
+     * @param Request|null $request
+     *
+     * @return void
+     */
+    private function handleForRequest(Request $request = null)
+    {
+        Environment::setRequest($request);
+        Input::setValueAdapter($request ? $request->attributes->get('_contao_value_adapter') : null);
+    }
+}

--- a/src/EventListener/LegacyRequestValueSynchronizingListener.php
+++ b/src/EventListener/LegacyRequestValueSynchronizingListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
  *             Use the request or request stack instead.
  */
-class LegacyRequestValueSynchronizingListener implements EventSubscriberInterface
+class LegacyRequestValueSynchronizingListener
 {
     /**
      * @var RequestStack
@@ -41,17 +41,6 @@ class LegacyRequestValueSynchronizingListener implements EventSubscriberInterfac
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public static function getSubscribedEvents()
-    {
-        return [
-            KernelEvents::REQUEST => array('startRequest', 10),
-            KernelEvents::FINISH_REQUEST => array('finishRequest', -10)
-        ];
     }
 
     /**

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -295,7 +295,6 @@ class ContaoFramework implements ContaoFrameworkInterface
 
         $this->validateInstallation();
 
-        Input::initialize();
         TemplateLoader::initialize();
 
         $this->setTimezone();

--- a/src/Request/ValueAdapter.php
+++ b/src/Request/ValueAdapter.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @internal
  */
-class ValueAdapter
+final class ValueAdapter
 {
     /**
      * The request instance.

--- a/src/Request/ValueAdapter.php
+++ b/src/Request/ValueAdapter.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Request;
+
+use Contao\Input;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This class is the encapsulation of the request values to keep bc with Contao 3.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ *
+ * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0. Use values from the request instead.
+ *
+ * @internal
+ */
+class ValueAdapter
+{
+    /**
+     * The request instance.
+     *
+     * @var Request
+     */
+    public $request;
+
+    /**
+     * The filtered values.
+     *
+     * @var Request
+     */
+    public $filtered = [];
+
+    /**
+     * The cached values.
+     *
+     * @var ParameterBag[]
+     */
+    private $cache = [];
+
+    /**
+     * Unused $_GET parameters
+     * @var array
+     */
+    private $unusedGet = [];
+
+    /**
+     * Create a new instance.
+     *
+     * @param Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $this->request  = $request;
+        $this->filtered = $request->duplicate(
+            Input::cleanKey($this->request->query->all()),
+            Input::cleanKey($this->request->request->all()),
+            $this->request->attributes->all(),
+            Input::cleanKey($this->request->cookies->all())
+        );
+    }
+
+    /**
+     * Export the filtered values to the super globals.
+     *
+     * This is for bc with legacy code reason only.
+     */
+    public function exportGlobals()
+    {
+        // Inline reader function for reading the protected property from the parameter bag.
+        // I know this approach is rather hacky but it is the only way for exporting the property
+        // by reference.
+        $reader = function & ($object) {
+            $value = & \Closure::bind(function & () {
+                if (isset($this->parameters)) {
+                    return $this->parameters;
+                }
+                // Fall through if symfony should ever rename the internal property
+                // (unlikely but we better be safe than sorry).
+                trigger_error(
+                    'Symfony has changed the "parameters" property name. Exporting without reference',
+                    E_USER_WARNING
+                );
+                /** @var ParameterBag $this */
+                return $this->all();
+            }, $object, $object)->__invoke();
+
+            return $value;
+        };
+
+        $_GET    = &$reader($this->filtered->query);
+        $_POST   = &$reader($this->filtered->request);
+        $_COOKIE = &$reader($this->filtered->cookies);
+    }
+
+    /**
+     * Test if a cache value is present.
+     *
+     * @param string $cacheKey  The cache name.
+     * @param string $valueName The value name.
+     *
+     * @return bool
+     */
+    public function hasCached($cacheKey, $valueName)
+    {
+        return array_key_exists($cacheKey, $this->cache) && $this->cache[$cacheKey]->has($valueName);
+    }
+
+    /**
+     * Retrieve a cached value.
+     *
+     * @param string $cacheKey  The cache name.
+     * @param string $valueName The value name.
+     *
+     * @return mixed|null
+     */
+    public function getCached($cacheKey, $valueName)
+    {
+        if (!array_key_exists($cacheKey, $this->cache)) {
+            return null;
+        }
+
+        return $this->cache[$cacheKey]->get($valueName);
+    }
+
+    /**
+     * Set a cached value and return it.
+     *
+     * @param string $cacheKey  The cache name.
+     * @param string $valueName The value name.
+     * @param mixed  $value     The value to cache.
+     *
+     * @return mixed
+     */
+    public function setCached($cacheKey, $valueName, $value)
+    {
+        if (!array_key_exists($cacheKey, $this->cache)) {
+            $this->cache[$cacheKey] = new ParameterBag();
+        }
+
+        $this->cache[$cacheKey]->set($valueName, $value);
+
+        return $value;
+    }
+
+    /**
+     * Remove a cached value.
+     *
+     * @param string $cacheKey  The cache name.
+     * @param string $valueName The value name.
+     */
+    public function removeCached($cacheKey, $valueName)
+    {
+        if (!array_key_exists($cacheKey, $this->cache)) {
+            return;
+        }
+
+        $this->cache[$cacheKey]->remove($valueName);
+    }
+
+    /**
+     * Clear the cache.
+     *
+     * @return void
+     */
+    public function clearCache()
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * Set the "unused" state for a GET parameter.
+     *
+     * @param string $name The name of the parameter.
+     * @param bool   $used The state (defaults to true).
+     */
+    public function setUsed($name, $used = true)
+    {
+        if ($used) {
+            unset($this->unusedGet[$name]);
+
+            return;
+        }
+
+        $this->unusedGet[$name] = $name;
+    }
+
+    /**
+     * Return whether there are unused GET parameters
+     *
+     * @return boolean True if there are unused GET parameters
+     */
+    public function hasUnusedGet()
+    {
+        return count($this->unusedGet) > 0;
+    }
+
+    /**
+     * Return the unused GET parameters as array
+     *
+     * @return array The unused GET parameter array
+     */
+    public function getUnusedGet()
+    {
+        return array_keys($this->unusedGet);
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -112,6 +112,13 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 
+    contao.listener.request_synchronizer:
+         class: Contao\CoreBundle\EventListener\LegacyRequestValueSynchronizingListener
+         arguments:
+            - "@request_stack"
+         tags:
+            - { name: kernel.event_subscriber }
+
     contao.listener.response_exception:
         class: Contao\CoreBundle\EventListener\ResponseExceptionListener
         tags:

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -38,7 +38,7 @@ services:
             - "@contao.framework"
             - "%fragment.path%"
         tags:
-            - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
     contao.listener.bypass_maintenance:
         class: Contao\CoreBundle\EventListener\BypassMaintenanceListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -117,7 +117,8 @@ services:
          arguments:
             - "@request_stack"
          tags:
-            - { name: kernel.event_subscriber }
+            - { name: kernel.event_listener, event: kernel.request, method: startRequest, priority: 10 }
+            - { name: kernel.event_listener, event: kernel.finish_request, method: finishRequest, priority: -10 }
 
     contao.listener.response_exception:
         class: Contao\CoreBundle\EventListener\ResponseExceptionListener

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -448,7 +448,7 @@ class Environment
 	 */
 	protected static function isAjaxRequest()
 	{
-		return self::$objRequest->headers->get('X-Requested-With') == 'XMLHttpRequest';
+		return self::$objRequest->isXmlHttpRequest();
 	}
 
 

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -292,7 +292,7 @@ class Environment
 	 */
 	protected static function ssl()
 	{
-		return self::$objRequest->server->get('SSL_SESSION_ID') || (self::$objRequest->server->get('HTTPS') == 'on') || (self::$objRequest->server->get('HTTPS') == 1);
+		return self::$objRequest->isSecure();
 	}
 
 

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -281,7 +281,6 @@ class Environment
 	 */
 	protected static function httpXForwardedHost()
 	{
-		// FIXME: is broken.
 		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', self::$objRequest->headers->get('X-Forwarded-For'));
 	}
 

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Reads the environment variables
@@ -23,9 +24,16 @@ namespace Contao;
  *     echo Environment::get('requestUri');
  *
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
+ *             You should not use this class anymore but use the request or request stack directly.
  */
 class Environment
 {
+	/**
+	 * @var Request
+	 */
+	private static $objRequest;
 
 	/**
 	 * Object instance (Singleton)
@@ -45,6 +53,16 @@ class Environment
 	 */
 	protected static $arrCache = array();
 
+	/**
+	 * Gateway function used by Contao3RequestSynchronizingListener to push the current (sub-)request.
+	 *
+	 * @param Request $objRequest The request.
+	 */
+	public static function setRequest(Request $objRequest = null)
+	{
+		self::$objRequest = $objRequest;
+		self::reset();
+	}
 
 	/**
 	 * Return an environment variable
@@ -68,7 +86,7 @@ class Environment
 		{
 			$arrChunks = preg_split('/([A-Z][a-z]*)/', $strKey, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
 			$strServerKey = strtoupper(implode('_', $arrChunks));
-			static::$arrCache[$strKey] = $_SERVER[$strServerKey];
+			static::$arrCache[$strKey] = self::$objRequest->server->get($strServerKey);
 		}
 
 		return static::$arrCache[$strKey];
@@ -103,7 +121,17 @@ class Environment
 	 */
 	protected static function scriptFilename()
 	{
-		return str_replace('//', '/', strtr((static::$strSapi == 'cgi' || static::$strSapi == 'isapi' || static::$strSapi == 'cgi-fcgi' || static::$strSapi == 'fpm-fcgi') && (@$_SERVER['ORIG_PATH_TRANSLATED'] ?: $_SERVER['PATH_TRANSLATED']) ? (@$_SERVER['ORIG_PATH_TRANSLATED'] ?: $_SERVER['PATH_TRANSLATED']) : (@$_SERVER['ORIG_SCRIPT_FILENAME'] ?: $_SERVER['SCRIPT_FILENAME']), '\\', '/'));
+		if ((static::$strSapi == 'cgi' || static::$strSapi == 'isapi' || static::$strSapi == 'cgi-fcgi' || static::$strSapi == 'fpm-fcgi'))
+		{
+			$script = self::$objRequest->server->get('ORIG_PATH_TRANSLATED', self::$objRequest->server->get('PATH_TRANSLATED'));
+		}
+
+		if (empty($script))
+		{
+			$script = self::$objRequest->server->get('ORIG_SCRIPT_FILENAME', self::$objRequest->server->get('SCRIPT_FILENAME'));
+		}
+
+		return str_replace('//', '/', strtr($script, '\\', '/'));
 	}
 
 
@@ -114,14 +142,7 @@ class Environment
 	 */
 	protected static function scriptName()
 	{
-		$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		if ($request === null)
-		{
-			return @$_SERVER['ORIG_SCRIPT_NAME'] ?: $_SERVER['SCRIPT_NAME'];
-		}
-
-		return $request->getScriptName();
+		return self::$objRequest->getScriptName();
 	}
 
 
@@ -154,7 +175,7 @@ class Environment
 		// Fallback to DOCUMENT_ROOT if SCRIPT_FILENAME and SCRIPT_NAME point to different files
 		if (basename($scriptName) != basename($scriptFilename))
 		{
-			return str_replace('//', '/', strtr(realpath($_SERVER['DOCUMENT_ROOT']), '\\', '/'));
+			return str_replace('//', '/', strtr(realpath(self::$objRequest->server->get('DOCUMENT_ROOT')), '\\', '/'));
 		}
 
 		if (substr($scriptFilename, 0, 1) == '/')
@@ -191,12 +212,7 @@ class Environment
 	 */
 	protected static function queryString()
 	{
-		if (!isset($_SERVER['QUERY_STRING']))
-		{
-			return '';
-		}
-
-		return static::encodeRequestString($_SERVER['QUERY_STRING']);
+		return static::encodeRequestString(self::$objRequest->getQueryString());
 	}
 
 
@@ -207,16 +223,7 @@ class Environment
 	 */
 	protected static function requestUri()
 	{
-		if (!empty($_SERVER['REQUEST_URI']))
-		{
-			$strRequest = $_SERVER['REQUEST_URI'];
-		}
-		else
-		{
-			$strRequest = '/' . preg_replace('/^\//', '', static::get('scriptName')) . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '');
-		}
-
-		return static::encodeRequestString($strRequest);
+		return static::encodeRequestString(self::$objRequest->getRequestUri());
 	}
 
 
@@ -224,43 +231,10 @@ class Environment
 	 * Return the first eight accepted languages as array
 	 *
 	 * @return array The languages array
-	 *
-	 * @author Leo Unglaub <https://github.com/LeoUnglaub>
 	 */
 	protected static function httpAcceptLanguage()
 	{
-		$arrAccepted = array();
-		$arrLanguages = array();
-
-		// The implementation differs from the original implementation and also works with .jp browsers
-		preg_match_all('/([a-z]{1,8}(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $arrAccepted);
-
-		// Remove all invalid locales
-		foreach ($arrAccepted[1] as $v)
-		{
-			$chunks = explode('-', $v);
-
-			// Language plus dialect, e.g. en-US or fr-FR
-			if (isset($chunks[1]))
-			{
-				$locale = $chunks[0] . '-' . strtoupper($chunks[1]);
-
-				if (preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $locale))
-				{
-					$arrLanguages[] = $locale;
-				}
-			}
-
-			$locale = $chunks[0];
-
-			// Language only, e.g. en or fr (see #29)
-			if (preg_match('/^[a-z]{2}$/', $locale))
-			{
-				$arrLanguages[] = $locale;
-			}
-		}
-
-		return array_slice(array_unique($arrLanguages), 0, 8);
+		return array_slice(array_map(function($strLanguage) { return strtr($strLanguage, '_', '-'); }, self::$objRequest->getLanguages()), 0, 8);
 	}
 
 
@@ -271,7 +245,7 @@ class Environment
 	 */
 	protected static function httpAcceptEncoding()
 	{
-		return array_values(array_unique(explode(',', strtolower($_SERVER['HTTP_ACCEPT_ENCODING']))));
+		return self::$objRequest->getEncodings();
 	}
 
 
@@ -282,7 +256,7 @@ class Environment
 	 */
 	protected static function httpUserAgent()
 	{
-		$ua = strip_tags($_SERVER['HTTP_USER_AGENT']);
+		$ua = strip_tags(self::$objRequest->headers->get('User-Agent'));
 		$ua = preg_replace('/javascript|vbscri?pt|script|applet|alert|document|write|cookie/i', '', $ua);
 
 		return substr($ua, 0, 255);
@@ -296,21 +270,7 @@ class Environment
 	 */
 	protected static function httpHost()
 	{
-		if (!empty($_SERVER['HTTP_HOST']))
-		{
-			$host = $_SERVER['HTTP_HOST'];
-		}
-		else
-		{
-			$host = $_SERVER['SERVER_NAME'];
-
-			if ($_SERVER['SERVER_PORT'] != 80)
-			{
-				$host .= ':' . $_SERVER['SERVER_PORT'];
-			}
-		}
-
-		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', $host);
+		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', self::$objRequest->getHttpHost());
 	}
 
 
@@ -321,7 +281,8 @@ class Environment
 	 */
 	protected static function httpXForwardedHost()
 	{
-		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', @$_SERVER['HTTP_X_FORWARDED_HOST']);
+		// FIXME: is broken.
+		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', self::$objRequest->headers->get('X-Forwarded-For'));
 	}
 
 
@@ -332,7 +293,7 @@ class Environment
 	 */
 	protected static function ssl()
 	{
-		return (@$_SERVER['SSL_SESSION_ID'] || @$_SERVER['HTTPS'] == 'on' || @$_SERVER['HTTPS'] == 1);
+		return self::$objRequest->server->get('SSL_SESSION_ID') || (self::$objRequest->server->get('HTTPS') == 'on') || (self::$objRequest->server->get('HTTPS') == 1);
 	}
 
 
@@ -374,14 +335,7 @@ class Environment
 	 */
 	protected static function ip()
 	{
-		$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		if ($request === null)
-		{
-			return '';
-		}
-
-		return $request->getClientIp();
+		return self::$objRequest->getClientIp();
 	}
 
 
@@ -392,12 +346,12 @@ class Environment
 	 */
 	protected static function server()
 	{
-		$strServer = !empty($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : $_SERVER['LOCAL_ADDR'];
+		$strServer = self::$objRequest->server->get('SERVER_ADDR', self::$objRequest->server->get('LOCAL_ADDR'));
 
 		// Special workaround for Strato users
 		if (empty($strServer))
 		{
-			$strServer = @gethostbyname($_SERVER['SERVER_NAME']);
+			$strServer = @gethostbyname(self::$objRequest->server->get('SERVER_NAME'));
 		}
 
 		return $strServer;
@@ -411,14 +365,7 @@ class Environment
 	 */
 	protected static function path()
 	{
-		$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		if ($request === null)
-		{
-			return '';
-		}
-
-		return $request->getBasePath();
+		return self::$objRequest->getBasePath();
 	}
 
 
@@ -502,7 +449,7 @@ class Environment
 	 */
 	protected static function isAjaxRequest()
 	{
-		return @$_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest';
+		return self::$objRequest->headers->get('X-Requested-With') == 'XMLHttpRequest';
 	}
 
 

--- a/src/Resources/contao/library/Contao/Environment.php
+++ b/src/Resources/contao/library/Contao/Environment.php
@@ -54,7 +54,7 @@ class Environment
 	protected static $arrCache = array();
 
 	/**
-	 * Gateway function used by Contao3RequestSynchronizingListener to push the current (sub-)request.
+	 * Gateway function used by LegacyRequestValueSynchronizingListener to push the current (sub-)request.
 	 *
 	 * @param Request $objRequest The request.
 	 */

--- a/src/Resources/contao/library/Contao/RequestToken.php
+++ b/src/Resources/contao/library/Contao/RequestToken.php
@@ -75,10 +75,12 @@ class RequestToken
 			return true;
 		}
 
+		$container = \System::getContainer();
+
 		// Check against the whitelist (thanks to Tristan Lins) (see #3164)
 		if (\Config::get('requestTokenWhitelist'))
 		{
-			$strHostname = gethostbyaddr($_SERVER['REMOTE_ADDR']);
+			$strHostname = gethostbyaddr($container->get('request_stack')->getCurrentRequest()->getClientIp());
 
 			foreach (\Config::get('requestTokenWhitelist') as $strDomain)
 			{
@@ -88,8 +90,6 @@ class RequestToken
 				}
 			}
 		}
-
-		$container = \System::getContainer();
 
 		return $container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), $strToken));
 	}

--- a/tests/Contao/EnvironmentTest.php
+++ b/tests/Contao/EnvironmentTest.php
@@ -22,15 +22,32 @@ use Symfony\Component\HttpFoundation\Request;
 class EnvironmentTest extends TestCase
 {
     /**
+     * @var array
+     */
+    private static $server;
+
+    /**
      * {@inheritdoc}
      */
     public static function setupBeforeClass()
     {
+        parent::setUpBeforeClass();
+        self::$server = $_SERVER;
+
         Environment::reset();
         Environment::set('path', '/core');
 
         require __DIR__.'/../../src/Resources/contao/config/default.php';
         require __DIR__.'/../../src/Resources/contao/config/agents.php';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function tearDownAfterClass()
+    {
+        $_SERVER = self::$server;
+        parent::tearDownAfterClass();
     }
 
     /**

--- a/tests/Contao/WidgetTest.php
+++ b/tests/Contao/WidgetTest.php
@@ -10,7 +10,9 @@
 
 namespace Contao\CoreBundle\Test\Contao;
 
+use Contao\CoreBundle\Request\ValueAdapter;
 use Contao\Input;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the Widget class.
@@ -55,9 +57,7 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
 
         $method->setAccessible(true);
 
-        $_POST[$input] = $value;
-        Input::resetCache();
-        Input::initialize();
+        Input::setValueAdapter(new ValueAdapter(new Request([], [$input => $value])));
 
         $this->assertEquals($expected, $method->invoke($widget, $key));
 

--- a/tests/EventListener/AddToSearchIndexListenerTest.php
+++ b/tests/EventListener/AddToSearchIndexListenerTest.php
@@ -13,8 +13,9 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\EventListener\AddToSearchIndexListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Tests the AddToSearchIndexListener class.
@@ -83,14 +84,14 @@ class AddToSearchIndexListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new AddToSearchIndexListener($this->framework);
-        $event = $this->mockPostResponseEvent();
+        $event = $this->mockFilterResponseEvent();
 
         $event
             ->expects($this->never())
             ->method('getResponse')
         ;
 
-        $listener->onKernelTerminate($event);
+        $listener->onKernelResponse($event);
     }
 
     /**
@@ -108,7 +109,7 @@ class AddToSearchIndexListenerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $listener = new AddToSearchIndexListener($this->framework);
-        $event = $this->mockPostResponseEvent();
+        $event = $this->mockFilterResponseEvent();
 
         $event
             ->expects($this->once())
@@ -116,22 +117,23 @@ class AddToSearchIndexListenerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new Response())
         ;
 
-        $listener->onKernelTerminate($event);
+        $listener->onKernelResponse($event);
     }
 
     /**
      * Returns a PostResponseEvent mock object.
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject|PostResponseEvent
+     * @return \PHPUnit_Framework_MockObject_MockObject|FilterResponseEvent
      */
-    private function mockPostResponseEvent()
+    private function mockFilterResponseEvent()
     {
         return $this->getMock(
-            'Symfony\Component\HttpKernel\Event\PostResponseEvent',
+            'Symfony\Component\HttpKernel\Event\FilterResponseEvent',
             ['getResponse'],
             [
                 $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]),
                 new Request(),
+                HttpKernelInterface::MASTER_REQUEST,
                 new Response(),
             ]
         );

--- a/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
+++ b/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\EventListener;
+
+use Contao\CoreBundle\EventListener\LegacyRequestValueSynchronizingListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Tests the LegacyRequestValueSynchronizingListener class.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ */
+class LegacyRequestValueSynchronizingListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that the getSubscribedEvents() method subscribes to all desired events.
+     */
+    public function testSubscribesToAllEvents()
+    {
+        $this->assertEquals(
+            [KernelEvents::REQUEST, KernelEvents::FINISH_REQUEST],
+            array_keys(LegacyRequestValueSynchronizingListener::getSubscribedEvents())
+        );
+    }
+
+    /**
+     * Test that the request is handled correctly.
+     */
+    public function testRequestHandling()
+    {
+        $stack = new RequestStack();
+
+        $stack->push($request1 = new Request(['param' => 'value']));
+
+        $listener = new LegacyRequestValueSynchronizingListener($stack);
+        $listener->startRequest();
+
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $stack->push($request2 = new Request(['param2' => 'value2']));
+        $listener->startRequest();
+        $this->assertEnvironmentHas($request2);
+        $this->assertInputHas($request2);
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
+    }
+
+    /**
+     * Assertion helper to check that the Environment class holds the correct request.
+     *
+     * @param Request $expectedRequest The expected request
+     */
+    private function assertEnvironmentHas($expectedRequest)
+    {
+        $environment = new \ReflectionProperty('\Contao\Environment', 'objRequest');
+        $environment->setAccessible(true);
+        $this->assertSame($expectedRequest, $environment->getValue());
+    }
+
+    /**
+     * Assertion helper to check that the Input class holds the correct request.
+     *
+     * @param Request $expectedRequest The expected request
+     */
+    private function assertInputHas($expectedRequest)
+    {
+        $input = new \ReflectionProperty('\Contao\Input', 'objValueAdapter');
+        $input->setAccessible(true);
+
+        if (null === $expectedRequest) {
+            $this->assertNull($input->getValue());
+            return;
+        }
+
+        $this->assertSame($expectedRequest, $input->getValue()->request);
+    }
+}

--- a/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
+++ b/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\EventListener\LegacyRequestValueSynchronizingListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Tests the LegacyRequestValueSynchronizingListener class.
@@ -22,17 +21,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class LegacyRequestValueSynchronizingListenerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * Test that the getSubscribedEvents() method subscribes to all desired events.
-     */
-    public function testSubscribesToAllEvents()
-    {
-        $this->assertEquals(
-            [KernelEvents::REQUEST, KernelEvents::FINISH_REQUEST],
-            array_keys(LegacyRequestValueSynchronizingListener::getSubscribedEvents())
-        );
-    }
-
     /**
      * Test that the request is handled correctly.
      */

--- a/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
+++ b/tests/EventListener/LegacyRequestValueSynchronizingListenerTest.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\Test\EventListener;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\LegacyRequestValueSynchronizingListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -24,7 +25,67 @@ class LegacyRequestValueSynchronizingListenerTest extends \PHPUnit_Framework_Tes
     /**
      * Test that the request is handled correctly.
      */
-    public function testRequestHandling()
+    public function testRequestHandlingBackend()
+    {
+        $stack = new RequestStack();
+
+        $stack->push($request1 = new Request(['param' => 'value'], [], ['_scope' => ContaoCoreBundle::SCOPE_BACKEND]));
+
+        $listener = new LegacyRequestValueSynchronizingListener($stack);
+        $listener->startRequest();
+
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $stack->push($request2 = new Request(['param2' => 'value2'], [], ['_scope' => ContaoCoreBundle::SCOPE_BACKEND]));
+        $listener->startRequest();
+        $this->assertEnvironmentHas($request2);
+        $this->assertInputHas($request2);
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
+    }
+
+    /**
+     * Test that the request is handled correctly.
+     */
+    public function testRequestHandlingFrontend()
+    {
+        $stack = new RequestStack();
+
+        $stack->push($request1 = new Request(['param' => 'value'], [], ['_scope' => ContaoCoreBundle::SCOPE_FRONTEND]));
+
+        $listener = new LegacyRequestValueSynchronizingListener($stack);
+        $listener->startRequest();
+
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $stack->push($request2 = new Request(['param2' => 'value2'], [], ['_scope' => ContaoCoreBundle::SCOPE_FRONTEND]));
+        $listener->startRequest();
+        $this->assertEnvironmentHas($request2);
+        $this->assertInputHas($request2);
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas($request1);
+        $this->assertInputHas($request1);
+
+        $listener->finishRequest();
+        $stack->pop();
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
+    }
+
+    /**
+     * Test that the request is handled correctly.
+     */
+    public function testRequestHandlingForNonContao()
     {
         $stack = new RequestStack();
 
@@ -33,17 +94,17 @@ class LegacyRequestValueSynchronizingListenerTest extends \PHPUnit_Framework_Tes
         $listener = new LegacyRequestValueSynchronizingListener($stack);
         $listener->startRequest();
 
-        $this->assertEnvironmentHas($request1);
-        $this->assertInputHas($request1);
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
 
         $stack->push($request2 = new Request(['param2' => 'value2']));
         $listener->startRequest();
-        $this->assertEnvironmentHas($request2);
-        $this->assertInputHas($request2);
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
         $listener->finishRequest();
         $stack->pop();
-        $this->assertEnvironmentHas($request1);
-        $this->assertInputHas($request1);
+        $this->assertEnvironmentHas(null);
+        $this->assertInputHas(null);
 
         $listener->finishRequest();
         $stack->pop();

--- a/tests/EventListener/ToggleViewListenerTest.php
+++ b/tests/EventListener/ToggleViewListenerTest.php
@@ -29,6 +29,11 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 class ToggleViewListenerTest extends TestCase
 {
     /**
+     * @var array
+     */
+    private static $server;
+
+    /**
      * @var ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
      */
     private $framework;
@@ -38,9 +43,21 @@ class ToggleViewListenerTest extends TestCase
      */
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+        self::$server = $_SERVER;
+
         $_SERVER['HTTP_HOST'] = 'localhost';
         Environment::setRequest(Request::createFromGlobals());
         $_SERVER = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function tearDownAfterClass()
+    {
+        $_SERVER = self::$server;
+        parent::tearDownAfterClass();
     }
 
     /**

--- a/tests/EventListener/ToggleViewListenerTest.php
+++ b/tests/EventListener/ToggleViewListenerTest.php
@@ -13,6 +13,7 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\ToggleViewListener;
 use Contao\CoreBundle\Test\TestCase;
+use Contao\Environment;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +39,8 @@ class ToggleViewListenerTest extends TestCase
     public static function setUpBeforeClass()
     {
         $_SERVER['HTTP_HOST'] = 'localhost';
+        Environment::setRequest(Request::createFromGlobals());
+        $_SERVER = [];
     }
 
     /**

--- a/tests/Request/ValueAdapterTest.php
+++ b/tests/Request/ValueAdapterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Request;
+
+use Contao\CoreBundle\Request\ValueAdapter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Test the ValueAdapter class.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ */
+class ValueAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that the internal cache works correctly.
+     */
+    public function testCachingWorks()
+    {
+        $adapter = new ValueAdapter(new Request());
+
+        $this->assertFalse($adapter->hasCached('cacheKey', 'valueName'));
+        $adapter->removeCached('cacheKey', 'valueName');
+        $this->assertFalse($adapter->hasCached('cacheKey', 'valueName'));
+        $this->assertNull($adapter->getCached('cacheKey', 'valueName'));
+        $this->assertEquals('value', $adapter->setCached('cacheKey', 'valueName', 'value'));
+        $this->assertTrue($adapter->hasCached('cacheKey', 'valueName'));
+        $this->assertEquals('value', $adapter->getCached('cacheKey', 'valueName'));
+        $adapter->removeCached('cacheKey', 'valueName');
+        $this->assertFalse($adapter->hasCached('cacheKey', 'valueName'));
+
+        $adapter->setCached('cacheKey', 'valueName', 'value');
+        $adapter->setCached('cacheKey', 'valueName', 'value2');
+        $this->assertEquals('value2', $adapter->getCached('cacheKey', 'valueName'));
+
+        $adapter->clearCache();
+        $this->assertNull($adapter->getCached('cacheKey', 'valueName'));
+    }
+
+    /**
+     * Test that marking parameters as used and unused works.
+     */
+    public function testUsedGetParameterHandling()
+    {
+        $adapter = new ValueAdapter(new Request());
+
+        $this->assertFalse($adapter->hasUnusedGet());
+        $adapter->setUsed('test', false);
+        $adapter->setUsed('test2', false);
+        $this->assertTrue($adapter->hasUnusedGet());
+        $this->assertEquals(['test', 'test2'], $adapter->getUnusedGet());
+        $adapter->setUsed('test');
+        $this->assertEquals(['test2'], $adapter->getUnusedGet());
+    }
+
+    /**
+     * Test that exporting the globals works.
+     */
+    public function testExportGlobals()
+    {
+        $adapter = new ValueAdapter(new Request());
+
+        $adapter->exportGlobals();
+
+        $this->assertEmpty($_GET);
+        $this->assertEmpty($_POST);
+        $this->assertEmpty($_COOKIE);
+
+        $adapter->filtered->query->set('test', 'value');
+        $this->assertEquals(['test' => 'value'], $_GET);
+
+        $adapter->filtered->request->set('test', 'value');
+        $this->assertEquals(['test' => 'value'], $_POST);
+
+        $adapter->filtered->cookies->set('test', 'value');
+        $this->assertEquals(['test' => 'value'], $_COOKIE);
+
+        $_GET['another'] = 'value';
+        $this->assertEquals(['test' => 'value', 'another' => 'value'], $adapter->filtered->query->all());
+    }
+}


### PR DESCRIPTION
This PR tries to remove the dependency on the super global arrays `$_SERVER`, `$_GET`, `$_POST` and  `$_COOKIE`.

It does so by registering a new listener which is executed upon every request prior and after the request has been handled.

Things to do:
- [X] Make class `\Contao\Environment` independent of super globals.
- [X] Make class `\Contao\Input` independent of super globals (It still holds a dependency on `$_SESSION` which can not be solved in the current state - we need to discuss).
  - [X] Link the filtered request values to the super globals.
- [X] Make class `ValueAdapter` final so no one will tamper with it 71c861f.
- [X] Utilize `return self::$objRequest->isXmlHttpRequest();` in `Environment` d8bee92.
- [ ] Remove access to super globals from the core where possible (rewrite to use the request directly).
- [ ] Remove access to `Environment` and `Input` from the core where possible (rewrite to use the request directly).
- [x] Use scopes in `LegacyRequestValueSynchronizingListener` 2c27fb1.

Some words about the implementation:
I tried to keep the changes to an absolute minimum while maintaining the maximum of backwards compatibility, therefore the whole input filtering is still in the input class and hence still not unit tested.
I'd prefer to move the filter stuff into `Utils\InputFilter` or something like that as they are completely unrelated to the input itself (aside from caching), even as we intend to remove all of this for Contao 5 it would be better to move the XSS checks and the like into an own class as the `Input` class would become a pretty small delegator then.

So far I have not run into any bc breaks, if you find some, please comment.

Things to decide:

* Move enconding methods from `\Input` to `StringUtil`
  - [ ] `\Input::stripTags` (Strip HTML and PHP tags preserving HTML comments).
  - [ ] `\Input::decodeEntities` (Decode HTML entities - will be needed for converting the current DB values to unencoded values in Contao 5 when we switch to output encoding).
  - [ ] `\Input::preserveBasicEntities` (Preserve basic entities by replacing them with square brackets (e.g. `&amp;` becomes `[amp]` - comes in handy when working with the RTE and we have the restoreBasicEntities in `StringUtil` already so why not also this method?)).
  - [ ] `\Input::encodeSpecialChars` (Encode special characters which are potentially dangerous, these are: `[#<>()\=]`).
  - [ ] `\Input::encodeInsertTags` (Encode the opening and closing delimiters of insert tags - don't know if we still need this when we have fragments).