### PR TITLE
Only remove headers if not already sent

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -145,7 +145,7 @@ class MergeHttpHeadersListener
         foreach ($this->getHeaders() as $header) {
             list($name, $content) = explode(':', $header, 2);
 
-            if ('cli' !== PHP_SAPI) {
+            if ('cli' !== PHP_SAPI && !headers_sent()) {
                 header_remove($name);
             }
 


### PR DESCRIPTION
When you get PHP warnings because you did something wrong and their not suppressed, headers will be already sent by the time our listener is triggered.
It will cause yet another warning because headers are already sent.

Not a big deal but we should not try to work on the headers if they're already sent because it possibly won't do anything at all anyway as the header might be already sent :-)