### PR TITLE
[RTM] Fixed {{toggle_view}} insert tag

### DIFF
--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -576,7 +576,7 @@ class InsertTags extends \Controller
 
 					$strUrl = ampersand($strRequest);
 					$strGlue = (strpos($strUrl, '?') === false) ? '?' : '&amp;';
-					
+
 					\System::loadLanguageFile('default');
 
 					if (\Input::cookie('TL_VIEW') == 'mobile' || (\Environment::get('agent')->mobile && \Input::cookie('TL_VIEW') != 'desktop'))

--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -120,7 +120,10 @@ class InsertTags extends \Controller
 				{
 					/** @var FragmentHandler $fragmentHandler */
 					$fragmentHandler = \System::getContainer()->get('fragment.handler');
-					$strBuffer .= $fragmentHandler->render(new ControllerReference('contao.controller.insert_tags:renderAction', ['insertTag' => '{{' . $strTag . '}}']), 'esi');
+					$strBuffer .= $fragmentHandler->render(new ControllerReference('contao.controller.insert_tags:renderAction',
+						['insertTag' => '{{' . $strTag . '}}'],
+						['pageId' => $objPage->id, 'request' => \Environment::get('request')]
+					), 'esi');
 					continue;
 				}
 			}
@@ -562,8 +565,19 @@ class InsertTags extends \Controller
 
 				// Mobile/desktop toggle (see #6469)
 				case 'toggle_view':
-					$strUrl = ampersand(\Environment::get('request'));
+					$strRequest = \Environment::get('request');
+
+					// ESI request
+					if (preg_match('/^' . preg_quote(ltrim(\System::getContainer()->getParameter('fragment.path'), '/'), '/') . '/', $strRequest))
+					{
+						$request = \System::getContainer()->get('request_stack')->getCurrentRequest();
+						$strRequest = $request->query->get('request');
+					}
+
+					$strUrl = ampersand($strRequest);
 					$strGlue = (strpos($strUrl, '?') === false) ? '?' : '&amp;';
+					
+					\System::loadLanguageFile('default');
 
 					if (\Input::cookie('TL_VIEW') == 'mobile' || (\Environment::get('agent')->mobile && \Input::cookie('TL_VIEW') != 'desktop'))
 					{


### PR DESCRIPTION
Same issue as mentioned multiple times: When a page is cached (in case of Contao 3.5) there's no environment information anymore. That's why every fragment that wants to be included using ESI (in Contao 4) needs to make sure it works 100% without any dependencies.
I've added the `request` query parameter to pass on the original request to the ESI request string and while I was on it, also passed on the `pageId` parameter.
Again, there might be a lot of other use cases and we just cannot fix them all with the software architecture we currently have. I'm working on it and these small PR's are tiny step-by-step fixes so that at least the core works fine (if an extension dev needs another param, we might provide it until the proper solution was implemented).