### PR TITLE
[RFC] Fix deprecations in unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ sudo: false
 env:
   global:
     - COMPOSER_ALLOW_XDEBUG=0
-    - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ cache:
 
 init:
   - SET PATH=c:\php;%PATH%
-  - SET SYMFONY_DEPRECATIONS_HELPER=weak
 
 install:
   - mkdir c:\php && cd c:\php

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -147,18 +147,19 @@ services:
     contao.security.authenticator:
         class: Contao\CoreBundle\Security\ContaoAuthenticator
         public: false
+        arguments:
+            - "@contao.routing.scope_matcher"
         calls:
             - ["setContainer", ["@service_container"]]
-            - ["setScopeMatcher", ["@contao.routing.scope_matcher"]]
 
     contao.security.user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
         public: false
         arguments:
             - "@contao.framework"
+            - "@contao.routing.scope_matcher"
         calls:
             - ["setContainer", ["@service_container"]]
-            - ["setScopeMatcher", ["@contao.routing.scope_matcher"]]
 
     contao.image.imagine:
         class: Imagine\Gd\Imagine

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -149,6 +149,7 @@ services:
         public: false
         calls:
             - ["setContainer", ["@service_container"]]
+            - ["setScopeMatcher", ["@contao.routing.scope_matcher"]]
 
     contao.security.user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
@@ -157,6 +158,7 @@ services:
             - "@contao.framework"
         calls:
             - ["setContainer", ["@service_container"]]
+            - ["setScopeMatcher", ["@contao.routing.scope_matcher"]]
 
     contao.image.imagine:
         class: Imagine\Gd\Imagine

--- a/src/Resources/contao/library/Contao/ClassLoader.php
+++ b/src/Resources/contao/library/Contao/ClassLoader.php
@@ -10,8 +10,6 @@
 
 namespace Contao;
 
-@trigger_error('Using the Contao\ClassLoader class has been deprecated and will no longer work in Contao 5.0. Use the Composer autoloader instead.', E_USER_DEPRECATED);
-
 
 /**
  * Automatically loads class files based on a mapper array
@@ -50,9 +48,13 @@ class ClassLoader
 	 * Add a new namespace
 	 *
 	 * @param string $name The namespace name
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function addNamespace($name)
 	{
+		@trigger_error('Using ClassLoader::addNamespace() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		if (in_array($name, self::$namespaces))
 		{
 			return;
@@ -66,9 +68,13 @@ class ClassLoader
 	 * Add multiple new namespaces
 	 *
 	 * @param array $names An array of namespace names
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function addNamespaces($names)
 	{
+		@trigger_error('Using ClassLoader::addNamespaces() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		foreach ($names as $name)
 		{
 			self::addNamespace($name);
@@ -80,9 +86,13 @@ class ClassLoader
 	 * Return the namespaces as array
 	 *
 	 * @return array An array of all namespaces
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function getNamespaces()
 	{
+		@trigger_error('Using ClassLoader::getNamespaces() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		return self::$namespaces;
 	}
 
@@ -92,9 +102,13 @@ class ClassLoader
 	 *
 	 * @param string $class The class name
 	 * @param string $file  The path to the class file
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function addClass($class, $file)
 	{
+		@trigger_error('Using ClassLoader::addClass() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		self::$classes[$class] = $file;
 	}
 
@@ -103,9 +117,13 @@ class ClassLoader
 	 * Add multiple new classes with their file paths
 	 *
 	 * @param array $classes An array of classes
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function addClasses($classes)
 	{
+		@trigger_error('Using ClassLoader::addClasses() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		foreach ($classes as $class=>$file)
 		{
 			self::addClass($class, $file);
@@ -117,9 +135,13 @@ class ClassLoader
 	 * Return the classes as array.
 	 *
 	 * @return array An array of all classes
+	 *
+	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.
 	 */
 	public static function getClasses()
 	{
+		@trigger_error('Using ClassLoader::getClasses() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		return self::$classes;
 	}
 

--- a/src/Resources/contao/library/Contao/ModuleLoader.php
+++ b/src/Resources/contao/library/Contao/ModuleLoader.php
@@ -10,8 +10,6 @@
 
 namespace Contao;
 
-@trigger_error('Using the Contao\ModuleLoader class has been deprecated and will no longer work in Contao 5.0. Use the container parameter "kernel.bundles" instead.', E_USER_DEPRECATED);
-
 
 /**
  * Loads modules based on their autoload.ini configuration
@@ -52,9 +50,13 @@ class ModuleLoader
 	 * Return the active modules as array
 	 *
 	 * @return array An array of active modules
+	 *
+	 * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.
 	 */
 	public static function getActive()
 	{
+		@trigger_error('Using ModuleLoader::getActive() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		$bundles = array_keys(\System::getContainer()->getParameter('kernel.bundles'));
 
 		foreach (static::$legacy as $bundleName => $module)
@@ -73,9 +75,13 @@ class ModuleLoader
 	 * Return the disabled modules as array
 	 *
 	 * @return array An array of disabled modules
+	 *
+	 * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.
 	 */
 	public static function getDisabled()
 	{
+		@trigger_error('Using ModuleLoader::getDisabled() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 		return array();
 	}
 }

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -10,10 +10,11 @@
 
 namespace Contao\CoreBundle\Security;
 
-use Contao\CoreBundle\Framework\ScopeAwareTrait;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\ContaoToken;
 use Contao\User;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -29,7 +30,22 @@ use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterfa
  */
 class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthenticatorInterface
 {
-    use ScopeAwareTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var ScopeMatcher
+     */
+    protected $scopeMatcher;
+
+    /**
+     * Sets the scope matcher.
+     *
+     * @param ScopeMatcher|null $scopeMatcher
+     */
+    public function setScopeMatcher(ScopeMatcher $scopeMatcher = null)
+    {
+        $this->scopeMatcher = $scopeMatcher;
+    }
 
     /**
      * Creates an authentication token.
@@ -110,6 +126,8 @@ class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthentic
             throw new \LogicException('The service container has not been set.');
         }
 
-        return !$this->isContaoScope();
+        return !$this->scopeMatcher->isContaoRequest(
+            $this->container->get('request_stack')->getCurrentRequest()
+        );
     }
 }

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -38,11 +38,11 @@ class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthentic
     protected $scopeMatcher;
 
     /**
-     * Sets the scope matcher.
+     * Constructor.
      *
-     * @param ScopeMatcher|null $scopeMatcher
+     * @param ScopeMatcher $scopeMatcher
      */
-    public function setScopeMatcher(ScopeMatcher $scopeMatcher = null)
+    public function __construct(ScopeMatcher $scopeMatcher)
     {
         $this->scopeMatcher = $scopeMatcher;
     }

--- a/src/Security/ContaoAuthenticator.php
+++ b/src/Security/ContaoAuthenticator.php
@@ -126,8 +126,8 @@ class ContaoAuthenticator implements ContainerAwareInterface, SimplePreAuthentic
             throw new \LogicException('The service container has not been set.');
         }
 
-        return !$this->scopeMatcher->isContaoRequest(
-            $this->container->get('request_stack')->getCurrentRequest()
-        );
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+
+        return null === $request || !$this->scopeMatcher->isContaoRequest($request);
     }
 }

--- a/src/Security/User/ContaoUserProvider.php
+++ b/src/Security/User/ContaoUserProvider.php
@@ -44,19 +44,11 @@ class ContaoUserProvider implements ContainerAwareInterface, UserProviderInterfa
      * Constructor.
      *
      * @param ContaoFrameworkInterface $framework
+     * @param ScopeMatcher             $scopeMatcher
      */
-    public function __construct(ContaoFrameworkInterface $framework)
+    public function __construct(ContaoFrameworkInterface $framework, ScopeMatcher $scopeMatcher)
     {
         $this->framework = $framework;
-    }
-
-    /**
-     * Sets the scope matcher.
-     *
-     * @param ScopeMatcher|null $scopeMatcher
-     */
-    public function setScopeMatcher(ScopeMatcher $scopeMatcher = null)
-    {
         $this->scopeMatcher = $scopeMatcher;
     }
 

--- a/tests/Security/ContaoAuthenticatorTest.php
+++ b/tests/Security/ContaoAuthenticatorTest.php
@@ -34,7 +34,7 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testInstantiation()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\CoreBundle\Security\ContaoAuthenticator', $authenticator);
     }
@@ -44,7 +44,7 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testCreateToken()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
         $token = $authenticator->createToken(new Request(), 'frontend');
 
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', $token);
@@ -57,9 +57,8 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testAuthenticateToken()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
         $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
-        $authenticator->setScopeMatcher($this->mockScopeMatcher());
 
         $provider = $this->mockUserProvider();
 
@@ -86,9 +85,8 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testAuthenticateInvalidToken()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
         $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
-        $authenticator->setScopeMatcher($this->mockScopeMatcher());
 
         $authenticator->authenticateToken(
             new PreAuthenticatedToken('foo', 'bar', 'console'), $this->mockUserProvider(), 'console'
@@ -102,7 +100,7 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testAuthenticateTokenWithoutContainer()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
 
         $authenticator->authenticateToken(
             new AnonymousToken('frontend', 'anon.'), $this->mockUserProvider(), 'frontend'
@@ -114,7 +112,7 @@ class ContaoAuthenticatorTest extends TestCase
      */
     public function testSupportsToken()
     {
-        $authenticator = new ContaoAuthenticator();
+        $authenticator = new ContaoAuthenticator($this->mockScopeMatcher());
 
         $this->assertTrue($authenticator->supportsToken(new ContaoToken($this->mockUser()), 'frontend'));
         $this->assertTrue($authenticator->supportsToken(new AnonymousToken('anon.', 'foo'), 'frontend'));

--- a/tests/Security/ContaoAuthenticatorTest.php
+++ b/tests/Security/ContaoAuthenticatorTest.php
@@ -59,6 +59,7 @@ class ContaoAuthenticatorTest extends TestCase
     {
         $authenticator = new ContaoAuthenticator();
         $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
+        $authenticator->setScopeMatcher($this->mockScopeMatcher());
 
         $provider = $this->mockUserProvider();
 
@@ -87,6 +88,7 @@ class ContaoAuthenticatorTest extends TestCase
     {
         $authenticator = new ContaoAuthenticator();
         $authenticator->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
+        $authenticator->setScopeMatcher($this->mockScopeMatcher());
 
         $authenticator->authenticateToken(
             new PreAuthenticatedToken('foo', 'bar', 'console'), $this->mockUserProvider(), 'console'

--- a/tests/Security/User/ContaoUserProviderTest.php
+++ b/tests/Security/User/ContaoUserProviderTest.php
@@ -48,7 +48,7 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testInstantiation()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\CoreBundle\Security\User\ContaoUserProvider', $provider);
     }
@@ -61,9 +61,8 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testLoadUserBackend()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
-        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\BackendUser', $provider->loadUserByUsername('backend'));
     }
@@ -76,9 +75,8 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testLoadUserFrontend()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
-        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\FrontendUser', $provider->loadUserByUsername('frontend'));
     }
@@ -90,9 +88,8 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testLoadWithInvalidScope()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes('invalid'));
-        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $provider->loadUserByUsername('frontend');
     }
@@ -104,7 +101,7 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testLoadUnsupportedUsername()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
 
         $provider->loadUserByUsername('foo');
@@ -117,7 +114,7 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testRefreshUser()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
 
         $provider->refreshUser(new User('foo', 'bar'));
@@ -128,7 +125,7 @@ class ContaoUserProviderTest extends TestCase
      */
     public function testSupportsClass()
     {
-        $provider = new ContaoUserProvider($this->framework);
+        $provider = new ContaoUserProvider($this->framework, $this->mockScopeMatcher());
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
 
         $this->assertTrue($provider->supportsClass('Contao\FrontendUser'));

--- a/tests/Security/User/ContaoUserProviderTest.php
+++ b/tests/Security/User/ContaoUserProviderTest.php
@@ -63,6 +63,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider($this->framework);
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_BACKEND));
+        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\BackendUser', $provider->loadUserByUsername('backend'));
     }
@@ -77,6 +78,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider($this->framework);
         $provider->setContainer($this->mockContainerWithContaoScopes(ContaoCoreBundle::SCOPE_FRONTEND));
+        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $this->assertInstanceOf('Contao\FrontendUser', $provider->loadUserByUsername('frontend'));
     }
@@ -90,6 +92,7 @@ class ContaoUserProviderTest extends TestCase
     {
         $provider = new ContaoUserProvider($this->framework);
         $provider->setContainer($this->mockContainerWithContaoScopes('invalid'));
+        $provider->setScopeMatcher($this->mockScopeMatcher());
 
         $provider->loadUserByUsername('frontend');
     }


### PR DESCRIPTION
### ToDo:

- [x] Remove ScopeAwareTrait from ContaoAuthenticator, use scope matcher service instead