### PR TITLE
[RFC] Use scope matcher instead of directly check for the request attribute

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -226,5 +226,6 @@ services:
         arguments:
             - "@request_stack"
             - "@contao.framework"
+            - "@contao.routing.scope_matcher"
         tags:
             - { name: twig.extension }

--- a/src/Twig/Extension/ContaoTemplateExtension.php
+++ b/src/Twig/Extension/ContaoTemplateExtension.php
@@ -12,6 +12,7 @@ namespace Contao\CoreBundle\Twig\Extension;
 
 use Contao\BackendCustom;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -29,18 +30,25 @@ class ContaoTemplateExtension extends \Twig_Extension
     /**
      * @var ContaoFrameworkInterface
      */
-    private $contaoFramework;
+    private $framework;
+
+    /**
+     * @var ScopeMatcher
+     */
+    private $scopeMatcher;
 
     /**
      * Constructor.
      *
      * @param RequestStack             $requestStack
-     * @param ContaoFrameworkInterface $contaoFramework
+     * @param ContaoFrameworkInterface $framework
+     * @param ScopeMatcher             $scopeMatcher
      */
-    public function __construct(RequestStack $requestStack, ContaoFrameworkInterface $contaoFramework)
+    public function __construct(RequestStack $requestStack, ContaoFrameworkInterface $framework, ScopeMatcher $scopeMatcher)
     {
         $this->requestStack = $requestStack;
-        $this->contaoFramework = $contaoFramework;
+        $this->framework = $framework;
+        $this->scopeMatcher = $scopeMatcher;
     }
 
     /**
@@ -62,14 +70,12 @@ class ContaoTemplateExtension extends \Twig_Extension
      */
     public function renderContaoBackendTemplate(array $blocks = [])
     {
-        $scope = $this->requestStack->getCurrentRequest()->attributes->get('_scope');
-
-        if ('backend' !== $scope) {
+        if (!$this->scopeMatcher->isBackendRequest($this->requestStack->getCurrentRequest())) {
             return '';
         }
 
         /** @var BackendCustom $controller */
-        $controller = $this->contaoFramework->createInstance(BackendCustom::class);
+        $controller = $this->framework->createInstance(BackendCustom::class);
         $template = $controller->getTemplateObject();
 
         foreach ($blocks as $key => $content) {

--- a/tests/Twig/Extension/ContaoTemplateExtensionTest.php
+++ b/tests/Twig/Extension/ContaoTemplateExtensionTest.php
@@ -61,7 +61,6 @@ class ContaoTemplateExtensionTest extends TestCase
         ]);
 
         $scopeMatcher = $this->mockScopeMatcher();
-
         $extension = new ContaoTemplateExtension($requestStack, $contaoFramework, $scopeMatcher);
 
         $extension->renderContaoBackendTemplate([
@@ -87,7 +86,6 @@ class ContaoTemplateExtensionTest extends TestCase
         $requestStack->push($request);
 
         $contaoFramework = $this->mockContaoFramework(null, null, [], []);
-
         $scopeMatcher = $this->mockScopeMatcher();
 
         $extension = new ContaoTemplateExtension($requestStack, $contaoFramework, $scopeMatcher);

--- a/tests/Twig/Extension/ContaoTemplateExtensionTest.php
+++ b/tests/Twig/Extension/ContaoTemplateExtensionTest.php
@@ -60,7 +60,9 @@ class ContaoTemplateExtensionTest extends TestCase
             BackendCustom::class => $backendRoute
         ]);
 
-        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework);
+        $scopeMatcher = $this->mockScopeMatcher();
+
+        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework, $scopeMatcher);
 
         $extension->renderContaoBackendTemplate([
             'a' => 'a',
@@ -86,7 +88,9 @@ class ContaoTemplateExtensionTest extends TestCase
 
         $contaoFramework = $this->mockContaoFramework(null, null, [], []);
 
-        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework);
+        $scopeMatcher = $this->mockScopeMatcher();
+
+        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework, $scopeMatcher);
         $functions = $extension->getFunctions();
 
         $renderBaseTemplateFunction = array_filter($functions, function(\Twig_SimpleFunction $function) {
@@ -107,8 +111,10 @@ class ContaoTemplateExtensionTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
+        $scopeMatcher = $this->mockScopeMatcher();
+
         $contaoFramework = $this->mockContaoFramework(null, null, [], []);
-        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework);
+        $extension = new ContaoTemplateExtension($requestStack, $contaoFramework, $scopeMatcher);
 
         $this->assertEmpty($extension->renderContaoBackendTemplate());
     }


### PR DESCRIPTION
Two things changed:

* We now use the `RequestMatcher` instead of directly check the request attribute in the request object
* Renamed `contaoFramework` to `framework`