### PR TITLE
Index options were added in Doctrine DBAL 2.5

### DIFF
--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -78,7 +78,8 @@ class DoctrineSchemaListener
                     $data['unique'],
                     $data['primary'],
                     $data['flags'],
-                    $data['options'])
+                    isset($data['options']) ? $data['options'] : null
+                )
             );
 
             $event->preventDefault();


### PR DESCRIPTION
In my current installation it got doctrine/dbal 2.4.5 installed after `composer update`. Probably because doctrine/dbal 2.5 seems to conflict with doctrine/common 2.7, and for whatever reason 2.7.1 was installed.

The options array key was not defined and raised a notice error, causing the doctrine diff command to fail.