### PR TITLE
BC compat for tl_content::pagePicker

### DIFF
--- a/src/Resources/contao/classes/Backend.php
+++ b/src/Resources/contao/classes/Backend.php
@@ -1099,9 +1099,9 @@ abstract class Backend extends \Controller
 			$params['context'] = $config['context'];
 		}
 
-		return ' <a href="' . ampersand(System::getContainer()->get('router')->generate('contao_backend_picker', $params)) . '" title="' . \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $field . '">' . \Image::getHtml((is_array($config) && isset($config['icon']) ? $config['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
+		return ' <a href="' . ampersand(System::getContainer()->get('router')->generate('contao_backend_picker', $params)) . '" title="' . \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $inputName . '">' . \Image::getHtml((is_array($config) && isset($config['icon']) ? $config['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
   <script>
-    $("pp_' . $field . '").addEvent("click", function(e) {
+    $("pp_' . $inputName . '").addEvent("click", function(e) {
       e.preventDefault();
       Backend.openModalSelector({
         "title": "' . \StringUtil::specialchars(str_replace("'", "\\'", $GLOBALS['TL_DCA'][$table]['fields'][$field]['label'][0])) . '",

--- a/src/Resources/contao/classes/Backend.php
+++ b/src/Resources/contao/classes/Backend.php
@@ -1069,6 +1069,59 @@ abstract class Backend extends \Controller
 
 
 	/**
+	 * Generates wizard HTML for the dca picker.
+	 *
+	 * @param bool|array $config
+	 * @param string     $table
+	 * @param string     $field
+	 * @param int        $id
+	 * @param string     $value
+	 * @param string     $inputName
+	 *
+	 * @return string
+	 */
+	public static function getDcaPickerWizard($config, $table, $field, $id, $value, $inputName)
+	{
+		$params = array();
+
+		if (is_array($config) && isset($config['do']))
+		{
+			$params['do'] = $config['do'];
+		}
+
+		$params['context'] = 'link';
+		$params['target'] = $table.'.'.$field.'.'.$id;
+		$params['value'] = $value;
+		$params['popup'] = 1;
+
+		if (is_array($config) && isset($config['context']))
+		{
+			$params['context'] = $config['context'];
+		}
+
+		return ' <a href="' . ampersand(System::getContainer()->get('router')->generate('contao_backend_picker', $params)) . '" title="' . \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $field . '">' . \Image::getHtml((is_array($config) && isset($config['icon']) ? $config['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
+  <script>
+    $("pp_' . $field . '").addEvent("click", function(e) {
+      e.preventDefault();
+      Backend.openModalSelector({
+        "title": "' . \StringUtil::specialchars(str_replace("'", "\\'", $GLOBALS['TL_DCA'][$table]['fields'][$field]['label'][0])) . '",
+        "url": this.href,
+        "callback": function(table, value) {
+          new Request.Contao({
+            evalScripts: false,
+            onSuccess: function(txt, json) {
+              $("ctrl_' . $inputName . '").value = (json.tag || json.content);
+              this.set("href", this.get("href").replace(/&value=[^&]*/, "&value=" + (json.tag || json.content)));
+            }.bind(this)
+          }).post({"action":"processPickerSelection", "table":table, "value":value.join(","), "REQUEST_TOKEN":"' . REQUEST_TOKEN . '"});
+        }.bind(this)
+      });
+    });
+  </script>';
+	}
+
+
+	/**
 	 * Add the custom layout section references
 	 */
 	public function addCustomLayoutSectionReferences()

--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -488,7 +488,7 @@ abstract class DataContainer extends \Backend
 		// DCA picker
 		if (isset($arrData['eval']['dcaPicker']) && (is_array($arrData['eval']['dcaPicker']) || $arrData['eval']['dcaPicker'] === true))
 		{
-			$wizard .= $this->getDcaPickerWizard($arrData['eval']['dcaPicker']);
+			$wizard .= \Backend::getDcaPickerWizard($arrData['eval']['dcaPicker'], $this->strTable, $this->strField, $this->intId, $this->varValue, $this->strInputName);
 		}
 
 		// Add a custom wizard
@@ -498,13 +498,6 @@ abstract class DataContainer extends \Backend
 			{
 				if (is_array($callback))
 				{
-					if ($callback[0] === 'tl_content' && $callback[1] === 'pagePicker')
-					{
-						trigger_error('The tl_content::pagePicker methods was removed, use the dcaPicker eval attribute instead.', E_USER_DEPRECATED);
-						$wizard .= $this->getDcaPickerWizard(true);
-						continue;
-					}
-
 					$this->import($callback[0]);
 					$wizard .= $this->{$callback[0]}->{$callback[1]}($this);
 				}
@@ -1047,51 +1040,4 @@ abstract class DataContainer extends \Backend
 	 * @throws \Exception
 	 */
 	abstract protected function save($varValue);
-
-	/**
-	 * Generates wizard HTML for the dca picker.
-	 *
-	 * @param bool|array $value
-	 *
-	 * @return string
-	 */
-	private function getDcaPickerWizard($value)
-	{
-		$params = array();
-
-		if (is_array($value) && isset($value['do']))
-		{
-			$params['do'] = $value['do'];
-		}
-
-		$params['context'] = 'link';
-		$params['target'] = $this->strTable.'.'.$this->strField.'.'.$this->intId;
-		$params['value'] = $this->varValue;
-		$params['popup'] = 1;
-
-		if (is_array($value) && isset($value['context']))
-		{
-			$params['context'] = $value['context'];
-		}
-
-		return ' <a href="' . ampersand(System::getContainer()->get('router')->generate('contao_backend_picker', $params)) . '" title="' . \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $this->strField . '">' . \Image::getHtml((is_array($value) && isset($value['icon']) ? $value['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
-  <script>
-    $("pp_' . $this->strField . '").addEvent("click", function(e) {
-      e.preventDefault();
-      Backend.openModalSelector({
-        "title": "' . \StringUtil::specialchars(str_replace("'", "\\'", $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][0])) . '",
-        "url": this.href,
-        "callback": function(table, value) {
-          new Request.Contao({
-            evalScripts: false,
-            onSuccess: function(txt, json) {
-              $("ctrl_' . $this->strInputName . '").value = (json.tag || json.content);
-              this.set("href", this.get("href").replace(/&value=[^&]*/, "&value=" + (json.tag || json.content)));
-            }.bind(this)
-          }).post({"action":"processPickerSelection", "table":table, "value":value.join(","), "REQUEST_TOKEN":"' . REQUEST_TOKEN . '"});
-        }.bind(this)
-      });
-    });
-  </script>';
-	}
 }

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -1601,6 +1601,23 @@ class tl_content extends Backend
 
 
 	/**
+	 * Return the link picker wizard
+	 *
+	 * @param DataContainer $dc
+	 *
+	 * @return string
+	 *
+	 * @deprecated Deprecated since Contao 4.4. Use the dcaPicker eval attribute instead.
+	 */
+	public function pagePicker(DataContainer $dc)
+	{
+		trigger_error('The '.__METHOD__.' is deprecated since Contao 4.4, use the dcaPicker eval attribute instead.', E_USER_DEPRECATED);
+
+		return \Backend::getDcaPickerWizard(true, $dc->table, $dc->field, $dc->id, $dc->value, $dc->inputName);
+	}
+
+
+	/**
 	 * Return the delete content element button
 	 *
 	 * @param array  $row


### PR DESCRIPTION
The `tl_content::pagePicker` method is used by any extension that wanted to add a page picker before Contao 4.4. I know `tl_content` is not a BC layer, but we sure should try to prevent such issues if we can…