### PR TITLE
Handle namespaces and declare() statements when combining files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "oyejorge/less.php": "^1.7",
         "patchwork/utf8": "^1.2",
         "phpspec/php-diff": "^1.0",
+        "phpunit/php-token-stream": "^1.4",
         "psr/log": "^1.0",
         "simplepie/simplepie": "^1.3",
         "tecnickcom/tcpdf": "^6.0",

--- a/src/Config/Dumper/CombinedFileDumper.php
+++ b/src/Config/Dumper/CombinedFileDumper.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\Config\Dumper;
 
+use Contao\CoreBundle\Config\Loader\PhpFileLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -83,19 +84,11 @@ class CombinedFileDumper implements DumperInterface
      */
     public function dump($files, $cacheFile, array $options = [])
     {
-        $type = isset($options['type']) ? $options['type'] : null;
         $buffer = $this->header;
+        $type = $this->addNamespace ? PhpFileLoader::NAMESPACED : null;
 
         foreach ((array) $files as $file) {
-            if ($this->addNamespace) {
-                $buffer .= "\nnamespace {";
-            }
-
             $buffer .= $this->loader->load($file, $type);
-
-            if ($this->addNamespace) {
-                $buffer .= "\n}\n";
-            }
         }
 
         $this->filesystem->dumpFile($this->cacheDir.'/'.$cacheFile, $buffer);

--- a/tests/Config/Dumper/CombinedFileDumperTest.php
+++ b/tests/Config/Dumper/CombinedFileDumperTest.php
@@ -54,21 +54,6 @@ class CombinedFileDumperTest extends TestCase
     }
 
     /**
-     * Tests dumping a file with namespace declaration.
-     */
-    public function testDumpWithNamespace()
-    {
-        $dumper = new CombinedFileDumper(
-            $this->mockFilesystem("<?php\n\nnamespace {\necho 'test';\n\n}\n"),
-            $this->mockLoader(),
-            $this->getCacheDir(),
-            true
-        );
-
-        $dumper->dump(['test.php'], 'test.php');
-    }
-
-    /**
      * Tests setting a valid header.
      */
     public function testValidHeader()
@@ -105,7 +90,7 @@ class CombinedFileDumperTest extends TestCase
      *
      * @param mixed $expects
      *
-     * @return Filesystem
+     * @return Filesystem|\PHPUnit_Framework_MockObject_MockObject
      */
     private function mockFilesystem($expects)
     {
@@ -126,7 +111,7 @@ class CombinedFileDumperTest extends TestCase
     /**
      * Returns a mocked file loader object.
      *
-     * @return PhpFileLoader
+     * @return PhpFileLoader|\PHPUnit_Framework_MockObject_MockObject
      */
     private function mockLoader()
     {

--- a/tests/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Config/Loader/PhpFileLoaderTest.php
@@ -66,13 +66,18 @@ class PhpFileLoaderTest extends TestCase
      */
     public function testLoad()
     {
+        $expects = <<<'EOF'
+
+$GLOBALS['TL_TEST'] = true;
+
+EOF;
+
         $this->assertEquals(
-            "\n\n\$GLOBALS['TL_TEST'] = true;\n",
+            $expects,
             $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/config/config.php')
         );
 
-        $content = <<<'EOF'
-
+        $expects = <<<'EOF'
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
@@ -93,14 +98,83 @@ $GLOBALS['TL_DCA']['tl_test'] = [
 EOF;
 
         $this->assertEquals(
-            $content,
+            $expects,
             $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/dca/tl_test.php')
         );
+    }
+
+    /**
+     * Test loading a file with a custom namespace.
+     */
+    public function testLoadNamespace()
+    {
+        $expects = <<<'EOF'
+
+namespace Foo\Bar {
+//namespace Foo\Bar;
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+}
+
+EOF;
 
         $this->assertEquals(
-            "\n\n\$GLOBALS['TL_TEST'] = true;\n",
+            $expects,
             $this->loader->load(
-                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php'
+                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/dca/tl_namespace.php',
+                PhpFileLoader::NAMESPACED
+            )
+        );
+    }
+
+    /**
+     * Test loading a file with a declare statement.
+     */
+    public function testLoadDeclare()
+    {
+        $expects = <<<'EOF'
+
+/**
+ * I am a declare(strict_types=1) comment
+ */
+
+//declare(strict_types=1);
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+
+EOF;
+
+        $this->assertEquals(
+            $expects,
+            $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/dca/tl_declare.php')
+        );
+
+        $expects = <<<'EOF'
+
+//declare(strict_types  =   1,ticks = 1);
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+
+EOF;
+
+        $this->assertEquals(
+            $expects,
+            $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/dca/tl_declare2.php')
+        );
+
+        $expects = <<<'EOF'
+
+namespace {
+$GLOBALS['TL_TEST'] = true;
+}
+
+EOF;
+
+        $this->assertEquals(
+            $expects,
+            $this->loader->load(
+                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php',
+                PhpFileLoader::NAMESPACED
             )
         );
     }

--- a/tests/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Config/Loader/PhpFileLoaderTest.php
@@ -125,6 +125,22 @@ EOF;
                 PhpFileLoader::NAMESPACED
             )
         );
+
+        $expects = <<<'EOF'
+
+namespace  {
+$GLOBALS['TL_TEST'] = true;
+}
+
+EOF;
+
+        $this->assertEquals(
+            $expects,
+            $this->loader->load(
+                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php',
+                PhpFileLoader::NAMESPACED
+            )
+        );
     }
 
     /**
@@ -160,22 +176,6 @@ EOF;
         $this->assertEquals(
             $expects,
             $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/dca/tl_declare2.php')
-        );
-
-        $expects = <<<'EOF'
-
-namespace {
-$GLOBALS['TL_TEST'] = true;
-}
-
-EOF;
-
-        $this->assertEquals(
-            $expects,
-            $this->loader->load(
-                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php',
-                PhpFileLoader::NAMESPACED
-            )
         );
     }
 }

--- a/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_declare.php
+++ b/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_declare.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * I am a declare(strict_types=1) comment
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+
+?>

--- a/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_declare2.php
+++ b/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_declare2.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types  =   1,ticks = 1);
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+
+?>

--- a/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_namespace.php
+++ b/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_namespace.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Foo\Bar;
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'DC_Table';
+
+?>


### PR DESCRIPTION
This is a follow-up PR on #730, which uses the tokenizer to handle everything (PHP tags, declare statements and namespaces).