### PR TITLE
[RTM] Fix bug with relative ../ parts in image URLs

### DIFF
--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -468,14 +468,7 @@ class Image
 			)
 		;
 
-		$this->resizedPath = $image->getPath();
-
-		if (strpos($this->resizedPath, TL_ROOT . '/') === 0 || strpos($this->resizedPath, TL_ROOT . '\\') === 0)
-		{
-			$this->resizedPath = substr($this->resizedPath, strlen(TL_ROOT) + 1);
-		}
-
-		$this->resizedPath = \System::urlEncode($this->resizedPath);
+		$this->resizedPath = $image->getUrl(TL_ROOT);
 
 		return $this;
 	}


### PR DESCRIPTION
Using the legacy image class `\Image::get('image.jpg', 100, 100);` generates URLs like `app/../assets/images/5/image-42ccae20.jpg`. This was fixed for the new image services in contao/image#16 but we missed the legacy image class. This pull request fixes that.