### PR TITLE
Prevent double parse of the page frontend template

### DIFF
--- a/src/Resources/contao/classes/FrontendTemplate.php
+++ b/src/Resources/contao/classes/FrontendTemplate.php
@@ -102,6 +102,13 @@ class FrontendTemplate extends \Template
 	 */
 	protected function compile($blnCheckRequest=false)
 	{
+		// Do not compile the template again if already called e.g. by parent::getResponse()
+		if ($this->strBuffer)
+		{
+			parent::compile();
+			return;
+		}
+
 		$this->keywords = '';
 		$arrKeywords = \StringUtil::trimsplit(',', $GLOBALS['TL_KEYWORDS']);
 


### PR DESCRIPTION
I am not sure if this is intended behavior so please ignore if it is. I have noticed that the ```fe_*``` templates are being parsed twice upon each page render. For example if you add a simple ```<?php dump('foobar') ?>``` in such template you will see it twice in the Symfony's debug bar.

This happens because:

1. The ```PageRegular``` calls the ```FrontendTemplate::getResponse``` (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/pages/PageRegular.php#L51)
2. The ```FrontendTemplate``` compiles itself for the first time (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/FrontendTemplate.php#L88)
3. After the compilation it calls the ```Template::getResponse()``` method (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/FrontendTemplate.php#L90)
4. The ```Template::getResponse()``` method compiles template **again** as the ```compile()``` method is overridden by ```FrontendTemplate``` class (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/library/Contao/Template.php#L313)
5. The response is finally returned (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/library/Contao/Template.php#L320)

The solution would be to apply the very same check of the buffer that is in the ```Template::compile()``` method.

I believe it will be solved in 5.0 when the method becomes private (https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/FrontendTemplate.php#L101) but for now this could be fixed.

Note: this probably does not relate to other frontend templates as ```FrontendTemplate::getResponse()``` seems to be explicitly called by pages only.