### PR TITLE
Ignore the important part if it does not fit

### DIFF
--- a/src/Image/ImageFactory.php
+++ b/src/Image/ImageFactory.php
@@ -253,13 +253,15 @@ class ImageFactory implements ImageFactoryInterface
         /** @var FilesModel $filesModel */
         $filesModel = $this->framework->getAdapter(FilesModel::class);
         $file = $filesModel->findByPath($image->getPath());
+
+        if (null === $file || !$file->importantPartWidth || !$file->importantPartHeight) {
+            return null;
+        }
+
         $imageSize = $image->getDimensions()->getSize();
 
         if (
-            null === $file
-            || !$file->importantPartWidth
-            || !$file->importantPartHeight
-            || $file->importantPartX + $file->importantPartWidth > $imageSize->getWidth()
+            $file->importantPartX + $file->importantPartWidth > $imageSize->getWidth()
             || $file->importantPartY + $file->importantPartHeight > $imageSize->getHeight()
         ) {
             return null;

--- a/src/Image/ImageFactory.php
+++ b/src/Image/ImageFactory.php
@@ -130,7 +130,7 @@ class ImageFactory implements ImageFactoryInterface
 
         if (!is_object($path) || !($path instanceof ImageInterface)) {
             if (null === $importantPart) {
-                $importantPart = $this->createImportantPart($image->getPath());
+                $importantPart = $this->createImportantPart($image);
             }
 
             $image->setImportantPart($importantPart);
@@ -244,17 +244,24 @@ class ImageFactory implements ImageFactoryInterface
     /**
      * Fetches the important part from the database.
      *
-     * @param string $path
+     * @param ImageInterface $image
      *
      * @return ImportantPart|null
      */
-    private function createImportantPart($path)
+    private function createImportantPart(ImageInterface $image)
     {
         /** @var FilesModel $filesModel */
         $filesModel = $this->framework->getAdapter(FilesModel::class);
-        $file = $filesModel->findByPath($path);
+        $file = $filesModel->findByPath($image->getPath());
+        $imageSize = $image->getDimensions()->getSize();
 
-        if (null === $file || !$file->importantPartWidth || !$file->importantPartHeight) {
+        if (
+            null === $file
+            || !$file->importantPartWidth
+            || !$file->importantPartHeight
+            || $file->importantPartX + $file->importantPartWidth > $imageSize->getWidth()
+            || $file->importantPartY + $file->importantPartHeight > $imageSize->getHeight()
+        ) {
             return null;
         }
 

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -673,6 +673,63 @@ class ImageFactoryTest extends TestCase
     }
 
     /**
+     * Tests the create() method.
+     */
+    public function testCreateImportantPartOutOfBounds()
+    {
+        $path = $this->getRootDir().'/images/dummy.jpg';
+
+        $framework = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\ContaoFramework')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $filesModel = $this->getMock('Contao\FilesModel');
+
+        $filesModel
+            ->expects($this->any())
+            ->method('__get')
+            ->will(
+                $this->returnCallback(function ($key) {
+                    return [
+                        'importantPartX' => '50',
+                        'importantPartY' => '50',
+                        'importantPartWidth' => '175',
+                        'importantPartHeight' => '175',
+                    ][$key];
+                })
+            )
+        ;
+
+        $filesAdapter = $this
+            ->getMockBuilder('Contao\CoreBundle\Framework\Adapter')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $filesAdapter
+            ->expects($this->any())
+            ->method('__call')
+            ->willReturn($filesModel)
+        ;
+
+        $framework
+            ->expects($this->any())
+            ->method('getAdapter')
+            ->willReturn($filesAdapter)
+        ;
+
+        $imageFactory = $this->createImageFactory(null, null, null, null, $framework);
+        $image = $imageFactory->create($path);
+
+        $this->assertEquals(
+            new ImportantPart(new Point(0, 0), new Box(200, 200)),
+            $image->getImportantPart()
+        );
+    }
+
+    /**
      * Tests the executeResize hook.
      *
      * @runInSeparateProcess


### PR DESCRIPTION
There is a bug if the important part from the database does not fit inside the image dimensions.

Steps to reproduce:

1. Add an important part to a large image
2. Replace the image with a much smaller one
3. Open the contao filemanager

This results in the `OutOfBoundsException`: *“Crop coordinates must start at minimum 0, 0 position from top left corner, crop height and width must be positive integers and must not exceed the current image borders”*