### PR TITLE
Fix install tool displaying "incomplete installation" exception

### DIFF
--- a/src/Cors/WebsiteRootsConfigProvider.php
+++ b/src/Cors/WebsiteRootsConfigProvider.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\Cors;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Nelmio\CorsBundle\Options\ProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -79,6 +80,10 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      */
     private function canRunDbQuery()
     {
-        return $this->connection->isConnected() && $this->connection->getSchemaManager()->tablesExist(['tl_page']);
+        try {
+            return $this->connection->isConnected() && $this->connection->getSchemaManager()->tablesExist(['tl_page']);
+        } catch (ConnectionException $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Due to your MySQL server setup (e.g. allow anonymous connection), the existing check was successful but the call to `tableExists` results in an exception.