### PR TITLE
Use class set in config.php for form module to allow customization

### DIFF
--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -531,7 +531,13 @@ abstract class Controller extends \System
 
 		$objRow->typePrefix = 'ce_';
 		$objRow->form = $objRow->id;
-		$objElement = new \Form($objRow, $strColumn);
+
+		$class = Module::findClass('form');
+		if (!class_exists($class)) {
+			throw new \RuntimeException('Class for module of type \'form\' could not be found.');
+		}
+		$objElement = new $class($objRow, $strColumn);
+
 		$strBuffer = $objElement->generate();
 
 		// HOOK: add custom logic


### PR DESCRIPTION
Overriding the class used for the form frontend module does not work when using getForm() of  Controller.php.

Let's use Module::findClass() to resolve the class.