### PR TITLE
Correct a symlink issue with Symfony 3.2.7

### DIFF
--- a/src/Util/SymlinkUtil.php
+++ b/src/Util/SymlinkUtil.php
@@ -38,7 +38,7 @@ class SymlinkUtil
         if ('\\' === DIRECTORY_SEPARATOR) {
             $fs->symlink($rootDir.'/'.$target, $rootDir.'/'.$link);
         } else {
-            $fs->symlink(rtrim($fs->makePathRelative($target, dirname($link)), '/'), $rootDir.'/'.$link);
+            $fs->symlink(rtrim($fs->makePathRelative($rootDir.'/'.$target, dirname($rootDir.'/'.$link)), '/'), $rootDir.'/'.$link);
         }
     }
 


### PR DESCRIPTION
Since Symfony 3.2.7, there is a change in makePathRelative method and symlink doesn't work on my host server.