### PR TITLE
[RFC] Fix missing TL_FILES_URL for pictures

### DIFF
--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -1511,8 +1511,8 @@ abstract class Controller extends \System
 
 			$picture = array
 			(
-				'img' => $picture->getImg(TL_ROOT),
-				'sources' => $picture->getSources(TL_ROOT)
+				'img' => $picture->getImg(TL_ROOT, TL_FILES_URL),
+				'sources' => $picture->getSources(TL_ROOT, TL_FILES_URL)
 			);
 
 			if ($src !== $arrItem['singleSRC'])

--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -836,8 +836,8 @@ class InsertTags extends \Controller
 
 							$picture = array
 							(
-								'img' => $picture->getImg(TL_ROOT),
-								'sources' => $picture->getSources(TL_ROOT)
+								'img' => $picture->getImg(TL_ROOT, TL_FILES_URL),
+								'sources' => $picture->getSources(TL_ROOT, TL_FILES_URL)
 							);
 
 							$picture['alt'] = $alt;

--- a/src/Resources/contao/library/Contao/Picture.php
+++ b/src/Resources/contao/library/Contao/Picture.php
@@ -249,8 +249,8 @@ class Picture
 
 		return array
 		(
-			'img' => $picture->getImg(TL_ROOT),
-			'sources' => $picture->getSources(TL_ROOT),
+			'img' => $picture->getImg(TL_ROOT, TL_FILES_URL),
+			'sources' => $picture->getSources(TL_ROOT, TL_FILES_URL),
 		);
 	}
 

--- a/tests/Contao/PictureTest.php
+++ b/tests/Contao/PictureTest.php
@@ -74,7 +74,7 @@ class PictureTest extends TestCase
         $GLOBALS['TL_CONFIG']['validImageTypes'] = 'jpeg,jpg,svg,svgz';
 
         define('TL_ERROR', 'ERROR');
-        define('TL_FILES_URL', '');
+        define('TL_FILES_URL', 'http://example.com/');
         define('TL_ROOT', self::$rootDir);
 
         $container = $this->mockContainerWithContaoScopes();
@@ -142,8 +142,8 @@ class PictureTest extends TestCase
 
         $this->assertEquals(200, $pictureData['img']['width']);
         $this->assertEquals(200, $pictureData['img']['height']);
-        $this->assertEquals('dummy.jpg', $pictureData['img']['src']);
-        $this->assertEquals('dummy.jpg', $pictureData['img']['srcset']);
+        $this->assertEquals('http://example.com/dummy.jpg', $pictureData['img']['src']);
+        $this->assertEquals('http://example.com/dummy.jpg', $pictureData['img']['srcset']);
         $this->assertEquals([], $pictureData['sources']);
     }
 
@@ -314,8 +314,8 @@ class PictureTest extends TestCase
 
         $this->assertEquals(200, $pictureData['img']['width']);
         $this->assertEquals(200, $pictureData['img']['height']);
-        $this->assertEquals('dummy%20with%20spaces.jpg', $pictureData['img']['src']);
-        $this->assertEquals('dummy%20with%20spaces.jpg', $pictureData['img']['srcset']);
+        $this->assertEquals('http://example.com/dummy%20with%20spaces.jpg', $pictureData['img']['src']);
+        $this->assertEquals('http://example.com/dummy%20with%20spaces.jpg', $pictureData['img']['srcset']);
         $this->assertEquals([], $pictureData['sources']);
     }
 


### PR DESCRIPTION
Fixes #659

The legacy Picture class in Contao 4.2 used the `TL_FILES_URL` constant in [Picture.php:281](https://github.com/contao/core-bundle/blob/58cf7360ddebbcffb51020d7ddd2892d71bd5c79/src/Resources/contao/library/Contao/Picture.php#L281). This is missing now and so the `TL_FILES_URL` is currently ignored in pictures. To fix it I added the constant to all `Picture::getImg()` and `Picture::getSources()` calls.