### PR TITLE
Use the SF var dumper directly to show template variables

### DIFF
--- a/src/Resources/contao/library/Contao/Template.php
+++ b/src/Resources/contao/library/Contao/Template.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use MatthiasMullie\Minify;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\VarDumper;
 
 
 /**
@@ -236,22 +237,21 @@ abstract class Template extends \Controller
 
 
 	/**
-	 * Print all template variables to the screen using print_r
+	 * Here for BC only.
 	 */
 	public function showTemplateVars()
 	{
-		echo "<pre>\n";
-		print_r($this->arrData);
-		echo "</pre>\n";
+		$this->dumpTemplateVars();
 	}
 
 
 	/**
-	 * Print all template variables to the screen using var_dump
+	 * Print all template variables to the screen using the Symfony VarDumper
+	 * component
 	 */
 	public function dumpTemplateVars()
 	{
-		dump($this->arrData);
+		VarDumper::dump($this->arrData);
 	}
 
 

--- a/src/Resources/contao/library/Contao/Template.php
+++ b/src/Resources/contao/library/Contao/Template.php
@@ -237,17 +237,21 @@ abstract class Template extends \Controller
 
 
 	/**
-	 * Here for BC only.
+	 * Print all template variables to the screen using print_r
+	 *
+	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.
+	 *             Use Template::dumpTemplateVars() instead.
 	 */
 	public function showTemplateVars()
 	{
+		@trigger_error('Using Template::showTemplateVars() has been deprecated and will no longer work in Contao 5.0. Use Template::dumpTemplateVars() instead.', E_USER_DEPRECATED);
+
 		$this->dumpTemplateVars();
 	}
 
 
 	/**
-	 * Print all template variables to the screen using the Symfony VarDumper
-	 * component
+	 * Print all template variables to the screen using the Symfony VarDumper component
 	 */
 	public function dumpTemplateVars()
 	{


### PR DESCRIPTION
Fix for https://github.com/contao/core/issues/8686.
Was actually way easier than I thought because we don't need the debug bundle for dumping the template vars. Here's the output:

![screen shot 2017-04-02 at 00 37 15](https://cloud.githubusercontent.com/assets/481937/24582989/22de02c4-173d-11e7-880e-2e3125df902c.png)

Oh, and here's what you will be able to do when Symfony 3.3 is released and you hit <kbd>CTRL</kbd>/<kbd>CMD</kbd> + <kbd>F</kbd>:

![screen shot 2017-04-02 at 00 37 33](https://cloud.githubusercontent.com/assets/481937/24583003/840de258-173d-11e7-9198-3739a975673a.png)

Symfony ❤️ 