### PR TITLE
[RFC] Use try-finally blocks to close all opened output buffers

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -288,9 +288,17 @@ class FrontendIndex extends \Frontend
 					if (!method_exists($objHandler, 'getResponse'))
 					{
 						ob_start();
-						$objHandler->generate($objPage, true);
+						try
+						{
+							$objHandler->generate($objPage, true);
+							$objResponse = new Response(ob_get_contents(), http_response_code());
+						}
+						finally
+						{
+							ob_end_clean();
+						}
 
-						return new Response(ob_get_clean(), http_response_code());
+						return $objResponse;
 					}
 
 					return $objHandler->getResponse($objPage, true);

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\ResponseException;
 use Contao\Image\Image as ContaoImage;
 use Contao\Image\ImageDimensions;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 
@@ -776,8 +775,6 @@ class File extends \System
 	 */
 	public function sendToBrowser($filename='')
 	{
-		Response::closeOutputBuffers(0, false); // see #698
-
 		$response = new BinaryFileResponse(TL_ROOT . '/' . $this->strFile);
 
 		$response->setContentDisposition

--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -912,8 +912,15 @@ class InsertTags extends \Controller
 					if (preg_match('/\.(php|tpl|xhtml|html5)$/', $strFile) && file_exists(TL_ROOT . '/templates/' . $strFile))
 					{
 						ob_start();
-						include TL_ROOT . '/templates/' . $strFile;
-						$arrCache[$strTag] = ob_get_clean();
+						try
+						{
+							include TL_ROOT . '/templates/' . $strFile;
+							$arrCache[$strTag] = ob_get_contents();
+						}
+						finally
+						{
+							ob_end_clean();
+						}
 					}
 
 					$_GET = $arrGet;

--- a/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -61,6 +61,12 @@ trait TemplateInheritance
 	 */
 	protected $arrBlockNames = array();
 
+	/**
+	 * Buffer level
+	 * @var int
+	 */
+	protected $intBufferLevel = 0;
+
 
 	/**
 	 * Parse the template file and return it as string
@@ -85,19 +91,28 @@ trait TemplateInheritance
 			$this->strDefault = null;
 
 			ob_start();
-			include $strParent;
+			$this->intBufferLevel = 1;
 
-			// Capture the output of the root template
-			if ($this->strParent === null)
+			try
 			{
-				$strBuffer = ob_get_contents();
-			}
-			elseif ($this->strParent == $strCurrent)
-			{
-				$this->strDefault = $this->getTemplatePath($this->strParent, $this->strFormat, true);
-			}
+				include $strParent;
 
-			ob_end_clean();
+				// Capture the output of the root template
+				if ($this->strParent === null)
+				{
+					$strBuffer = ob_get_contents();
+				}
+				elseif ($this->strParent == $strCurrent)
+				{
+					$this->strDefault = $this->getTemplatePath($this->strParent, $this->strFormat, true);
+				}
+			}
+			finally
+			{
+				for ($i = 0; $i < $this->intBufferLevel; $i++) {
+					ob_end_clean();
+				}
+			}
 		}
 
 		// Reset the internal arrays
@@ -179,6 +194,7 @@ trait TemplateInheritance
 				{
 					echo $this->arrBlocks[$name];
 					ob_start();
+					$this->intBufferLevel++;
 				}
 			}
 		}
@@ -187,16 +203,13 @@ trait TemplateInheritance
 		else
 		{
 			// Clean the output buffer
-			ob_end_clean();
+			ob_clean();
 
 			// Check for nested blocks
 			if (count($this->arrBlockNames) > 1)
 			{
 				throw new \Exception('Nested blocks are not allowed in child templates');
 			}
-
-			// Start a new output buffer
-			ob_start();
 		}
 	}
 
@@ -234,6 +247,7 @@ trait TemplateInheritance
 				else
 				{
 					ob_end_clean();
+					$this->intBufferLevel--;
 				}
 			}
 		}

--- a/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -194,7 +194,7 @@ trait TemplateInheritance
 				{
 					echo $this->arrBlocks[$name];
 					ob_start();
-					$this->intBufferLevel++;
+					++$this->intBufferLevel;
 				}
 			}
 		}
@@ -247,7 +247,7 @@ trait TemplateInheritance
 				else
 				{
 					ob_end_clean();
-					$this->intBufferLevel--;
+					--$this->intBufferLevel;
 				}
 			}
 		}

--- a/tests/Contao/TemplateTest.php
+++ b/tests/Contao/TemplateTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\BackendTemplate;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\System;
+use Exception;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Tests the Template class.
+ *
+ * @author Martin Auswöger <martin@auswoeger.com>
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @group contao3
+ */
+class TemplateTest extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $fs = new Filesystem();
+        $fs->mkdir($this->getRootDir().'/templates');
+
+        define('TL_ROOT', $this->getRootDir());
+        define('TL_MODE', 'BE');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->getRootDir().'/templates');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Tests the parse() method.
+     */
+    public function testParse()
+    {
+        file_put_contents(
+            $this->getRootDir().'/templates/test_template.html5',
+            '<?= $this->value ?>'
+        );
+        $template = new BackendTemplate('test_template');
+
+        $template->setData([
+            'value' => 'test',
+        ]);
+
+        $obLevel = ob_get_level();
+        $this->assertEquals('test', $template->parse());
+        $this->assertEquals($obLevel, ob_get_level());
+    }
+
+    /**
+     * Tests the parse() method.
+     */
+    public function testParseWithException()
+    {
+        file_put_contents(
+            $this->getRootDir().'/templates/test_template.html5',
+            'test<?php throw new Exception ?>'
+        );
+
+        $template = new BackendTemplate('test_template');
+        $obLevel = ob_get_level();
+
+        ob_start();
+
+        try {
+            $template->parse();
+            $this->fail('Parse should throw an exception');
+        } catch (Exception $e) {
+            // Ignore
+        }
+
+        $this->assertEquals('', ob_get_clean());
+        $this->assertEquals($obLevel, ob_get_level());
+    }
+
+    /**
+     * Tests the parse() method.
+     */
+    public function testParseWithExceptionInBlock()
+    {
+        file_put_contents($this->getRootDir().'/templates/test_template.html5', <<<'EOF'
+<?php
+    echo 'test1';
+    $this->block('a');
+    echo 'test2';
+    $this->block('b');
+    echo 'test3';
+    $this->block('c');
+    echo 'test4';
+    throw new Exception;
+EOF
+        );
+
+        $template = new BackendTemplate('test_template');
+        $obLevel = ob_get_level();
+
+        ob_start();
+
+        try {
+            $template->parse();
+            $this->fail('Parse should throw an exception');
+        } catch (Exception $e) {
+            // Ignore
+        }
+
+        $this->assertEquals('', ob_get_clean());
+        $this->assertEquals($obLevel, ob_get_level());
+    }
+
+    /**
+     * Tests the parse() method.
+     */
+    public function testParseWithExceptionInBlockExtended()
+    {
+        file_put_contents($this->getRootDir().'/templates/test_parent.html5', <<<'EOF'
+<?php
+    echo 'test1';
+    $this->block('a');
+    echo 'test2';
+    $this->endblock();
+    $this->block('b');
+    echo 'test3';
+    $this->endblock();
+    $this->block('c');
+    echo 'test4';
+    $this->block('d');
+    echo 'test5';
+    $this->block('e');
+    echo 'test6';
+    throw new Exception;
+EOF
+        );
+
+        file_put_contents($this->getRootDir().'/templates/test_template.html5', <<<'EOF'
+<?php
+    echo 'test1';
+    $this->extend('test_parent');
+    echo 'test2';
+    $this->block('a');
+    echo 'test3';
+    $this->parent();
+    echo 'test4';
+    $this->endblock('a');
+    echo 'test5';
+    $this->block('b');
+    echo 'test6';
+    $this->endblock('b');
+    echo 'test7';
+EOF
+        );
+
+        $template = new BackendTemplate('test_template');
+        $obLevel = ob_get_level();
+
+        ob_start();
+
+        try {
+            $template->parse();
+            $this->fail('Parse should throw an exception');
+        } catch (Exception $e) {
+            // Ignore
+        }
+
+        $this->assertEquals('', ob_get_clean());
+        $this->assertEquals($obLevel, ob_get_level());
+    }
+
+    /**
+     * Tests the parse() method.
+     */
+    public function testParseNestedBlock()
+    {
+        file_put_contents($this->getRootDir().'/templates/test_parent.html5', '');
+
+        file_put_contents($this->getRootDir().'/templates/test_template.html5', <<<'EOF'
+<?php
+    echo 'test1';
+    $this->extend('test_parent');
+    echo 'test2';
+    $this->block('a');
+    echo 'test3';
+    $this->block('b');
+    echo 'test4';
+    $this->endblock('b');
+    echo 'test5';
+    $this->endblock('a');
+    echo 'test6';
+EOF
+        );
+
+        $template = new BackendTemplate('test_template');
+        $obLevel = ob_get_level();
+
+        ob_start();
+
+        try {
+            $template->parse();
+            $this->fail('Parse should throw an exception');
+        } catch (Exception $e) {
+            // Ignore
+        }
+
+        $this->assertEquals('', ob_get_clean());
+        $this->assertEquals($obLevel, ob_get_level());
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/contao/core-bundle/pull/698#issuecomment-279708701

@antoinedavid can you verify that this solves your issue with `sendToBrowser()`?