### PR TITLE
do not force {{file::PATH}} insert tags to be uncached

### DIFF
--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -116,7 +116,7 @@ class InsertTags extends \Controller
 			// Skip certain elements if the output will be cached
 			if ($blnCache)
 			{
-				if ($elements[0] == 'date' || $elements[0] == 'ua' || $elements[0] == 'post' || ($elements[0] == 'file' && !\Validator::isStringUuid($elements[1])) || $elements[1] == 'back' || $elements[1] == 'referer' || $elements[0] == 'request_token' || $elements[0] == 'toggle_view' || strncmp($elements[0], 'cache_', 6) === 0 || in_array('uncached', $flags))
+				if ($elements[0] == 'date' || $elements[0] == 'ua' || $elements[0] == 'post' || $elements[1] == 'back' || $elements[1] == 'referer' || $elements[0] == 'request_token' || $elements[0] == 'toggle_view' || strncmp($elements[0], 'cache_', 6) === 0 || in_array('uncached', $flags))
 				{
 					/** @var FragmentHandler $fragmentHandler */
 					$fragmentHandler = \System::getContainer()->get('fragment.handler');


### PR DESCRIPTION
See https://github.com/contao/core-bundle/issues/731#issuecomment-295773166

@Toflar and I discussed this in IRC and we came to the conclusion, that this condition
```php
($elements[0] == 'file' && !\Validator::isStringUuid($elements[1]))
```
could simply be dropped from [InsertTags.php#L119](https://github.com/contao/core-bundle/blob/4.3.9/src/Resources/contao/library/Contao/InsertTags.php#L119) altogether.

This way the user/developer can decide himself, whether or not a `{{file::PATH}}` insert tag should be uncached or not.

Previous behaviour in Contao 3 was, that `{{file::UUID}}` and `{{file::PATH}}` insert tags are always forced to be uncached (see [InsertTags.php#L94](https://github.com/contao/core/blob/3.5.27/system/modules/core/library/Contao/InsertTags.php#L94)). This creates a problem in Contao 3 where users are integrating a PHP script via `{{file::PATH}}` and this script wants to access information that is not available when the page is generated from the page cache (e.g. page layout information or other page object information, that is not saved within the page cache file). See https://github.com/contao/core/issues/8658 for instance.

In Contao 4 this restriction was removed from `{{file::UUID}}` insert tags (now you can decide for yourself whether or not that insert tag should be uncached), but still remained for `{{file::PATH}}` insert tags.

By removing this condition the user/developer can now decide whether to use

* `{{file::PATH}}`

or 

* `{{file::PATH|uncached}}`