### PR TITLE
[WIP] Fix CORS detection

### DIFF
--- a/src/Cors/WebsiteRootsConfigProvider.php
+++ b/src/Cors/WebsiteRootsConfigProvider.php
@@ -69,7 +69,7 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      */
     private function isCors(Request $request)
     {
-        return $request->headers->has('Origin') && $request->headers->get('Origin') != $request->getSchemeAndHttpHost();
+        return $request->headers->has('Origin') && $request->headers->get('Origin') !== $request->getSchemeAndHttpHost();
     }
 
     /**

--- a/src/Cors/WebsiteRootsConfigProvider.php
+++ b/src/Cors/WebsiteRootsConfigProvider.php
@@ -41,7 +41,7 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      */
     public function getOptions(Request $request)
     {
-        if (!$this->isCors($request) || !$this->canRunDbQuery()) {
+        if (!$this->isCorsRequest($request) || !$this->canRunDbQuery()) {
             return [];
         }
 
@@ -67,9 +67,11 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      *
      * @return bool
      */
-    private function isCors(Request $request)
+    private function isCorsRequest(Request $request)
     {
-        return $request->headers->has('Origin') && $request->headers->get('Origin') !== $request->getSchemeAndHttpHost();
+        return $request->headers->has('Origin')
+            && $request->headers->get('Origin') !== $request->getSchemeAndHttpHost()
+        ;
     }
 
     /**

--- a/src/Cors/WebsiteRootsConfigProvider.php
+++ b/src/Cors/WebsiteRootsConfigProvider.php
@@ -41,7 +41,7 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      */
     public function getOptions(Request $request)
     {
-        if (!$this->hasOrigin($request) || !$this->canRunDbQuery()) {
+        if (!$this->isCors($request) || !$this->canRunDbQuery()) {
             return [];
         }
 
@@ -67,9 +67,9 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      *
      * @return bool
      */
-    private function hasOrigin(Request $request)
+    private function isCors(Request $request)
     {
-        return $request->headers->has('Origin') && '' !== $request->headers->get('Origin');
+        return $request->headers->has('Origin') && $request->headers->get('Origin') != $request->getSchemeAndHttpHost();
     }
 
     /**

--- a/tests/Cors/WebsiteRootsConfigProviderTest.php
+++ b/tests/Cors/WebsiteRootsConfigProviderTest.php
@@ -118,12 +118,12 @@ class WebsiteRootsConfigProviderTest extends TestCase
     }
 
     /**
-     * Tests that no configuration is provided if the origin is empty.
+     * Tests that no configuration is provided if the origin equals the host.
      */
-    public function testNoConfigProvidedIfOriginEmpty()
+    public function testNoConfigProvidedIfOriginEqualsHost()
     {
         $request = Request::create('https://foobar.com');
-        $request->headers->set('Origin', '');
+        $request->headers->set('Origin', 'https://foobar.com');
 
         $connection = $this->createMock(Connection::class);
 


### PR DESCRIPTION
Fix for https://github.com/contao/installation-bundle/issues/56, see [explanation](https://github.com/contao/installation-bundle/issues/56#issuecomment-309824158).

This PR changes the CORS detection to the same methodology as used in [nelmio/NelmioCorsBundle/EventListener/CorsListener.php#L68](https://github.com/nelmio/NelmioCorsBundle/blob/1.5.3/EventListener/CorsListener.php#L68).

This way the Install Tool works in browsers like Chrome and Safari as well (who set the `Origin` header on `POST` requests).