### PR TITLE
[RTM] Skip folder DCs that are not database assisted in DcaExtractor

### DIFF
--- a/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -401,6 +401,12 @@ class DcaExtractor extends \Controller
 			return;
 		}
 
+		// Return if the DC type is "Folder" and is not database assisted
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'Folder' && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
+		{
+			return;
+		}
+
 		$blnFromFile = false;
 		$arrRelations = array();
 

--- a/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -401,7 +401,7 @@ class DcaExtractor extends \Controller
 			return;
 		}
 
-		// Return if the DC type is "Folder" and is not database assisted
+		// Return if the DC type is "Folder" and the DC is not database assisted
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'Folder' && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
 		{
 			return;


### PR DESCRIPTION
The install tool currently shows the deprecation message *“Using database.sql files has been deprecated and will no longer work in Contao 5.0. Use a DCA file instead.”* because it thinks `tl_templates` uses a *database.sql* file.

With this PR `DC_Folder`s that are not database assisted get skipped in the `DcaExtractor`.