### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ContaoCoreBundle:
     resource: "@ContaoCoreBundle/Resources/config/routing.yml"
 ```
 
-Add the following entries to your `app/config/security.yml` file:
+Replace the content of your `app/config/security.yml` file with the following:
 
 ```yml
 imports:


### PR DESCRIPTION
If you simply add (append or prepend)
```yml
imports:
    - { resource: "@ContaoCoreBundle/Resources/config/security.yml" }
```
to the `app/config/security.yml`, Symfony will complain with the following error:
```
[Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]
You are not allowed to define new elements for path "security.firewalls".
Please define all elements for this path in one config file.
```
This happens at least in Symfony `3.2.7`.