### PR TITLE
[RTM] Allow to disable input encoding for a whole dca

### DIFF
--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -273,6 +273,12 @@ abstract class DataContainer extends \Backend
 			$this->varValue = \StringUtil::insertTagToSrc($this->varValue);
 		}
 
+		// Use raw request if set globally
+		if (isset($GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData']) && $GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData'] === true)
+		{
+			$arrData['eval']['useRawRequestData'] = true;
+		}
+
 		/** @var Widget $objWidget */
 		$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $this->strInputName, $this->varValue, $this->strField, $this->strTable, $this));
 

--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -273,8 +273,11 @@ abstract class DataContainer extends \Backend
 			$this->varValue = \StringUtil::insertTagToSrc($this->varValue);
 		}
 
-		// Use raw request if set globally
-		if (isset($GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData']) && $GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData'] === true)
+		// Use raw request if set globally but allow opting out setting useRawRequestData to false explicitly
+		$useRawGlobally = isset($GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData']) && $GLOBALS['TL_DCA'][$this->strTable]['config']['useRawRequestData'] === true;
+		$notRawForField = isset($arrData['eval']['useRawRequestData']) && $arrData['eval']['useRawRequestData'] === false;
+
+		if ($useRawGlobally && !$notRawForField)
 		{
 			$arrData['eval']['useRawRequestData'] = true;
 		}

--- a/src/Resources/contao/controllers/BackendPassword.php
+++ b/src/Resources/contao/controllers/BackendPassword.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 
@@ -50,13 +51,16 @@ class BackendPassword extends \Backend
 	 */
 	public function run()
 	{
+		/** @var Request $request */
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
 		/** @var BackendTemplate|object $objTemplate */
 		$objTemplate = new \BackendTemplate('be_password');
 
 		if (\Input::post('FORM_SUBMIT') == 'tl_password')
 		{
-			$pw = \Input::postUnsafeRaw('password');
-			$cnf = \Input::postUnsafeRaw('confirm');
+			$pw = $request->request->get('password');
+			$cnf = $request->request->get('confirm');
 
 			// The passwords do not match
 			if ($pw != $cnf)

--- a/src/Resources/contao/forms/FormPassword.php
+++ b/src/Resources/contao/forms/FormPassword.php
@@ -56,14 +56,14 @@ class FormPassword extends \Widget
 
 
 	/**
-	 * Always decode entities
+	 * Always use raw request data.
 	 *
 	 * @param array $arrAttributes An optional attributes array
 	 */
 	public function __construct($arrAttributes=null)
 	{
 		parent::__construct($arrAttributes);
-		$this->decodeEntities = true;
+		$this->useRawRequestData = true;
 	}
 
 

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Doctrine\DBAL\Types\Type;
 use Patchwork\Utf8;
+use Symfony\Component\HttpFoundation\Request;
 
 
 /**
@@ -83,6 +84,7 @@ use Patchwork\Utf8;
  * @property string                  $slabel            The submit button label
  * @property boolean                 $preserveTags      Preserve HTML tags
  * @property boolean                 $decodeEntities    Decode HTML entities
+ * @property boolean                 useRawRequestData  Use the raw request data from the Symfony request
  * @property integer                 $minlength         The minimum length
  * @property integer                 $maxlength         The maximum length
  * @property integer                 $minval            The minimum value
@@ -261,6 +263,14 @@ abstract class Widget extends \Controller
 
 			case 'prefix':
 				$this->strPrefix = $varValue;
+				break;
+
+			case 'useRawRequestData':
+				/** @var Request $request */
+				$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
+				$this->setInputCallback(function() use ($request) {
+					return $request->request->get($this->name);
+				});
 				break;
 
 			case 'template':

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -342,6 +342,7 @@ abstract class Widget extends \Controller
 			case 'trailingSlash':
 			case 'spaceToUnderscore':
 			case 'doNotTrim':
+			case 'useRawRequestData':
 				$this->arrConfiguration[$strKey] = $varValue ? true : false;
 				break;
 

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -266,11 +266,19 @@ abstract class Widget extends \Controller
 				break;
 
 			case 'useRawRequestData':
-				/** @var Request $request */
-				$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
-				$this->setInputCallback(function() use ($request) {
-					return $request->request->get($this->name);
-				});
+				if ($varValue === true)
+				{
+					/** @var Request $request */
+					$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
+					$this->setInputCallback(function() use ($request) {
+						return $request->request->get($this->name);
+					});
+				}
+				else
+				{
+					$this->setInputCallback(null);
+				}
+
 				break;
 
 			case 'template':

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -265,22 +265,6 @@ abstract class Widget extends \Controller
 				$this->strPrefix = $varValue;
 				break;
 
-			case 'useRawRequestData':
-				if ($varValue === true)
-				{
-					/** @var Request $request */
-					$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
-					$this->setInputCallback(function() use ($request) {
-						return $request->request->get($this->name);
-					});
-				}
-				else
-				{
-					$this->setInputCallback(null);
-				}
-
-				break;
-
 			case 'template':
 				$this->strTemplate = $varValue;
 				break;
@@ -811,6 +795,13 @@ abstract class Widget extends \Controller
 	 */
 	protected function getPost($strKey)
 	{
+		if ($this->useRawRequestData === true)
+		{
+			/** @var Request $request */
+			$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
+			return $request->request->get($strKey);
+		}
+
 		$strMethod = $this->allowHtml ? 'postHtml' : 'post';
 
 		if ($this->preserveTags)

--- a/src/Resources/contao/widgets/Password.php
+++ b/src/Resources/contao/widgets/Password.php
@@ -46,14 +46,14 @@ class Password extends \Widget
 
 
 	/**
-	 * Always decode entities
+	 * Always use raw request data.
 	 *
 	 * @param array $arrAttributes
 	 */
 	public function __construct($arrAttributes=null)
 	{
 		parent::__construct($arrAttributes);
-		$this->decodeEntities = true;
+		$this->useRawRequestData = true;
 	}
 
 


### PR DESCRIPTION
Here's another feature for Contao 4.4.

For my own modules I want to be able to disable the input encoding all together and output stuff using twig or encode it myself. I have an application which even doesn't output anything at all but manages content that's fetched through an API. I have to set the `eval` attributes on every field which is a bit tedious. I think it can be very helpful to disable this completely and prepare for the future already in your own bundles/applications :-)