### PR TITLE
[RTM] Fix the namespace declaration of various tests

### DIFF
--- a/tests/Analyzer/HtaccessAnalyzerTest.php
+++ b/tests/Analyzer/HtaccessAnalyzerTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\HttpKernel\Bundle;
+namespace Contao\CoreBundle\Test\Analyzer;
 
 use Contao\CoreBundle\Analyzer\HtaccessAnalyzer;
 use Contao\CoreBundle\Test\TestCase;

--- a/tests/Cache/ContaoCacheClearerTest.php
+++ b/tests/Cache/ContaoCacheClearerTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Command;
+namespace Contao\CoreBundle\Test\Cache;
 
 use Contao\CoreBundle\Cache\ContaoCacheClearer;
 use Contao\CoreBundle\Test\TestCase;

--- a/tests/Cache/ContaoCacheWarmerTest.php
+++ b/tests/Cache/ContaoCacheWarmerTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Command;
+namespace Contao\CoreBundle\Test\Cache;
 
 use Contao\CoreBundle\Cache\ContaoCacheWarmer;
 use Contao\CoreBundle\Config\ResourceFinder;

--- a/tests/Config/ResourceFinderTest.php
+++ b/tests/Config/ResourceFinderTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Controller;
+namespace Contao\CoreBundle\Test\Config;
 
 use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\Test\TestCase;

--- a/tests/DependencyInjection/Compiler/AddSessionBagsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddSessionBagsPassTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\EventListener;
+namespace Contao\CoreBundle\Test\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/tests/Framework/Adapter/AdapterTest.php
+++ b/tests/Framework/Adapter/AdapterTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Adapter;
+namespace Contao\CoreBundle\Test\Framework\Adapter;
 
 use Contao\CoreBundle\Framework\Adapter;
 

--- a/tests/Security/ContaoAuthenticatorTest.php
+++ b/tests/Security/ContaoAuthenticatorTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Security\Authentication;
+namespace Contao\CoreBundle\Test\Security;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Security\Authentication\ContaoToken;

--- a/tests/Security/User/ContaoUserProviderTest.php
+++ b/tests/Security/User/ContaoUserProviderTest.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0+
  */
 
-namespace Contao\CoreBundle\Test\Security\Authentication;
+namespace Contao\CoreBundle\Test\Security\User;
 
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Framework\ContaoFramework;


### PR DESCRIPTION
This PR corrects the namespaces for various test classes.

In addition, we also might want to change `composer.json`:
```diff
         "exclude-from-classmap": [
             "src/Resources/contao/config",
             "src/Resources/contao/dca",
-            "src/Resources/contao/helper",
             "src/Resources/contao/languages",
             "src/Resources/contao/templates",
             "src/Resources/contao/themes"
```

Otherwise the interfaces and deprecated exception classes can't get auto loaded.