### PR TITLE
Set up a default public folder on contao:install command

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Installs the required Contao directories.
@@ -97,6 +98,7 @@ class InstallCommand extends AbstractLockedCommand
         $this->webDir = rtrim($input->getArgument('target'), '/');
 
         $this->addEmptyDirs();
+        $this->setupUploadDir();
         $this->addIgnoredDirs();
 
         if (!empty($this->rows)) {
@@ -117,8 +119,27 @@ class InstallCommand extends AbstractLockedCommand
         foreach ($this->emptyDirs as $path) {
             $this->addEmptyDir($this->rootDir.'/'.sprintf($path, $this->webDir));
         }
+    }
 
-        $this->addEmptyDir($this->rootDir.'/'.$this->getContainer()->getParameter('contao.upload_path'));
+    /**
+     * Sets up the upload directory (upload_path - "files" by default)
+     */
+    private function setupUploadDir()
+    {
+        $uploadPath = $this->rootDir.'/'.$this->getContainer()->getParameter('contao.upload_path');
+
+        $this->addEmptyDir($uploadPath);
+
+        // Add best practice folder "public" if not empty
+        $files = Finder::create()
+                    ->ignoreDotFiles(true)
+                    ->in($uploadPath)
+                    ->count();
+
+        if (0 === $files) {
+            $this->addEmptyDir($uploadPath . '/public');
+            $this->fs->dumpFile($uploadPath . '/public/.public', '');
+        }
     }
 
     /**

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -85,6 +85,7 @@ class InstallCommandTest extends TestCase
         $this->assertContains(' * system/cache', $display);
         $this->assertContains(' * system/config', $display);
         $this->assertContains(' * system/tmp', $display);
+        $this->assertFileExists($this->getRootDir().'/files/public/.public');
     }
 
     /**


### PR DESCRIPTION
I think a lot of users forget that as of Contao 4, folders are protected by default.
And even if you know about it, I guess every project needs public files and I found myself creating the same file structure over and over again. I'm always using

* files
    * public
    * protected

While people might not like the "protected" folder, I think it is a good idea to create a "public" folder by default when setting up Contao. It makes setup faster and gives the users a hint about having to explicitly make folders public automatically.