### PR TITLE
Allow to run Contao without a localconfig.php

### DIFF
--- a/src/Resources/contao/library/Contao/Config.php
+++ b/src/Resources/contao/library/Contao/Config.php
@@ -317,17 +317,7 @@ class Config
 	 */
 	public static function isComplete()
 	{
-		if (!static::$blnHasLcf)
-		{
-			return false;
-		}
-
-		if (!static::has('licenseAccepted'))
-		{
-			return false;
-		}
-
-		return true;
+		return static::$blnHasLcf !== null && static::has('licenseAccepted');
 	}
 
 


### PR DESCRIPTION
Since the localconfig parameters can be specified in the container, we don't need the file to be present.