### PR TITLE
Add new MS Office formats

### DIFF
--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -288,7 +288,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_form_field']['extensions'],
 			'exclude'                 => true,
-			'default'                 => 'jpg,jpeg,gif,png,pdf,doc,xls,ppt',
+			'default'                 => 'jpg,jpeg,gif,png,pdf,doc,docx,xls,xlsx,ppt,pptx',
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'extnd', 'maxlength'=>255, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"


### PR DESCRIPTION
Imho the default value for `tl_form_field.extensions` should also contain the new MS Office formats, similar to [config/default.php#L62-L68](https://github.com/contao/core-bundle/blob/4.4.0/src/Resources/contao/config/default.php#L62-L68)