### PR TITLE
[RTM] Fix bug overwriting cache/clientCache with zero values

### DIFF
--- a/src/Resources/contao/classes/FrontendTemplate.php
+++ b/src/Resources/contao/classes/FrontendTemplate.php
@@ -366,7 +366,7 @@ class FrontendTemplate extends \Template
 		/** @var $objPage \PageModel */
 		global $objPage;
 
-		if ($objPage->cache === false && $objPage->clientCache === false)
+		if (($objPage->cache === false || $objPage->cache === 0) && ($objPage->clientCache === false || $objPage->clientCache === 0))
 		{
 			return $response->setPrivate();
 		}

--- a/src/Resources/contao/models/PageModel.php
+++ b/src/Resources/contao/models/PageModel.php
@@ -889,8 +889,8 @@ class PageModel extends \Model
 					// Cache
 					if ($objParentPage->includeCache)
 					{
-						$this->cache = $this->cache ?: $objParentPage->cache;
-						$this->clientCache = $this->clientCache ?: $objParentPage->clientCache;
+						$this->cache = $this->cache !== false ? $this->cache : $objParentPage->cache;
+						$this->clientCache = $this->clientCache !== false ? $this->clientCache : $objParentPage->clientCache;
 					}
 
 					// Layout


### PR DESCRIPTION
If you set a cache time in the root page of a website and want to overwrite it with `0` in a subpage it doesn’t work currently because the check doesn’t differentiate between `0` and `false`.