### PR TITLE
[RTM] Deprecate the contao:version command

### DIFF
--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -18,6 +18,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Outputs the Contao version.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @deprecated Using the contao:version command has been deprecated and will no longer work in Contao 5.0; use
+ *             "composer show contao/core-bundle | grep versions | awk '{ print $4 }'" instead
  */
 class VersionCommand extends ContainerAwareCommand
 {
@@ -28,7 +31,7 @@ class VersionCommand extends ContainerAwareCommand
     {
         $this
             ->setName('contao:version')
-            ->setDescription('Outputs the Contao version.')
+            ->setDescription('Outputs the contao/core-bundle version (deprecated).')
         ;
     }
 


### PR DESCRIPTION
This PR will deprecate the contao:version command (see #665).