### PR TITLE
[RTM] Fixed call to count() method on page objects

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -96,7 +96,7 @@ class FrontendIndex extends \Frontend
 		$objPage = $pageModel;
 
 		// Check the URL and language of each page if there are multiple results
-		if ($objPage !== null && $objPage->count() > 1)
+		if ($objPage instanceof \Model\Collection && $objPage->count() > 1)
 		{
 			$objNewPage = null;
 			$arrPages = array();

--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -96,7 +96,7 @@ class FrontendIndex extends \Frontend
 		$objPage = $pageModel;
 
 		// Check the URL and language of each page if there are multiple results
-		if ($objPage instanceof \Model\Collection && $objPage->count() > 1)
+		if ($objPage instanceof Model\Collection && $objPage->count() > 1)
 		{
 			$objNewPage = null;
 			$arrPages = array();


### PR DESCRIPTION
Passing a `PageModel` object is valid for the method, but the `count()` method does not exist.