### PR TITLE
[RFC] Hide captcha field for users and add honeypot field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### DEV
 
+ * Hide the CAPTCHA field by default by adding a honypot field (see #832).
  * Add the "href" parameter to the article list (see #694).
  * Show both paths and UUIDs in the "show" view (see #793).
  * Do not romanize file names anymore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### DEV
 
- * Hide the CAPTCHA field by default by adding a honypot field (see #832).
+ * Hide the CAPTCHA field by default by adding a honeypot field (see #832).
  * Add the "href" parameter to the article list (see #694).
  * Show both paths and UUIDs in the "show" view (see #793).
  * Do not romanize file names anymore.

--- a/src/Resources/contao/forms/FormCaptcha.php
+++ b/src/Resources/contao/forms/FormCaptcha.php
@@ -136,7 +136,7 @@ class FormCaptcha extends \Widget
 
 		$arrCaptcha = $objSession->get('captcha_' . $this->strId);
 
-		if (!is_array($arrCaptcha) || !strlen($arrCaptcha['key']) || !strlen($arrCaptcha['sum']) || \Input::post($arrCaptcha['key']) != $arrCaptcha['sum'] || $arrCaptcha['time'] > (time() - 3))
+		if (!is_array($arrCaptcha) || !strlen($arrCaptcha['key']) || !strlen($arrCaptcha['sum']) || \Input::post($arrCaptcha['key']) != $arrCaptcha['sum'] || $arrCaptcha['time'] > (time() - 3) || \Input::post($arrCaptcha['key'].'_name'))
 		{
 			$this->class = 'error';
 			$this->addError($GLOBALS['TL_LANG']['ERR']['captcha']);
@@ -178,6 +178,22 @@ class FormCaptcha extends \Widget
 		}
 
 		return $strEncoded;
+	}
+
+
+	/**
+	 * Get the correct sum for the current session
+	 *
+	 * @return int The sum
+	 */
+	protected function getSum()
+	{
+		/** @var SessionInterface $objSession */
+		$objSession = \System::getContainer()->get('session');
+
+		$arrCaptcha = $objSession->get('captcha_' . $this->strId);
+
+		return $arrCaptcha['sum'];
 	}
 
 

--- a/src/Resources/contao/templates/forms/form_captcha.html5
+++ b/src/Resources/contao/templates/forms/form_captcha.html5
@@ -17,7 +17,7 @@
   <span class="captcha_text<?php if ($this->class) echo ' ' . $this->class; ?>"><?= $this->getQuestion() ?></span>
 
   <?php if (!$this->hasErrors()): ?>
-    <div style="display: none;">
+    <div style="display:none">
       <label for="ctrl_<?= $this->id ?>_hp">Do not fill out this field</label>
       <input type="text" name="<?= $this->name ?>_name" id="ctrl_<?= $this->id ?>_hp" value="">
     </div>

--- a/src/Resources/contao/templates/forms/form_captcha.html5
+++ b/src/Resources/contao/templates/forms/form_captcha.html5
@@ -15,4 +15,16 @@
 
   <input type="text" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="captcha mandatory<?php if ($this->class) echo ' ' . $this->class; ?>" value=""<?= $this->getAttributes() ?>>
   <span class="captcha_text<?php if ($this->class) echo ' ' . $this->class; ?>"><?= $this->getQuestion() ?></span>
+
+  <?php if (!$this->hasErrors()): ?>
+    <div style="display: none;">
+      <label for="ctrl_<?= $this->id ?>_hp">Do not fill out this field</label>
+      <input type="text" name="<?= $this->name ?>_name" id="ctrl_<?= $this->id ?>_hp" value="">
+    </div>
+    <script>
+      document.getElementById('ctrl_<?= $this->id ?>').parentNode.style.display = 'none';
+      document.getElementById('ctrl_<?= $this->id ?>').value = '<?= $this->getSum() ?>';
+    </script>
+  <?php endif ?>
+
 <?php $this->endblock(); ?>


### PR DESCRIPTION
With these changes we would achieve the following:

1. Normal users won’t see the captcha field and can just submit the form.
2. If a user is detected as a spam bot, they can still send the form by answering the captcha question.
3. Bots that don’t support JS, or that can’t resist the honeypot cannot send the form.