### PR TITLE
set table and sorting parameter for eliminateNestedPages

### DIFF
--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -3522,12 +3522,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					}
 
 					$arrFound = $arrRoot;
-					$this->root = $this->eliminateNestedPages($arrFound);
+					$this->root = $this->eliminateNestedPages($arrFound, $table, $blnHasSorting);
 				}
 				else
 				{
 					$arrFound = $objRoot->fetchEach($fld);
-					$this->root = $this->eliminateNestedPages($arrFound);
+					$this->root = $this->eliminateNestedPages($arrFound, $table, $blnHasSorting);
 				}
 			}
 		}


### PR DESCRIPTION
`\Controller::eliminateNestedPages` is used in two new places, but without the (optional) parameters `$strTable` and `$blnSorting`. Without the former, the default table will be `tl_page`. However, this makes no sense if the table of the current DCA is something else. This will artificially limit the number of table records to be shown, depending on the IDs of your current root pages.

And due to the missing third parameter it will also display the records in the wrong order, since the sorting is omitted.

See https://github.com/codefog/contao-news_categories/issues/106 for example.