### PR TITLE
[RFC] Fix performance of File::$imageSize

### DIFF
--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -249,6 +249,7 @@ class File extends \System
 				if (empty($this->arrImageSize))
 				{
 					$strCacheKey = $this->strFile . '|' . $this->mtime;
+
 					if (isset(static::$arrImageSizeCache[$strCacheKey]))
 					{
 						$this->arrImageSize = static::$arrImageSizeCache[$strCacheKey];
@@ -286,6 +287,7 @@ class File extends \System
 							$this->arrImageSize = false;
 						}
 					}
+
 					if (!isset(static::$arrImageSizeCache[$strCacheKey]))
 					{
 						static::$arrImageSizeCache[$strCacheKey] = $this->arrImageSize;


### PR DESCRIPTION
On an article overview page with 50 pages/articles this change brings the response time from about 1800ms down to about 700ms.

This change should be OK to merge into 4.3 I think.

This is the alternative of #626

It may be useful to merge this back into 3.5...