### PR TITLE
[RTM] Hotfix/scope aware trait

### DIFF
--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\DataCollector;
 
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\LayoutModel;
 use Contao\Model\Registry;
 use Contao\PageModel;
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 class ContaoDataCollector extends DataCollector
 {
     use FrameworkAwareTrait;
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var array

--- a/src/DataCollector/ContaoDataCollector.php
+++ b/src/DataCollector/ContaoDataCollector.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\DataCollector;
 
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Contao\LayoutModel;
 use Contao\Model\Registry;
 use Contao\PageModel;
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 class ContaoDataCollector extends DataCollector
 {
     use FrameworkAwareTrait;
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var array

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  * Persists the locale from the accept header or the request in the session.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class LocaleListener
 {
@@ -47,11 +48,11 @@ class LocaleListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$this->isContaoScope()) {
+        $request = $event->getRequest();
+        if (!$this->isContaoScope($request)) {
             return;
         }
 
-        $request = $event->getRequest();
         $locale = $this->getLocale($request);
 
         $request->attributes->set('_locale', $locale);

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class LocaleListener
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var array

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class LocaleListener
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var array

--- a/src/EventListener/RefererIdListener.php
+++ b/src/EventListener/RefererIdListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  */
 class RefererIdListener
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var CsrfTokenManagerInterface

--- a/src/EventListener/RefererIdListener.php
+++ b/src/EventListener/RefererIdListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  */
 class RefererIdListener
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var CsrfTokenManagerInterface

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 class StoreRefererListener
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
     use UserAwareTrait;
 
     /**

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 class StoreRefererListener
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
     use UserAwareTrait;
 
     /**

--- a/src/EventListener/StoreRefererListener.php
+++ b/src/EventListener/StoreRefererListener.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  *
  * @author Yanick Witschi <https://github.com/toflar>
  * @author Leo Feyer <https://github.com/leofeyer>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class StoreRefererListener
 {
@@ -54,7 +55,7 @@ class StoreRefererListener
 
         $request = $event->getRequest();
 
-        if ($this->isBackendScope()) {
+        if ($this->isBackendScope($request)) {
             $this->storeBackendReferer($request);
         } else {
             $this->storeFrontendReferer($request);

--- a/src/EventListener/ToggleViewListener.php
+++ b/src/EventListener/ToggleViewListener.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class ToggleViewListener
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var ContaoFrameworkInterface

--- a/src/EventListener/ToggleViewListener.php
+++ b/src/EventListener/ToggleViewListener.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class ToggleViewListener
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var ContaoFrameworkInterface

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\FrontendUser;
 use Contao\User;
 use Doctrine\DBAL\Connection;
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class UserSessionListener
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
     use UserAwareTrait;
 
     /**

--- a/src/EventListener/UserSessionListener.php
+++ b/src/EventListener/UserSessionListener.php
@@ -11,7 +11,7 @@
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Contao\FrontendUser;
 use Contao\User;
 use Doctrine\DBAL\Connection;
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class UserSessionListener
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
     use UserAwareTrait;
 
     /**

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -189,7 +189,7 @@ class ContaoFramework implements ContaoFrameworkInterface
         }
 
         // Define the login status constants in the back end (see #4099, #5279)
-        if (!$this->request || !$this->isFrontendScope($this->request)) {
+        if (!($this->request instanceof Request) || !$this->isFrontendScope($this->request)) {
             define('BE_USER_LOGGED_IN', false);
             define('FE_USER_LOGGED_IN', false);
         }
@@ -205,11 +205,15 @@ class ContaoFramework implements ContaoFrameworkInterface
      */
     private function getMode()
     {
-        if ($this->request && $this->isBackendScope($this->request)) {
+        if (!($this->request instanceof Request)) {
+            return null;
+        }
+
+        if ($this->isBackendScope($this->request)) {
             return 'BE';
         }
 
-        if ($this->request && $this->isFrontendScope($this->request)) {
+        if ($this->isFrontendScope($this->request)) {
             return 'FE';
         }
 

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -19,6 +19,7 @@ use Contao\Input;
 use Contao\RequestToken;
 use Contao\System;
 use Contao\TemplateLoader;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -37,7 +38,8 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class ContaoFramework implements ContaoFrameworkInterface
 {
-    use ScopeAwareTrait;
+    use ContainerAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var bool

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -187,7 +187,7 @@ class ContaoFramework implements ContaoFrameworkInterface
         }
 
         // Define the login status constants in the back end (see #4099, #5279)
-        if (!$this->isFrontendScope()) {
+        if (!$this->request || !$this->isFrontendScope($this->request)) {
             define('BE_USER_LOGGED_IN', false);
             define('FE_USER_LOGGED_IN', false);
         }
@@ -203,11 +203,11 @@ class ContaoFramework implements ContaoFrameworkInterface
      */
     private function getMode()
     {
-        if ($this->isBackendScope()) {
+        if ($this->request && $this->isBackendScope($this->request)) {
             return 'BE';
         }
 
-        if ($this->isFrontendScope()) {
+        if ($this->request && $this->isFrontendScope($this->request)) {
             return 'FE';
         }
 

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -39,7 +39,7 @@ use Symfony\Component\Routing\RouterInterface;
 class ContaoFramework implements ContaoFrameworkInterface
 {
     use ContainerAwareTrait;
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var bool

--- a/src/Framework/ScopeAwareTrait.php
+++ b/src/Framework/ScopeAwareTrait.php
@@ -14,7 +14,7 @@ use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 
-@trigger_error('Trait Contao\CoreBundle\Framework\ScopeAwareTrait has been deprecated since Contao 4.3 and will get removed in Contao 5.0 - use Contao\CoreBundle\Framework\ScopeCheckingTrait instead', E_USER_DEPRECATED);
+@trigger_error('Trait Contao\CoreBundle\Framework\ScopeAwareTrait has been deprecated since Contao 4.3 and will get removed in Contao 5.0 - use ' . ScopeTrait::class . ' instead', E_USER_DEPRECATED);
 
 /**
  * Provides methods to test the request scope.

--- a/src/Framework/ScopeAwareTrait.php
+++ b/src/Framework/ScopeAwareTrait.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
 trait ScopeAwareTrait
 {
     use ContainerAwareTrait;
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * Checks whether the request is a Contao request.

--- a/src/Framework/ScopeAwareTrait.php
+++ b/src/Framework/ScopeAwareTrait.php
@@ -13,7 +13,8 @@ namespace Contao\CoreBundle\Framework;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\KernelEvent;
+
+@trigger_error('Trait Contao\CoreBundle\Framework\ScopeAwareTrait has been deprecated since Contao 4.3 and will get removed in Contao 5.0 - use Contao\CoreBundle\Framework\ScopeCheckingTrait instead', E_USER_DEPRECATED);
 
 /**
  * Provides methods to test the request scope.
@@ -21,46 +22,13 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
  * @author Andreas Schempp <https://github.com/aschempp>
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Christian Schiffler <https://github.com/discordier>
+ *
+ * @deprecated Since Contao 4.3 to be removed in 5.0 - Use the ScopeCheckingTrait instead.
  */
 trait ScopeAwareTrait
 {
     use ContainerAwareTrait;
-
-    /**
-     * Checks whether the request is a Contao the master request.
-     *
-     * @param KernelEvent $event
-     *
-     * @return bool
-     */
-    protected function isContaoMasterRequest(KernelEvent $event)
-    {
-        return $event->isMasterRequest() && $this->isContaoScope($event->getRequest());
-    }
-
-    /**
-     * Checks whether the request is a Contao back end master request.
-     *
-     * @param KernelEvent $event
-     *
-     * @return bool
-     */
-    protected function isBackendMasterRequest(KernelEvent $event)
-    {
-        return $event->isMasterRequest() && $this->isBackendScope($event->getRequest());
-    }
-
-    /**
-     * Checks whether the request is a Contao front end master request.
-     *
-     * @param KernelEvent $event
-     *
-     * @return bool
-     */
-    protected function isFrontendMasterRequest(KernelEvent $event)
-    {
-        return $event->isMasterRequest() && $this->isFrontendScope($event->getRequest());
-    }
+    use ScopeCheckingTrait;
 
     /**
      * Checks whether the request is a Contao request.
@@ -83,7 +51,7 @@ trait ScopeAwareTrait
      */
     protected function isBackendScope(Request $request = null)
     {
-        return $this->isScope(ContaoCoreBundle::SCOPE_BACKEND, $request);
+        return $this->isScopeWithContainerFallback(ContaoCoreBundle::SCOPE_BACKEND, $request);
     }
 
     /**
@@ -95,7 +63,7 @@ trait ScopeAwareTrait
      */
     protected function isFrontendScope(Request $request = null)
     {
-        return $this->isScope(ContaoCoreBundle::SCOPE_FRONTEND, $request);
+        return $this->isScopeWithContainerFallback(ContaoCoreBundle::SCOPE_FRONTEND, $request);
     }
 
     /**
@@ -106,20 +74,21 @@ trait ScopeAwareTrait
      *
      * @return bool
      */
-    private function isScope($scope, Request $request = null)
+    private function isScopeWithContainerFallback($scope, Request $request = null)
     {
-        if (!$request) {
+        if (null === $request) {
+            @trigger_error('Deriving the scope from the request_stack has been deprecated in Contao 4.3 and will get removed in Contao 5.0', E_USER_DEPRECATED);
             if (null === $this->container) {
                 return false;
             }
 
             $request = $this->container->get('request_stack')->getCurrentRequest();
+
+            if (null === $request) {
+                return false;
+            }
         }
 
-        if (null === $request || !$request->attributes->has('_scope')) {
-            return false;
-        }
-
-        return $request->attributes->get('_scope') === $scope;
+        return $this->isScope($scope, $request);
     }
 }

--- a/src/Framework/ScopeCheckingTrait.php
+++ b/src/Framework/ScopeCheckingTrait.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Framework;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+
+/**
+ * Provides methods to test the request scope.
+ *
+ * @author Andreas Schempp <https://github.com/aschempp>
+ * @author Leo Feyer <https://github.com/leofeyer>
+ * @author Christian Schiffler <https://github.com/discordier>
+ */
+trait ScopeCheckingTrait
+{
+    /**
+     * Checks whether the request is a Contao the master request.
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    protected function isContaoMasterRequest(KernelEvent $event)
+    {
+        return $event->isMasterRequest() && $this->isContaoScope($event->getRequest());
+    }
+
+    /**
+     * Checks whether the request is a Contao back end master request.
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    protected function isBackendMasterRequest(KernelEvent $event)
+    {
+        return $event->isMasterRequest() && $this->isBackendScope($event->getRequest());
+    }
+
+    /**
+     * Checks whether the request is a Contao front end master request.
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    protected function isFrontendMasterRequest(KernelEvent $event)
+    {
+        return $event->isMasterRequest() && $this->isFrontendScope($event->getRequest());
+    }
+
+    /**
+     * Checks whether the request is a Contao request.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    protected function isContaoScope(Request $request)
+    {
+        return $this->isBackendScope($request) || $this->isFrontendScope($request);
+    }
+
+    /**
+     * Checks whether the request is a Contao back end request.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    protected function isBackendScope(Request $request)
+    {
+        return $this->isScope(ContaoCoreBundle::SCOPE_BACKEND, $request);
+    }
+
+    /**
+     * Checks whether the request is a Contao front end request.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    protected function isFrontendScope(Request $request)
+    {
+        return $this->isScope(ContaoCoreBundle::SCOPE_FRONTEND, $request);
+    }
+
+    /**
+     * Checks whether the _scope attribute matches a scope.
+     *
+     * @param string $scope
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function isScope($scope, Request $request)
+    {
+        if (!$request->attributes->has('_scope')) {
+            return false;
+        }
+
+        return $scope === $request->attributes->get('_scope');
+    }
+}

--- a/src/Framework/ScopeTrait.php
+++ b/src/Framework/ScopeTrait.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Event\KernelEvent;
  * @author Leo Feyer <https://github.com/leofeyer>
  * @author Christian Schiffler <https://github.com/discordier>
  */
-trait ScopeCheckingTrait
+trait ScopeTrait
 {
     /**
      * Checks whether the request is a Contao the master request.

--- a/src/Monolog/ContaoTableProcessor.php
+++ b/src/Monolog/ContaoTableProcessor.php
@@ -166,7 +166,7 @@ class ContaoTableProcessor
             return;
         }
 
-        $context->setSource($request && $this->isBackendScope($request) ? 'BE' : 'FE');
+        $context->setSource(($request instanceof Request) && $this->isBackendScope($request) ? 'BE' : 'FE');
     }
 
     /**

--- a/src/Monolog/ContaoTableProcessor.php
+++ b/src/Monolog/ContaoTableProcessor.php
@@ -75,7 +75,7 @@ class ContaoTableProcessor
         $this->updateIp($context, $request);
         $this->updateBrowser($context, $request);
         $this->updateUsername($context);
-        $this->updateSource($context);
+        $this->updateSource($context, $request);
 
         $record['extra']['contao'] = $context;
         unset($record['context']['contao']);
@@ -158,14 +158,15 @@ class ContaoTableProcessor
      * Sets the source.
      *
      * @param ContaoContext $context
+     * @param Request       $request
      */
-    private function updateSource(ContaoContext $context)
+    private function updateSource(ContaoContext $context, Request $request = null)
     {
         if (null !== $context->getSource()) {
             return;
         }
 
-        $context->setSource($this->isBackendScope() ? 'BE' : 'FE');
+        $context->setSource($request && $this->isBackendScope($request) ? 'BE' : 'FE');
     }
 
     /**

--- a/src/Monolog/ContaoTableProcessor.php
+++ b/src/Monolog/ContaoTableProcessor.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\Monolog;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ContaoTableProcessor
 {
-    use ScopeAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var RequestStack

--- a/src/Monolog/ContaoTableProcessor.php
+++ b/src/Monolog/ContaoTableProcessor.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\Monolog;
 
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ContaoTableProcessor
 {
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var RequestStack

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -105,8 +105,6 @@ services:
         class: Contao\CoreBundle\EventListener\RefererIdListener
         arguments:
             - "@contao.referer_id.manager"
-        calls:
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -126,8 +126,6 @@ services:
         class: Contao\CoreBundle\EventListener\ToggleViewListener
         arguments:
             - "@contao.framework"
-        calls:
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -80,8 +80,6 @@ services:
         arguments:
             - "%kernel.default_locale%"
             - "%kernel.root_dir%"
-        calls:
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -141,7 +141,6 @@ services:
             - "@session"
             - "@database_connection"
         calls:
-            - ["setContainer", ["@service_container"]]
             - ["setTokenStorage", ["@security.token_storage"]]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -122,7 +122,6 @@ services:
         arguments:
             - "@session"
         calls:
-            - ["setContainer", ["@service_container"]]
             - ["setTokenStorage", ["@security.token_storage"]]
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -86,8 +86,6 @@ services:
         arguments:
             - "@request_stack"
             - "@security.token_storage"
-        calls:
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: monolog.processor }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -39,7 +39,6 @@ services:
             - "%kernel.packages%"
         calls:
             - ["setFramework", ["@contao.framework"]]
-            - ["setContainer", ["@service_container"]]
         tags:
             - { name: data_collector, template: "ContaoCoreBundle:Collector:contao", id: "contao" }
 

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -10,10 +10,11 @@
 
 namespace Contao\CoreBundle\Security;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Contao\CoreBundle\Security\Authentication\ContaoToken;
 use Contao\User;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -29,7 +30,8 @@ use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterfa
  */
 class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthenticatorInterface
 {
-    use ScopeAwareTrait;
+    use ContainerAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * Creates an authentication token.

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -10,7 +10,7 @@
 
 namespace Contao\CoreBundle\Security;
 
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\CoreBundle\Security\Authentication\ContaoToken;
 use Contao\User;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -31,7 +31,7 @@ use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterfa
 class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthenticatorInterface
 {
     use ContainerAwareTrait;
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * Creates an authentication token.

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -110,6 +110,6 @@ class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthentic
             throw new \LogicException('The service container has not been set.');
         }
 
-        return !$this->isContaoScope();
+        return !$this->isContaoScope($this->container->get('request_stack')->getCurrentRequest());
     }
 }

--- a/src/Security/User/ContaoUserProvider.php
+++ b/src/Security/User/ContaoUserProvider.php
@@ -12,7 +12,7 @@ namespace Contao\CoreBundle\Security\User;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\FrontendUser;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class ContaoUserProvider implements UserProviderInterface
 {
     use ContainerAwareTrait;
-    use ScopeCheckingTrait;
+    use ScopeTrait;
 
     /**
      * @var ContaoFrameworkInterface

--- a/src/Security/User/ContaoUserProvider.php
+++ b/src/Security/User/ContaoUserProvider.php
@@ -12,8 +12,9 @@ namespace Contao\CoreBundle\Security\User;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
 use Contao\FrontendUser;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -26,7 +27,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class ContaoUserProvider implements UserProviderInterface
 {
-    use ScopeAwareTrait;
+    use ContainerAwareTrait;
+    use ScopeCheckingTrait;
 
     /**
      * @var ContaoFrameworkInterface
@@ -90,7 +92,7 @@ class ContaoUserProvider implements UserProviderInterface
      */
     private function isFrontendUsername($username)
     {
-        return 'frontend' === $username && $this->isFrontendScope();
+        return 'frontend' === $username && $this->isFrontendScope($this->container->get('request_stack')->getCurrentRequest());
     }
 
     /**
@@ -102,6 +104,6 @@ class ContaoUserProvider implements UserProviderInterface
      */
     private function isBackendUsername($username)
     {
-        return 'backend' === $username && $this->isBackendScope();
+        return 'backend' === $username && $this->isBackendScope($this->container->get('request_stack')->getCurrentRequest());
     }
 }

--- a/tests/DataCollector/ContaoDataCollectorTest.php
+++ b/tests/DataCollector/ContaoDataCollectorTest.php
@@ -46,7 +46,6 @@ class ContaoDataCollectorTest extends TestCase
         ];
 
         $collector = new ContaoDataCollector(['contao/core-bundle' => '4.0.0']);
-        $collector->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $collector->collect(new Request(), new Response());
 
         $this->assertEquals(['ContentText' => 'Contao\ContentText'], $collector->getClassesAliased());
@@ -102,7 +101,6 @@ class ContaoDataCollectorTest extends TestCase
         $objPage->layoutId = 2;
 
         $collector = new ContaoDataCollector([]);
-        $collector->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $collector->setFramework($this->mockContaoFramework(null, null, ['Contao\LayoutModel' => $adapter]));
         $collector->collect(new Request(), new Response());
 

--- a/tests/EventListener/LocaleListenerTest.php
+++ b/tests/EventListener/LocaleListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * Tests the LocaleListener class.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class LocaleListenerTest extends TestCase
 {
@@ -49,11 +50,11 @@ class LocaleListenerTest extends TestCase
         $request = Request::create('/');
         $request->setSession($session);
         $request->attributes->set('_locale', $locale);
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($this->mockKernel(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new LocaleListener(['en']);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertEquals($expected, $request->attributes->get('_locale'));
@@ -76,11 +77,11 @@ class LocaleListenerTest extends TestCase
 
         $request = Request::create('/');
         $request->setSession($session);
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($this->mockKernel(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new LocaleListener(['en']);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertEquals($expected, $request->attributes->get('_locale'));
@@ -103,11 +104,11 @@ class LocaleListenerTest extends TestCase
         $request = Request::create('/');
         $request->setSession($session);
         $request->headers->set('Accept-Language', $locale);
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($this->mockKernel(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new LocaleListener($available);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertEquals($expected, $request->attributes->get('_locale'));
@@ -146,11 +147,11 @@ class LocaleListenerTest extends TestCase
     {
         $request = Request::create('/');
         $request->attributes->set('_locale', $locale);
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($this->mockKernel(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new LocaleListener(['en']);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertNull($request->getSession());
@@ -166,11 +167,11 @@ class LocaleListenerTest extends TestCase
     {
         $request = Request::create('/');
         $request->attributes->set('_locale', 'invalid');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($this->mockKernel(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new LocaleListener(['en']);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
     }
 

--- a/tests/EventListener/RefererIdListenerTest.php
+++ b/tests/EventListener/RefererIdListenerTest.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\Test\EventListener;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\RefererIdListener;
 use Contao\CoreBundle\Test\TestCase;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -22,6 +21,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Yanick Witschi <https:/github.com/toflar>
  * @author Leo Feyer <https:/github.com/leofeyer>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class RefererIdListenerTest extends TestCase
 {
@@ -43,13 +43,11 @@ class RefererIdListenerTest extends TestCase
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
 
-        $request = new Request();
-        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+        $request = $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND);
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RefererIdListener($this->mockTokenManager());
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($request->attributes->has('_contao_referer_id'));
@@ -64,13 +62,11 @@ class RefererIdListenerTest extends TestCase
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
 
-        $request = new Request();
-        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+        $request = $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND);
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RefererIdListener($this->mockTokenManager());
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($request->attributes->has('_contao_referer_id'));
@@ -84,13 +80,11 @@ class RefererIdListenerTest extends TestCase
         /** @var HttpKernelInterface $kernel */
         $kernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', ['test', false]);
 
-        $request = new Request();
-        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+        $request = $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND);
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
 
         $listener = new RefererIdListener($this->mockTokenManager());
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($request->attributes->has('_contao_referer_id'));

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -41,14 +41,13 @@ class StoreRefererListenerTest extends TestCase
     /**
      * Tests that the referer is stored upon kernel.response.
      *
-     * @param string  $scope
      * @param Request $request
      * @param array   $currentReferer
      * @param array   $expectedReferer
      *
      * @dataProvider refererStoredOnKernelResponseProvider
      */
-    public function testRefererStoredOnKernelResponse($scope, Request $request, $currentReferer, $expectedReferer)
+    public function testRefererStoredOnKernelResponse(Request $request, $currentReferer, $expectedReferer)
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
@@ -69,7 +68,7 @@ class StoreRefererListenerTest extends TestCase
             ->willReturn($token)
         ;
 
-        $container = $this->mockContainerWithContaoScopes($scope);
+        $container = $this->mockContainerWithRequest($request);
 
         // Set the current referer URLs
         $session = $this->mockSession();
@@ -189,23 +188,26 @@ class StoreRefererListenerTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', 'contao_backend');
         $request->attributes->set('_contao_referer_id', 'dummyTestRefererId');
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
         $request->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
 
         $requestFrontend = clone $request;
         $requestFrontend->attributes->set('_route', 'contao_frontend');
+        $requestFrontend->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         $requestWithRefInUrl = new Request();
         $requestWithRefInUrl->attributes->set('_route', 'contao_backend');
         $requestWithRefInUrl->attributes->set('_contao_referer_id', 'dummyTestRefererId');
+        $requestWithRefInUrl->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
         $requestWithRefInUrl->server->set('REQUEST_URI', '/path/of/contao?having&query&string=1');
         $requestWithRefInUrl->query->set('ref', 'dummyTestRefererId');
 
         $requestWithRefInUrlFrontend = clone $requestWithRefInUrl;
         $requestWithRefInUrlFrontend->attributes->set('_route', 'contao_frontend');
+        $requestWithRefInUrlFrontend->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
         return [
             'Test current referer null returns correct new referer for back end scope' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
                 $request,
                 null,
                 [
@@ -216,7 +218,6 @@ class StoreRefererListenerTest extends TestCase
                 ],
             ],
             'Test referer returns correct new referer for back end scope' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
                 $requestWithRefInUrl,
                 [
                     'dummyTestRefererId' => [
@@ -232,13 +233,11 @@ class StoreRefererListenerTest extends TestCase
                 ],
             ],
             'Test current referer null returns null for front end scope' => [
-                ContaoCoreBundle::SCOPE_FRONTEND,
                 $requestFrontend,
                 null,
                 null,
             ],
             'Test referer returns correct new referer for front end scope' => [
-                ContaoCoreBundle::SCOPE_FRONTEND,
                 $requestWithRefInUrlFrontend,
                 [
                     'last' => '',
@@ -250,7 +249,6 @@ class StoreRefererListenerTest extends TestCase
                 ],
             ],
             'Test referers are correctly added to the referers array (see #143)' => [
-                ContaoCoreBundle::SCOPE_BACKEND,
                 $requestWithRefInUrl,
                 [
                     'dummyTestRefererId' => [

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -90,7 +90,7 @@ class StoreRefererListenerTest extends TestCase
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND),
             HttpKernelInterface::MASTER_REQUEST,
             new Response()
         );
@@ -123,7 +123,7 @@ class StoreRefererListenerTest extends TestCase
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND),
             HttpKernelInterface::SUB_REQUEST,
             new Response()
         );
@@ -146,7 +146,7 @@ class StoreRefererListenerTest extends TestCase
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND),
             HttpKernelInterface::MASTER_REQUEST,
             new Response()
         );

--- a/tests/EventListener/StoreRefererListenerTest.php
+++ b/tests/EventListener/StoreRefererListenerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * Tests the StoreRefererListener class.
  *
  * @author Yanick Witschi <https:/github.com/toflar>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class StoreRefererListenerTest extends TestCase
 {
@@ -68,14 +69,11 @@ class StoreRefererListenerTest extends TestCase
             ->willReturn($token)
         ;
 
-        $container = $this->mockContainerWithRequest($request);
-
         // Set the current referer URLs
         $session = $this->mockSession();
         $session->set('referer', $currentReferer);
 
         $listener = $this->getListener($session, $tokenStorage);
-        $listener->setContainer($container);
         $listener->onKernelResponse($responseEvent);
 
         $this->assertSame($expectedReferer, $session->get('referer'));
@@ -153,7 +151,6 @@ class StoreRefererListenerTest extends TestCase
             new Response()
         );
 
-        $container = $this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND);
         $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
 
         $session
@@ -174,7 +171,6 @@ class StoreRefererListenerTest extends TestCase
         ;
 
         $listener = $this->getListener($session, $tokenStorage);
-        $listener->setContainer($container);
         $listener->onKernelResponse($responseEvent);
     }
 

--- a/tests/EventListener/ToggleViewListenerTest.php
+++ b/tests/EventListener/ToggleViewListenerTest.php
@@ -24,6 +24,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
  * Tests the ToggleViewListener class.
  *
  * @author Andreas Schempp <https:/github.com/aschempp>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class ToggleViewListenerTest extends TestCase
 {
@@ -98,7 +99,6 @@ class ToggleViewListenerTest extends TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -119,7 +119,6 @@ class ToggleViewListenerTest extends TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -140,7 +139,6 @@ class ToggleViewListenerTest extends TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -162,7 +160,6 @@ class ToggleViewListenerTest extends TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -184,7 +181,6 @@ class ToggleViewListenerTest extends TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());
@@ -212,7 +208,6 @@ class ToggleViewListenerTest extends TestCase
         $basePath->setValue($request, '/foo/bar');
 
         $listener = new ToggleViewListener($this->framework);
-        $listener->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
         $listener->onKernelRequest($event);
 
         $this->assertTrue($event->hasResponse());

--- a/tests/EventListener/UserSessionListenerTest.php
+++ b/tests/EventListener/UserSessionListenerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Security\Core\User\User;
  * Tests the UserSessionListener class.
  *
  * @author Yanick Witschi <https:/github.com/toflar>
+ * @author Christian Schiffler <https://github.com/discordier>
  */
 class UserSessionListenerTest extends TestCase
 {
@@ -45,13 +46,13 @@ class UserSessionListenerTest extends TestCase
     /**
      * Tests that the session is replaced upon kernel.request.
      *
-     * @param string $scope
-     * @param string $userClass
-     * @param string $sessionBagName
+     * @param Request $request
+     * @param string  $userClass
+     * @param string  $sessionBagName
      *
      * @dataProvider scopeBagProvider
      */
-    public function testSessionReplacedOnKernelRequest($scope, $userClass, $sessionBagName)
+    public function testSessionReplacedOnKernelRequest($request, $userClass, $sessionBagName)
     {
         $sessionValuesToBeSet = [
             'foo' => 'bar',
@@ -60,7 +61,7 @@ class UserSessionListenerTest extends TestCase
 
         $responseEvent = new GetResponseEvent(
             $this->mockKernel(),
-            new Request(),
+            $request,
             HttpKernelInterface::MASTER_REQUEST
         );
 
@@ -98,7 +99,6 @@ class UserSessionListenerTest extends TestCase
         ;
 
         $listener = $this->getListener($session, null, $tokenStorage);
-        $listener->setContainer($this->mockContainerWithContaoScopes($scope));
         $listener->onKernelRequest($responseEvent);
 
         /** @var AttributeBagInterface $bag */
@@ -110,17 +110,17 @@ class UserSessionListenerTest extends TestCase
     /**
      * Tests that the session is stored upon kernel.response.
      *
-     * @param string $scope
-     * @param string $userClass
-     * @param string $userTable
+     * @param Request $request
+     * @param string  $userClass
+     * @param string  $userTable
      *
      * @dataProvider scopeTableProvider
      */
-    public function testSessionStoredOnKernelResponse($scope, $userClass, $userTable)
+    public function testSessionStoredOnKernelResponse($request, $userClass, $userTable)
     {
         $responseEvent = new FilterResponseEvent(
             $this->mockKernel(),
-            new Request(),
+            $request,
             HttpKernelInterface::MASTER_REQUEST,
             new Response()
         );
@@ -169,7 +169,6 @@ class UserSessionListenerTest extends TestCase
         ;
 
         $listener = $this->getListener($this->mockSession(), $connection, $tokenStorage);
-        $listener->setContainer($this->mockContainerWithContaoScopes($scope));
         $listener->onKernelResponse($responseEvent);
     }
 
@@ -434,8 +433,8 @@ class UserSessionListenerTest extends TestCase
     public function scopeBagProvider()
     {
         return [
-            [ContaoCoreBundle::SCOPE_BACKEND, 'Contao\BackendUser', 'contao_backend'],
-            [ContaoCoreBundle::SCOPE_FRONTEND, 'Contao\FrontendUser', 'contao_frontend'],
+            [$this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND), 'Contao\BackendUser', 'contao_backend'],
+            [$this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND), 'Contao\FrontendUser', 'contao_frontend'],
         ];
     }
 
@@ -447,8 +446,8 @@ class UserSessionListenerTest extends TestCase
     public function scopeTableProvider()
     {
         return [
-            [ContaoCoreBundle::SCOPE_BACKEND, 'Contao\BackendUser', 'tl_user'],
-            [ContaoCoreBundle::SCOPE_FRONTEND, 'Contao\FrontendUser', 'tl_member'],
+            [$this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND), 'Contao\BackendUser', 'tl_user'],
+            [$this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND), 'Contao\FrontendUser', 'tl_member'],
         ];
     }
 

--- a/tests/Framework/ScopeAwareTraitTest.php
+++ b/tests/Framework/ScopeAwareTraitTest.php
@@ -1,0 +1,334 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Framework;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * This tests the scope aware trait.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ */
+class ScopeAwareTraitTest extends TestCase
+{
+    /**
+     * Generate test data for testIsScope()
+     *
+     * @return array
+     */
+    public function isAnyScopeProvider()
+    {
+        return [
+            'Test backend scope matches in isBackendScope()' => [
+                true,
+                'isBackendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test frontend scope does not match in isBackendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test request without scope does not match in isBackendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest()
+            ],
+            'Test backend scope matches in isBackendScope() with container fallback' => [
+                true,
+                'isBackendScope',
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend scope does not match in isBackendScope() with container fallback' => [
+                false,
+                'isBackendScope',
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test no match in isBackendScope() without request and container' => [
+                false,
+                'isBackendScope',
+                null,
+                null
+            ],
+
+            'Test frontend scope matches in isFrontendScope()' => [
+                true,
+                'isFrontendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test backend scope does not match in isFrontendScope()' => [
+                false,
+                'isFrontendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test request without scope does not match in isFrontendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest()
+            ],
+            'Test frontend scope matches in isFrontendScope() with container fallback' => [
+                true,
+                'isFrontendScope',
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test backend scope does not match in isFrontendScope() with container fallback' => [
+                false,
+                'isFrontendScope',
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test no match in isFrontendScope() without request and container' => [
+                false,
+                'isFrontendScope',
+                null,
+                null
+            ],
+        ];
+    }
+
+    /**
+     * Test the isScope method.
+     *
+     * @param bool               $expected  The expected result.
+     * @param string             $method    The method to call.
+     * @param Request            $request   The request.
+     * @param ContainerInterface $container Optional container.
+     *
+     * @dataProvider isAnyScopeProvider
+     */
+    public function testIsAnyScope($expected, $method, $request, ContainerInterface $container = null)
+    {
+        $this->assertSame($expected, $this->applyToMock($method, $request, $container));
+    }
+
+    /**
+     * Generate test data for testIsScope()
+     *
+     * @return array
+     */
+    public function isContaoScopeProvider()
+    {
+        return [
+            'Test backend scope matches' => [
+                true,
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test frontend scope matches' => [
+                true,
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test request without scope does not match' => [
+                false,
+                $this->mockRequest()
+            ],
+            'Test backend scope matches with container fallback' => [
+                true,
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend scope matches with container fallback' => [
+                true,
+                null,
+                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test no match without request and container' => [
+                false,
+                null,
+                null
+            ],
+        ];
+    }
+
+    /**
+     * Test the isContaoScope() method.
+     *
+     * @param bool                    $expected  The expected result.
+     * @param Request                 $request   The request.
+     * @param ContainerInterface|null $container Optional container.
+     *
+     * @dataProvider isContaoScopeProvider
+     */
+    public function testIsContaoScope($expected, $request, ContainerInterface $container = null)
+    {
+        $this->assertSame($expected, $this->applyToMock('isContaoScope', $request, $container));
+    }
+
+
+    /**
+     * Generate test data for testIsAnyMasterRequest()
+     *
+     * @return array
+     */
+    public function isAnyMasterRequestProvider()
+    {
+        return [
+            'Test backend master request matches in isContaoMasterRequest()' => [
+                true,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request matches in isContaoMasterRequest()' => [
+                true,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+
+            'Test backend master request matches in isBackendMasterRequest()' => [
+                true,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+
+            'Test backend master request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request does match in isFrontendMasterRequest()' => [
+                true,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+        ];
+    }
+
+    /**
+     * Test the isContaoMasterRequest() method.
+     *
+     * @param bool        $expected The expected result.
+     * @param KernelEvent $event    The kernel event.
+     *
+     * @dataProvider isAnyMasterRequestProvider
+     */
+    public function testIsAnyMasterRequest($expected, $method, KernelEvent $event)
+    {
+        $this->assertSame($expected, $this->applyToMock($method, $event));
+    }
+
+    /**
+     * Apply a method call to a mock.
+     *
+     * @param string             $method    The method.
+     * @param mixed              $argument  The argument to delegate.
+     * @param ContainerInterface $container The optional container to use.
+     *
+     * @return mixed
+     */
+    private function applyToMock($method, $argument, ContainerInterface $container = null)
+    {
+        $mock = $this->getTrait($container);
+
+        return \Closure::bind(function ($argument = null) use ($method) {
+            return $this->$method($argument);
+        }, $mock, $mock)->__invoke($argument);
+    }
+
+    /**
+     * Create a trait optionally using a container.
+     *
+     * @param ContainerInterface|null $container The optional container.
+     *
+     * @return ScopeAwareTrait
+     */
+    private function getTrait(ContainerInterface $container = null)
+    {
+        $mock = $this->getMockForTrait(ScopeAwareTrait::class);
+
+        if (null !== $container) {
+            $mock->setContainer($container);
+        }
+
+        return $mock;
+    }
+
+    private function getEvent($master, $request)
+    {
+        return new KernelEvent(
+            $this->getMockForAbstractClass(HttpKernelInterface::class),
+            $request,
+            $master ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST
+        );
+    }
+}

--- a/tests/Framework/ScopeAwareTraitTest.php
+++ b/tests/Framework/ScopeAwareTraitTest.php
@@ -15,6 +15,7 @@ use Contao\CoreBundle\Framework\ScopeAwareTrait;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -52,19 +53,25 @@ class ScopeAwareTraitTest extends TestCase
                 true,
                 'isBackendScope',
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
             ],
             'Test frontend scope does not match in isBackendScope() with container fallback' => [
                 false,
                 'isBackendScope',
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
             ],
             'Test no match in isBackendScope() without request and container' => [
                 false,
                 'isBackendScope',
                 null,
                 null
+            ],
+            'Test no match in isBackendScope() without request and empty container' => [
+                false,
+                'isBackendScope',
+                null,
+                $this->mockContainer()
             ],
 
             'Test frontend scope matches in isFrontendScope()' => [
@@ -86,19 +93,25 @@ class ScopeAwareTraitTest extends TestCase
                 true,
                 'isFrontendScope',
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
             ],
             'Test backend scope does not match in isFrontendScope() with container fallback' => [
                 false,
                 'isFrontendScope',
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
             ],
             'Test no match in isFrontendScope() without request and container' => [
                 false,
                 'isFrontendScope',
                 null,
                 null
+            ],
+            'Test no match in isFrontendScope() without request and empty container' => [
+                false,
+                'isFrontendScope',
+                null,
+                $this->mockContainer()
             ],
         ];
     }
@@ -141,17 +154,22 @@ class ScopeAwareTraitTest extends TestCase
             'Test backend scope matches with container fallback' => [
                 true,
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
             ],
             'Test frontend scope matches with container fallback' => [
                 true,
                 null,
-                $this->mockContainerWithRequest($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+                $this->mockContainer($this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
             ],
             'Test no match without request and container' => [
                 false,
                 null,
                 null
+            ],
+            'Test no match without request and empty container' => [
+                false,
+                null,
+                $this->mockContainer()
             ],
         ];
     }
@@ -278,6 +296,7 @@ class ScopeAwareTraitTest extends TestCase
      * Test the isContaoMasterRequest() method.
      *
      * @param bool        $expected The expected result.
+     * @param string      $method   The method to invoke.
      * @param KernelEvent $event    The kernel event.
      *
      * @dataProvider isAnyMasterRequestProvider
@@ -330,5 +349,25 @@ class ScopeAwareTraitTest extends TestCase
             $request,
             $master ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST
         );
+    }
+
+    /**
+     * Mocks a container with a request.
+     *
+     * @param Request $request
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
+    private function mockContainer($request = null)
+    {
+        $requestStack = new RequestStack();
+        if ($request) {
+            $requestStack->push($request);
+        }
+
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
+        $container->expects($this->any())->method('get')->with('request_stack')->willReturn($requestStack);
+
+        return $container;
     }
 }

--- a/tests/Framework/ScopeCheckingTraitTest.php
+++ b/tests/Framework/ScopeCheckingTraitTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Test\Framework;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * This tests the scope aware trait.
+ *
+ * @author Christian Schiffler <https://github.com/discordier>
+ */
+class ScopeCheckingTraitTest extends TestCase
+{
+    /**
+     * Generate test data for testIsScope()
+     *
+     * @return array
+     */
+    public function isAnyScopeProvider()
+    {
+        return [
+            'Test backend scope matches in isBackendScope()' => [
+                true,
+                'isBackendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test frontend scope does not match in isBackendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test request without scope does not match in isBackendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest()
+            ],
+
+            'Test frontend scope matches in isFrontendScope()' => [
+                true,
+                'isFrontendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test backend scope does not match in isFrontendScope()' => [
+                false,
+                'isFrontendScope',
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test request without scope does not match in isFrontendScope()' => [
+                false,
+                'isBackendScope',
+                $this->mockRequest()
+            ],
+        ];
+    }
+
+    /**
+     * Test the isScope method.
+     *
+     * @param bool               $expected  The expected result.
+     * @param string             $method    The method to call.
+     * @param Request            $request   The request.
+     *
+     * @dataProvider isAnyScopeProvider
+     */
+    public function testIsAnyScope($expected, $method, $request)
+    {
+        $this->assertSame($expected, $this->applyToMock($method, $request));
+    }
+
+    /**
+     * Generate test data for testIsScope()
+     *
+     * @return array
+     */
+    public function isContaoScopeProvider()
+    {
+        return [
+            'Test backend scope matches' => [
+                true,
+                $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND)
+            ],
+            'Test frontend scope matches' => [
+                true,
+                $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND)
+            ],
+            'Test request without scope does not match' => [
+                false,
+                $this->mockRequest()
+            ],
+        ];
+    }
+
+    /**
+     * Test the isContaoScope() method.
+     *
+     * @param bool                    $expected  The expected result.
+     * @param Request                 $request   The request.
+     *
+     * @dataProvider isContaoScopeProvider
+     */
+    public function testIsContaoScope($expected, $request)
+    {
+        $this->assertSame($expected, $this->applyToMock('isContaoScope', $request));
+    }
+
+
+    /**
+     * Generate test data for testIsAnyMasterRequest()
+     *
+     * @return array
+     */
+    public function isAnyMasterRequestProvider()
+    {
+        return [
+            'Test backend master request matches in isContaoMasterRequest()' => [
+                true,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request matches in isContaoMasterRequest()' => [
+                true,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isContaoMasterRequest()' => [
+                false,
+                'isContaoMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+
+            'Test backend master request matches in isBackendMasterRequest()' => [
+                true,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isBackendMasterRequest()' => [
+                false,
+                'isBackendMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+
+            'Test backend master request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend master request does match in isFrontendMasterRequest()' => [
+                true,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test master request without scope does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(true, $this->mockRequest())
+            ],
+            'Test backend sub request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_BACKEND))
+            ],
+            'Test frontend sub request does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest(ContaoCoreBundle::SCOPE_FRONTEND))
+            ],
+            'Test sub request without scope does not match in isFrontendMasterRequest()' => [
+                false,
+                'isFrontendMasterRequest',
+                $this->getEvent(false, $this->mockRequest())
+            ],
+        ];
+    }
+
+    /**
+     * Test the isContaoMasterRequest() method.
+     *
+     * @param bool        $expected The expected result.
+     * @param string      $method   The method to invoke.
+     * @param KernelEvent $event    The kernel event.
+     *
+     * @dataProvider isAnyMasterRequestProvider
+     */
+    public function testIsAnyMasterRequest($expected, $method, KernelEvent $event)
+    {
+        $this->assertSame($expected, $this->applyToMock($method, $event));
+    }
+
+    /**
+     * Apply a method call to a mock.
+     *
+     * @param string             $method    The method.
+     * @param mixed              $argument  The argument to delegate.
+     *
+     * @return mixed
+     */
+    private function applyToMock($method, $argument)
+    {
+        $mock = $this->getMockForTrait(ScopeCheckingTrait::class);
+
+        return \Closure::bind(function ($argument = null) use ($method) {
+            return $this->$method($argument);
+        }, $mock, $mock)->__invoke($argument);
+    }
+
+    private function getEvent($master, $request)
+    {
+        return new KernelEvent(
+            $this->getMockForAbstractClass(HttpKernelInterface::class),
+            $request,
+            $master ? HttpKernelInterface::MASTER_REQUEST : HttpKernelInterface::SUB_REQUEST
+        );
+    }
+}

--- a/tests/Framework/ScopeTraitTest.php
+++ b/tests/Framework/ScopeTraitTest.php
@@ -11,18 +11,18 @@
 namespace Contao\CoreBundle\Test\Framework;
 
 use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Framework\ScopeCheckingTrait;
+use Contao\CoreBundle\Framework\ScopeTrait;
 use Contao\CoreBundle\Test\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
- * This tests the scope aware trait.
+ * This tests the scope trait.
  *
  * @author Christian Schiffler <https://github.com/discordier>
  */
-class ScopeCheckingTraitTest extends TestCase
+class ScopeTraitTest extends TestCase
 {
     /**
      * Generate test data for testIsScope()
@@ -244,7 +244,7 @@ class ScopeCheckingTraitTest extends TestCase
      */
     private function applyToMock($method, $argument)
     {
-        $mock = $this->getMockForTrait(ScopeCheckingTrait::class);
+        $mock = $this->getMockForTrait(ScopeTrait::class);
 
         return \Closure::bind(function ($argument = null) use ($method) {
             return $this->$method($argument);

--- a/tests/Framework/ScopeTraitTest.php
+++ b/tests/Framework/ScopeTraitTest.php
@@ -251,6 +251,14 @@ class ScopeTraitTest extends TestCase
         }, $mock, $mock)->__invoke($argument);
     }
 
+    /**
+     * Create a kernel event for the passed request with a completely mocked kernel.
+     *
+     * @param bool    $master  Flag if it should be a master request - falso for sub requests.
+     * @param Request $request The request to use.
+     *
+     * @return KernelEvent.
+     */
     private function getEvent($master, $request)
     {
         return new KernelEvent(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -193,6 +193,18 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function mockContainerWithContaoScopes($scope = null)
     {
+        return $this->mockContainerWithRequest($this->mockRequest($scope));
+    }
+
+    /**
+     * Mocks a container with a request.
+     *
+     * @param string|null $request
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|Container
+     */
+    protected function mockContainerWithRequest($request = null)
+    {
         $container = new Container();
         $container->setParameter('kernel.root_dir', $this->getRootDir());
         $container->setParameter('kernel.cache_dir', $this->getCacheDir());
@@ -212,12 +224,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             new FileLocator($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao')
         );
 
-        $request = new Request();
-        $request->server->set('REMOTE_ADDR', '123.456.789.0');
-        $request->server->set('SCRIPT_NAME', '/core/index.php');
-
-        if (null !== $scope) {
-            $request->attributes->set('_scope', $scope);
+        if (null === $request) {
+            $request = $this->mockRequest();
         }
 
         $requestStack = new RequestStack();
@@ -231,6 +239,25 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Mock a Contao scoped request.
+     *
+     * @param string|null $scope The desired scope or null if none.
+     *
+     * @return Request
+     */
+    protected function mockRequest($scope = null)
+    {
+        $request = new Request();
+        $request->server->set('REMOTE_ADDR', '123.456.789.0');
+        $request->server->set('SCRIPT_NAME', '/core/index.php');
+        if (null !== $scope) {
+            $request->attributes->set('_scope', $scope);
+        }
+
+        return $request;
+    }
+
+    /**
      * Returns a ContaoFramework instance.
      *
      * @param RequestStack|null    $requestStack
@@ -240,9 +267,13 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @return ContaoFramework The object instance
      */
-    public function mockContaoFramework(RequestStack $requestStack = null, RouterInterface $router = null, array $adapters = [], array $instances = [])
-    {
-        $container = $this->mockContainerWithContaoScopes();
+    public function mockContaoFramework(
+        RequestStack $requestStack = null,
+        RouterInterface $router = null,
+        array $adapters = [],
+        array $instances = []
+    ) {
+        $container = $this->mockContainerWithRequest();
 
         if (null === $requestStack) {
             $requestStack = $container->get('request_stack');


### PR DESCRIPTION
This PR makes the `ScopeAwareTrait` use optional parameters for determining the request to match.

After implementing this, I noticed that many unit tests failed.
This was due to the fact, that these tests were pushing one request instance to the container (by using `TestCase::mockContainerWithContaoScopes`) and working on a completely unrelated request instance which got created in the test.
These tests therefore reflected a setup that could never happen in application workflow and therefore I straightened them out by always passing the correct request to the trait.

This then ultimately lead to the removal of all `setContainer()` calls in the listeners using the `ScopeAwareTrait`.

After doing so, I realized that we should prohibit `setContainer()` calls on these classes and eventually came up with `ScopeTrait`, this is used by `ScopeAwareTrait` internally in a 100% backwards compatible way.

Deprecations:
- `ScopeAwareTrait` has been deprecated in favor of `ScopeTrait` and a warning is issued.
- Not passing a `Request` object to any of the `ScopeAwareTrait::is*Scope()` methods has been deprecated separately and triggers another warning.