### PR TITLE
[RFC] Correctly parse Doctrine SQL array

### DIFF
--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -1463,7 +1463,8 @@ abstract class Widget extends \Controller
 			{
 				$sql = $sql['columnDefinition'];
 			}
-			else {
+			else
+			{
 				if (isset($sql['default']))
 				{
 					return $sql['default'];

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -1380,6 +1380,19 @@ abstract class Widget extends \Controller
 			}
 		}
 
+		if (is_array($arrAttributes['sql']) && !isset($arrAttributes['sql']['columnDefinition']))
+		{
+			if (isset($arrAttributes['sql']['length']) && !isset($arrAttributes['maxlength']))
+			{
+				$arrAttributes['maxlength'] = $arrAttributes['sql']['length'];
+			}
+
+			if (isset($arrAttributes['sql']['unique']) && !isset($arrAttributes['unique']))
+			{
+				$arrAttributes['unique'] = $arrAttributes['sql']['unique'];
+			}
+		}
+
 		$arrAttributes['value'] = \StringUtil::deserialize($varValue);
 
 		// Convert timestamps

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Doctrine\DBAL\Types\Type;
 use Patchwork\Utf8;
 
 
@@ -1438,9 +1439,35 @@ abstract class Widget extends \Controller
 	 */
 	public static function getEmptyValueByFieldType($sql)
 	{
-		if ($sql == '')
+		if (empty($sql))
 		{
 			return '';
+		}
+
+		if (is_array($sql))
+		{
+			if (isset($sql['columnDefinition']))
+			{
+				$sql = $sql['columnDefinition'];
+			}
+			else {
+				if (isset($sql['options']['default']))
+				{
+					return $sql['options']['default'];
+				}
+
+				if ($sql['nullable'])
+				{
+					return null;
+				}
+
+				if (in_array($sql['type'], array(Type::BIGINT, Type::DECIMAL, Type::INTEGER, Type::SMALLINT, Type::FLOAT)))
+				{
+					return 0;
+				}
+
+				return '';
+			}
 		}
 
 		if (stripos($sql, 'NOT NULL') === false)

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -1387,9 +1387,9 @@ abstract class Widget extends \Controller
 				$arrAttributes['maxlength'] = $arrAttributes['sql']['length'];
 			}
 
-			if (isset($arrAttributes['sql']['unique']) && !isset($arrAttributes['unique']))
+			if (isset($arrAttributes['sql']['customSchemaOptions']['unique']) && !isset($arrAttributes['unique']))
 			{
-				$arrAttributes['unique'] = $arrAttributes['sql']['unique'];
+				$arrAttributes['unique'] = $arrAttributes['sql']['customSchemaOptions']['unique'];
 			}
 		}
 
@@ -1464,12 +1464,12 @@ abstract class Widget extends \Controller
 				$sql = $sql['columnDefinition'];
 			}
 			else {
-				if (isset($sql['options']['default']))
+				if (isset($sql['default']))
 				{
-					return $sql['options']['default'];
+					return $sql['default'];
 				}
 
-				if ($sql['nullable'])
+				if (isset($sql['notnull']) && !$sql['notnull'])
 				{
 					return null;
 				}

--- a/src/Resources/contao/library/Contao/Widget.php
+++ b/src/Resources/contao/library/Contao/Widget.php
@@ -1524,20 +1524,12 @@ abstract class Widget extends \Controller
 	 */
 	public static function getEmptyStringOrNullByFieldType($sql)
 	{
-		if ($sql == '')
+		if (empty($sql))
 		{
 			return '';
 		}
 
-		// Strip the field type definition
-		list(, $def) = explode(' ', $sql, 2);
-
-		if (strpos($def, 'NULL') !== false && strpos($def, 'NOT NULL') === false)
-		{
-			return null;
-		}
-
-		return '';
+		return static::getEmptyValueByFieldType($sql) === null ? null : '';
 	}
 
 


### PR DESCRIPTION
Since Contao 4.3 we can set an array for the SQL definition in DCAs. However, the default value and other configs were not correctly detected/merged.