### PR TITLE
[RTM] Allow to pass objects in callback arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.4.0-beta1 (2017-XX-XX)
 
+ * Support using objects in callback arrays (see #699).
  * Support importing form field options from a CSV file (see #444).
  * Add a Doctrine DBAL field type for UUIDs (see #415).
  * Support custom backend routes (see #512).

--- a/src/Resources/contao/library/Contao/System.php
+++ b/src/Resources/contao/library/Contao/System.php
@@ -149,11 +149,20 @@ abstract class System
 	{
 		$strKey = $strKey ?: $strClass;
 
+		if (is_object($strKey))
+		{
+			$strKey = get_class($strClass);
+		}
+
 		if ($blnForce || !isset($this->arrObjects[$strKey]))
 		{
 			$container = static::getContainer();
 
-			if (!class_exists($strClass) && $container->has($strClass))
+			if (is_object($strClass))
+			{
+				$this->arrObjects[$strKey] = $strClass;
+			}
+			elseif (!class_exists($strClass) && $container->has($strClass))
 			{
 				$this->arrObjects[$strKey] = $container->get($strClass);
 			}
@@ -182,11 +191,20 @@ abstract class System
 	{
 		$strKey = $strKey ?: $strClass;
 
+		if (is_object($strKey))
+		{
+			$strKey = get_class($strClass);
+		}
+
 		if ($blnForce || !isset(static::$arrStaticObjects[$strKey]))
 		{
 			$container = static::getContainer();
 
-			if (!class_exists($strClass) && $container->has($strClass))
+			if (is_object($strClass))
+			{
+				static::$arrStaticObjects[$strKey] = $strClass;
+			}
+			elseif (!class_exists($strClass) && $container->has($strClass))
 			{
 				static::$arrStaticObjects[$strKey] = $container->get($strClass);
 			}


### PR DESCRIPTION
This simple change should get us closer to actually callables.

You can now use `[$this, 'foobar']` for a callback. 

**Example for current:**
```php
$GLOBALS['TL_DCA']['tl_example']['config']['onload_callback'][] = function () {
    $this->onLoad();
};
```

**Example for new:**
```php
$GLOBALS['TL_DCA']['tl_example']['config']['onload_callback'][] = [$this, 'onLoad'];
```