### PR TITLE
Add bundle requirements to manager plugin

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -10,17 +10,50 @@
 
 namespace Contao\CoreBundle\ContaoManager;
 
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
+use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Contao\CoreBundle\ContaoCoreBundle;
 
 /**
  * Plugin for the Contao Manager.
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  */
-class Plugin implements RoutingPluginInterface
+class Plugin implements BundlePluginInterface, RoutingPluginInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundles(ParserInterface $parser)
+    {
+        return [
+            BundleConfig::create(KnpTimeBundle::class),
+            BundleConfig::create(ContaoCoreBundle::class)
+                ->setReplace(['core'])
+                ->setLoadAfter(
+                    [
+                        'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+                        'Symfony\Bundle\SecurityBundle\SecurityBundle',
+                        'Symfony\Bundle\TwigBundle\TwigBundle',
+                        'Symfony\Bundle\MonologBundle\MonologBundle',
+                        'Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle',
+                        'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+                        'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+                        'Knp\Bundle\TimeBundle\KnpTimeBundle',
+                        'Lexik\Bundle\MaintenanceBundle\LexikMaintenanceBundle',
+                        'Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle',
+                        'Contao\ManagerBundle\ContaoManagerBundle'
+                    ]
+                )
+            ,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\ContaoManager;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
@@ -17,7 +18,6 @@ use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Contao\CoreBundle\ContaoCoreBundle;
 
 /**
  * Plugin for the Contao Manager.


### PR DESCRIPTION
as discussed in https://github.com/contao/manager-bundle/issues/13, the core bundle should know it's dependencies.