### PR TITLE
[RTM] Remove constructors from image and picture factory interfaces

### DIFF
--- a/src/Image/ImageFactory.php
+++ b/src/Image/ImageFactory.php
@@ -73,7 +73,16 @@ class ImageFactory implements ImageFactoryInterface
     private $validExtensions;
 
     /**
-     * {@inheritdoc}
+     * Constructor.
+     *
+     * @param ResizerInterface         $resizer
+     * @param ImagineInterface         $imagine
+     * @param ImagineInterface         $imagineSvg
+     * @param Filesystem               $filesystem
+     * @param ContaoFrameworkInterface $framework
+     * @param bool                     $bypassCache
+     * @param array                    $imagineOptions
+     * @param array                    $validExtensions
      */
     public function __construct(ResizerInterface $resizer, ImagineInterface $imagine, ImagineInterface $imagineSvg, Filesystem $filesystem, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions, array $validExtensions)
     {

--- a/src/Image/ImageFactoryInterface.php
+++ b/src/Image/ImageFactoryInterface.php
@@ -26,20 +26,6 @@ use Symfony\Component\Filesystem\Filesystem;
 interface ImageFactoryInterface
 {
     /**
-     * Constructor.
-     *
-     * @param ResizerInterface         $resizer
-     * @param ImagineInterface         $imagine
-     * @param ImagineInterface         $imagineSvg
-     * @param Filesystem               $filesystem
-     * @param ContaoFrameworkInterface $framework
-     * @param bool                     $bypassCache
-     * @param array                    $imagineOptions
-     * @param array                    $validExtensions
-     */
-    public function __construct(ResizerInterface $resizer, ImagineInterface $imagine, ImagineInterface $imagineSvg, Filesystem $filesystem, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions, array $validExtensions);
-
-    /**
      * Creates an Image object.
      *
      * @param string|ImageInterface                       $path       The path to the source image or an Image object

--- a/src/Image/ImageFactoryInterface.php
+++ b/src/Image/ImageFactoryInterface.php
@@ -10,13 +10,9 @@
 
 namespace Contao\CoreBundle\Image;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Image\ImageInterface;
 use Contao\Image\ImportantPartInterface;
 use Contao\Image\ResizeConfigurationInterface;
-use Contao\Image\ResizerInterface;
-use Imagine\Image\ImagineInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Image factory interface.

--- a/src/Image/PictureFactory.php
+++ b/src/Image/PictureFactory.php
@@ -62,7 +62,13 @@ class PictureFactory implements PictureFactoryInterface
     private $defaultDensities = '';
 
     /**
-     * {@inheritdoc}
+     * Constructor.
+     *
+     * @param PictureGeneratorInterface $pictureGenerator
+     * @param ImageFactoryInterface     $imageFactory
+     * @param ContaoFrameworkInterface  $framework
+     * @param bool                      $bypassCache
+     * @param array                     $imagineOptions
      */
     public function __construct(PictureGeneratorInterface $pictureGenerator, ImageFactoryInterface $imageFactory, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions)
     {

--- a/src/Image/PictureFactoryInterface.php
+++ b/src/Image/PictureFactoryInterface.php
@@ -24,17 +24,6 @@ use Contao\Image\PictureInterface;
 interface PictureFactoryInterface
 {
     /**
-     * Constructor.
-     *
-     * @param PictureGeneratorInterface $pictureGenerator
-     * @param ImageFactoryInterface     $imageFactory
-     * @param ContaoFrameworkInterface  $framework
-     * @param bool                      $bypassCache
-     * @param array                     $imagineOptions
-     */
-    public function __construct(PictureGeneratorInterface $pictureGenerator, ImageFactoryInterface $imageFactory, ContaoFrameworkInterface $framework, $bypassCache, array $imagineOptions);
-
-    /**
      * Sets the default densities for generating pictures.
      *
      * @param string $densities

--- a/src/Image/PictureFactoryInterface.php
+++ b/src/Image/PictureFactoryInterface.php
@@ -10,10 +10,8 @@
 
 namespace Contao\CoreBundle\Image;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfigurationInterface;
-use Contao\Image\PictureGeneratorInterface;
 use Contao\Image\PictureInterface;
 
 /**


### PR DESCRIPTION
The constructors should be removed from the interfaces as we did in contao/image#10.