### PR TITLE
[WIP] Feature/preflight http cache

### DIFF
--- a/src/Controller/PreflightRequestController.php
+++ b/src/Controller/PreflightRequestController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\CoreBundle\Event\ContaoCoreEvents;
+use Contao\CoreBundle\Event\PreflightRequestEvent;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Handles the Contao preflight route.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestController extends Controller
+{
+    /**
+     * EventDispatcher
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * PreflightController constructor.
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Handles the preflight request.
+     *
+     * @return Response
+     */
+    public function indexAction()
+    {
+        $event = new PreflightRequestEvent();
+        $event->setResponse(new Response());
+
+        $this->eventDispatcher->dispatch(ContaoCoreEvents::PREFLIGHT_REQUEST, $event);
+
+        return $event->getResponse();
+    }
+}

--- a/src/Event/ContaoCoreEvents.php
+++ b/src/Event/ContaoCoreEvents.php
@@ -37,6 +37,15 @@ final class ContaoCoreEvents
     const IMAGE_SIZES_USER = 'contao.image_sizes_user';
 
     /**
+     * The contao.preflight_request event is triggered when a preflight request is executed.
+     *
+     * @var string
+     *
+     * @see Contao\CoreBundle\Event\PreflightRequestEvent
+     */
+    const PREFLIGHT_REQUEST = 'contao.preflight_request';
+
+    /**
      * The contao.preview_url_create event is triggered when the front end preview URL is generated.
      *
      * @var string

--- a/src/Event/PreflightRequestEvent.php
+++ b/src/Event/PreflightRequestEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Allows to modify the preflight response.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestEvent extends Event
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/HttpKernel/HttpCache/PreflightRequestHttpCache.php
+++ b/src/HttpKernel/HttpCache/PreflightRequestHttpCache.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\HttpKernel\HttpCache;
+
+use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * This class executes a preflight request to the application if the request
+ * contains certain (configurable) HTTP headers. This preflight request contains
+ * the full original request (except for the path obviously) which is passed on
+ * as an HTTP header for reference.
+ * The original request is then decorated by the headers of the response of the
+ * preflight request and finally passed on to the regular Symfony HTTP cache.
+ *
+ * This mainly allows to implement advanced caching. If your application contains
+ * state, a lot of the information might be bound to the cookie which is sent by
+ * a single HTTP header (named "Cookie"). For any proxy it is thus impossible to
+ * represent different cache entries for the same URI as it can only vary (HTTP
+ * Vary header) on the Cookie header which is not recommended as it would generate
+ * way too many cache entries. The preflight request allows you to sort of split
+ * e.g. the sent Cookie header into different headers which will then allow you
+ * to easily vary on.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestHttpCache extends HttpCache
+{
+    private $mockResponse = null;
+    private $mockPreflightResponse = null;
+    private $parentHandleWasCalled = false;
+    private $parentPassWasCalled = false;
+
+    private $preflightOptions = [
+        'matchHeaders'           => ['Cookie', 'Authorization'],
+        'preflightPath'          => '/contao/preflight',
+        'decorateHeadersPrefix'  => 'Contao-Vary-',
+        'originalPathHeaderName' => 'Contao-Original-Path'
+    ];
+
+    /**
+     * @return array
+     */
+    public function getPreflightOptions()
+    {
+        return $this->preflightOptions;
+    }
+
+    /**
+     * @param array $preflightOptions
+     */
+    public function setPreflightOptions(array $preflightOptions)
+    {
+        $this->preflightOptions = $preflightOptions;
+    }
+
+    /**
+     * Mock the response (useful for unit testing).
+     *
+     * @param Response $response
+     */
+    public function setMockResponse(Response $response = null)
+    {
+        $this->mockResponse = $response;
+    }
+
+    /**
+     * Mock the preflight response (useful for unit testing).
+     *
+     * @param Response $response
+     */
+    public function setMockPreflightResponse(Response $response = null)
+    {
+        $this->mockPreflightResponse = $response;
+    }
+
+    /**
+     * Only needed for unit testing.
+     *
+     * @return boolean
+     */
+    public function getParentHandleWasCalled()
+    {
+        return $this->parentHandleWasCalled;
+    }
+
+    /**
+     * Only needed for unit testing.
+     *
+     * @return boolean
+     */
+    public function getParentPassWasCalled()
+    {
+        return $this->parentPassWasCalled;
+    }
+
+    /**
+     * @param Request $request
+     * @param int     $type
+     * @param bool    $catch
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        if (!$this->matchesPreflightRequirements($request)) {
+
+            return $this->parentHandle($request, $type, $catch);
+        }
+
+        $preflightRequest = $this->createPreflightRequest($request);
+
+        $preflightResponse = $this->parentPass($preflightRequest, $catch);
+
+        $this->decorateRequestWithPreflightResponse($request, $preflightResponse);
+
+        return $this->parentHandle($request, $type, $catch);
+    }
+
+    /**
+     * @param Request $request
+     * @param int     $type
+     * @param bool    $catch
+     *
+     * @return null|Response
+     */
+    private function parentHandle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        $this->parentHandleWasCalled = true;
+
+        if (null !== $this->mockResponse) {
+
+            return $this->mockResponse;
+        }
+
+        return parent::handle($request, $type, $catch);
+    }
+
+    /**
+     * @param Request $request
+     * @param         $catch
+     *
+     * @return null|Response
+     */
+    private function parentPass(Request $request, $catch)
+    {
+        $this->parentPassWasCalled = true;
+
+        if (null !== $this->mockPreflightResponse) {
+
+            return $this->mockPreflightResponse;
+        }
+
+        return parent::pass($request, $catch);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function matchesPreflightRequirements(Request $request)
+    {
+        // A none safe request is always ignored
+        if (!$request->isMethodSafe()) {
+
+            return false;
+        }
+
+        foreach ($this->preflightOptions['matchHeaders'] as $header) {
+            if ('Cookie' === $header) {
+                if (0 !== $request->cookies->count()) {
+
+                    return true;
+                }
+            }
+
+            if ($request->headers->has($header)) {
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Request
+     */
+    public function createPreflightRequest(Request $request)
+    {
+        $queryString = $request->getQueryString();
+
+        // Override path
+        $server = $request->server->all();
+        $server['REQUEST_URI'] = $this->preflightOptions['preflightPath'] . ('' !== $queryString ? '?' . $queryString : '');
+
+        $preflightRequest = $request->duplicate(null, null, null, null, null, $server);
+        $preflightRequest->headers->set(
+            $this->preflightOptions['originalPathHeaderName'],
+            $request->getPathInfo() . ('' !== $queryString ? '?' . $queryString : '')
+        );
+
+        return $preflightRequest;
+    }
+
+    /**
+     * @param Request  $request
+     * @param Response $preflightResponse
+     */
+    public function decorateRequestWithPreflightResponse(Request $request, Response $preflightResponse)
+    {
+        $rgxp = '/^' . preg_quote($this->preflightOptions['decorateHeadersPrefix'], '/') . '/i';
+
+        foreach ($preflightResponse->headers->all() as $header => $value) {
+            if (preg_match($rgxp, $header)) {
+                $request->headers->set($header, $value);
+            }
+        }
+    }
+}

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -2,6 +2,13 @@ contao:
     resource: "@ContaoCoreBundle/Controller"
     type: annotation
 
+# Caching preflight request
+contao_preflight:
+    path: /contao/preflight
+    defaults:
+        _scope: frontend
+        _controller: "contao.controller.preflight_request:indexAction"
+
 # Redirect /contao/ to /contao
 contao_backend_redirect:
     path: /contao/

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -27,6 +27,11 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
+    contao.controller.preflight_request:
+        class: Contao\CoreBundle\Controller\PreflightRequestController
+        arguments:
+            - "@event_dispatcher"
+
     contao.data_collector:
         class: Contao\CoreBundle\DataCollector\ContaoDataCollector
         public: false

--- a/tests/Controller/PreflightRequestControllerTest.php
+++ b/tests/Controller/PreflightRequestControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Controller;
+use Contao\CoreBundle\Controller\PreflightRequestController;
+use Contao\CoreBundle\Event\ContaoCoreEvents;
+use Contao\CoreBundle\Event\PreflightRequestEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Response;
+
+
+/**
+ * Tests the PreflightRequestController class.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $controller = new PreflightRequestController(new EventDispatcher());
+
+        $this->assertInstanceOf('Contao\CoreBundle\Controller\PreflightRequestController', $controller);
+    }
+
+    /**
+     * Tests the controller indexAction.
+     */
+    public function testIndexAction()
+    {
+        $response = new Response();
+        $event = new PreflightRequestEvent();
+        $event->setResponse($response);
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(ContaoCoreEvents::PREFLIGHT_REQUEST, function(PreflightRequestEvent $event) {
+            $event->getResponse()->setContent('foobar content');
+
+        });
+        $controller = new PreflightRequestController($eventDispatcher);
+
+        $this->assertSame('foobar content', $controller->indexAction()->getContent());
+    }
+}

--- a/tests/Event/PreflightRequestEventTest.php
+++ b/tests/Event/PreflightRequestEventTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Event;
+
+use Contao\CoreBundle\Event\PreflightRequestEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests the PreflightRequestEvent class.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $event = new PreflightRequestEvent();
+
+        $this->assertInstanceOf('Contao\CoreBundle\Event\PreflightRequestEvent', $event);
+    }
+
+    /**
+     * Tests the getters and setters.
+     */
+    public function testSetAndGet()
+    {
+        $event = new PreflightRequestEvent();
+        $response = new Response('foobar');
+
+        $event->setResponse($response);
+
+        $this->assertSame($response, $event->getResponse());
+    }
+}

--- a/tests/HttpKernel/HttpCache/PreflightRequestHttpCacheTest.php
+++ b/tests/HttpKernel/HttpCache/PreflightRequestHttpCacheTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\HttpKernel\HttpCache;
+
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests the PreflightRequestHttpCache class.
+ *
+ * @author Yanick Witschi <https://github.com/toflar>
+ */
+class PreflightRequestHttpCacheTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $this->assertInstanceOf('Contao\CoreBundle\HttpKernel\HttpCache\PreflightRequestHttpCache', $preflightKernel);
+    }
+
+    public function testNoPreflightIsExecutedWhenRequestDoesNotMatch()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $preflightKernel->setMockResponse(new Response());
+
+        $request = new Request();
+        $request->headers->set('Content-Type', 'application/json');
+
+        $preflightKernel->handle($request);
+        $this->assertTrue($preflightKernel->getParentHandleWasCalled());
+        $this->assertFalse($preflightKernel->getParentPassWasCalled());
+    }
+
+    public function testPreflightIsExecutedWhenRequestDoesMatch()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $preflightKernel->setMockResponse(new Response());
+        $preflightKernel->setMockPreflightResponse(new Response());
+
+        $request = new Request();
+        $request->headers->set('Authorization', 'foobar');
+
+        $preflightKernel->handle($request);
+        $this->assertTrue($preflightKernel->getParentHandleWasCalled());
+        $this->assertTrue($preflightKernel->getParentPassWasCalled());
+    }
+
+    public function testPreflightIsExecutedWhenRequestDoesMatchOnCookies()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $preflightKernel->setMockResponse(new Response());
+        $preflightKernel->setMockPreflightResponse(new Response());
+
+        $request = new Request();
+        $request->cookies->set('My-Cookie', 'foobar');
+
+        $preflightKernel->handle($request);
+        $this->assertTrue($preflightKernel->getParentHandleWasCalled());
+        $this->assertTrue($preflightKernel->getParentPassWasCalled());
+    }
+
+    public function testPreflightRequestIsCorrectlyBuilt()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $options = $preflightKernel->getPreflightOptions();
+
+        $request = Request::create(
+            'https://www.domain.tld/about/us?foo=bar',
+            'GET',
+            [],
+            [],
+            [],
+            ['HTTP_VERY_IMPORTANT_HEADER' => 'actually;not']
+        );
+
+
+        $preflightRequest = $preflightKernel->createPreflightRequest($request);
+
+        $this->assertSame($options['preflightPath'], $preflightRequest->getPathInfo());
+        $this->assertTrue($preflightRequest->headers->has('Very-Important-Header'));
+        $this->assertTrue($preflightRequest->headers->has($options['originalPathHeaderName']));
+        $this->assertSame('/about/us?foo=bar', $preflightRequest->headers->get($options['originalPathHeaderName']));
+    }
+
+    public function testRequestIsCorrectlyDecoratedByPreflightRequestHeaders()
+    {
+        $preflightKernel = new PreflightRequestHttpCache($this->mockKernel(), __DIR__);
+        $options = $preflightKernel->getPreflightOptions();
+
+        $request = new Request();
+        $preflightResponse = new Response();
+
+
+        $preflightResponse->headers->set($options['decorateHeadersPrefix'] . 'Foobar', 'foobar');
+        $preflightResponse->headers->set('Some-Irrelevant-Header', 'foobar');
+
+        $preflightKernel->decorateRequestWithPreflightResponse($request, $preflightResponse);
+
+        $this->assertTrue($request->headers->has($options['decorateHeadersPrefix'] . 'Foobar'));
+        $this->assertFalse($request->headers->has('Some-Irrelevant-Header'));
+    }
+}


### PR DESCRIPTION
This PR implements the preflight request functionality to allow proxies to vary on different headers. It already contains the support for Symfony's HttpCache. You only need to edit your `AppCache.php` like this:

``` diff
- class AppCache extends Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache
+ class AppCache extends Contao\CoreBundle\HttpKernel\HttpCache\PreflightRequestHttpCache
{
}
```

This PR is WIP and here for reference only. As written in (https://github.com/contao/core-bundle/issues/574) it will require numbers 2, 3 and 7 before it can be finished (the listeners have to be written) so there's no point in commenting on it yet (as I'm off for September now anyway).
