### PR TITLE
[RTM] Respect the XLIFF source-language attribute

### DIFF
--- a/src/Config/Loader/XliffFileLoader.php
+++ b/src/Config/Loader/XliffFileLoader.php
@@ -127,7 +127,21 @@ class XliffFileLoader extends Loader
      */
     private function getNodeByLanguage(\DOMElement $unit, $language)
     {
-        return ('en' === $language) ? $unit->getElementsByTagName('source') : $unit->getElementsByTagName('target');
+        $tagName = 'target';
+        $node = $unit;
+
+        // Use the source tag if the source language matches
+        while ($node = $node->parentNode) {
+            if (
+                'file' === $node->nodeName
+                && strtolower($node->getAttribute('source-language')) === strtolower($language)
+            ) {
+                $tagName = 'source';
+                break;
+            }
+        }
+
+        return $unit->getElementsByTagName($tagName);
     }
 
     /**

--- a/src/Config/Loader/XliffFileLoader.php
+++ b/src/Config/Loader/XliffFileLoader.php
@@ -102,7 +102,7 @@ class XliffFileLoader extends Loader
      *
      * @return string
      */
-    private function getPhpFromFileNode($fileNode, $tagName)
+    private function getPhpFromFileNode(\DOMElement $fileNode, $tagName)
     {
         $return = '';
         $units = $fileNode->getElementsByTagName('trans-unit');

--- a/tests/Config/Loader/XliffFileLoaderTest.php
+++ b/tests/Config/Loader/XliffFileLoaderTest.php
@@ -66,6 +66,10 @@ $GLOBALS['TL_LANG']['MSC']['second'][0] = 'This is the second source';
 $GLOBALS['TL_LANG']['MSC']['third']['with'][1] = 'This is the third source';
 $GLOBALS['TL_LANG']['tl_layout']['responsive.css'][1] = 'This is the fourth source';
 $GLOBALS['TL_LANG']['MSC']['fifth'] = "This is the\nfifth source";
+$GLOBALS['TL_LANG']['MSC']['only_source'] = 'This is the source';
+$GLOBALS['TL_LANG']['MSC']['in_group_1'] = 'This is in group 1 source';
+$GLOBALS['TL_LANG']['MSC']['in_group_2'] = 'This is in group 2 source';
+$GLOBALS['TL_LANG']['MSC']['second_file'] = 'This is the target';
 
 TXT;
 
@@ -77,6 +81,10 @@ $GLOBALS['TL_LANG']['MSC']['second'][0] = 'This is the second target';
 $GLOBALS['TL_LANG']['MSC']['third']['with'][1] = 'This is the third target';
 $GLOBALS['TL_LANG']['tl_layout']['responsive.css'][1] = 'This is the fourth target';
 $GLOBALS['TL_LANG']['MSC']['fifth'] = "This is the\nfifth target";
+$GLOBALS['TL_LANG']['MSC']['only_target'] = 'This is the target';
+$GLOBALS['TL_LANG']['MSC']['in_group_1'] = 'This is in group 1 target';
+$GLOBALS['TL_LANG']['MSC']['in_group_2'] = 'This is in group 2 target';
+$GLOBALS['TL_LANG']['MSC']['second_file'] = 'This is the source';
 
 TXT;
 

--- a/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/languages/en/default.xlf
+++ b/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/languages/en/default.xlf
@@ -24,6 +24,32 @@
                 <source>This is the\nfifth source</source>
                 <target>This is the\nfifth target</target>
             </trans-unit>
+            <trans-unit id="MSC.only_source">
+                <source>This is the source</source>
+            </trans-unit>
+            <trans-unit id="MSC.only_target">
+                <target>This is the target</target>
+            </trans-unit>
+            <group>
+                <trans-unit id="MSC.in_group_1">
+                    <source>This is in group 1 source</source>
+                    <target>This is in group 1 target</target>
+                </trans-unit>
+                <group>
+                    <trans-unit id="MSC.in_group_2">
+                        <source>This is in group 2 source</source>
+                        <target>This is in group 2 target</target>
+                    </trans-unit>
+                </group>
+            </group>
+        </body>
+    </file>
+    <file datatype="php" original="contao/languages/de/default.php" source-language="de">
+        <body>
+            <trans-unit id="MSC.second_file">
+                <source>This is the source</source>
+                <target>This is the target</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Fixes #642

The loader should behave the same way as before, but instead of the hardcoded assumption that the source language is `en` it respects the value of the XLIFF attribute `source-language`.

- [x] Check if the language format in Contao and XLIFF is the same