### PR TITLE
Use signed URLs instead of DcaFilterInterface to forward DCA configuration

### DIFF
--- a/src/DataContainer/DcaFilterInterface.php
+++ b/src/DataContainer/DcaFilterInterface.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\DataContainer;
  * DCA filter interface.
  *
  * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @deprecated Deprecated since Contao 4.4.1, to be removed in Contao 5.
  */
 interface DcaFilterInterface
 {

--- a/src/Menu/PagePickerProvider.php
+++ b/src/Menu/PagePickerProvider.php
@@ -62,6 +62,10 @@ class PagePickerProvider extends AbstractMenuProvider implements PickerMenuProvi
      */
     public function canHandle(Request $request)
     {
+        if ($request->query->get('context') === 'page') {
+            return true;
+        }
+
         return $request->query->has('value') && false !== strpos($request->query->get('value'), '{{link_url::');
     }
 
@@ -75,5 +79,21 @@ class PagePickerProvider extends AbstractMenuProvider implements PickerMenuProvi
         $params['value'] = str_replace(['{{link_url::', '}}'], '', $params['value']);
 
         return $this->route('contao_backend', $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getParametersFromRequest(Request $request)
+    {
+        $params = parent::getParametersFromRequest($request);
+
+        foreach (['rootNodes'] as $key) {
+            if ($request->query->has($key)) {
+                $params[$key] = $request->query->get($key);
+            }
+        }
+
+        return $params;
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -149,6 +149,7 @@ services:
             - "@router"
             - "@request_stack"
             - "@security.token_storage"
+            - "@uri_signer"
         tags:
             - { name: contao.picker_menu_provider, priority: 192 }
 
@@ -160,6 +161,7 @@ services:
             - "@request_stack"
             - "@security.token_storage"
             - "%contao.upload_path%"
+            - "@uri_signer"
         tags:
             - { name: contao.picker_menu_provider, priority: 160 }
 

--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\DataContainer\DcaFilterInterface;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\Image\ResizeConfiguration;
@@ -901,28 +900,13 @@ abstract class DataContainer extends \Backend
 			return false;
 		}
 
+		if (\System::getContainer()->get('uri_signer')->check(\Environment::get('uri')))
+		{
+			$this->strPickerFieldType = \Input::get('fieldType');
+		}
+
 		list($this->strPickerTable, $this->strPickerField, $this->intPickerId) = explode('.', \Input::get('target'), 3);
 		$this->intPickerId = (int) $this->intPickerId;
-
-		\Controller::loadDataContainer($this->strPickerTable);
-
-		if (!isset($GLOBALS['TL_DCA'][$this->strPickerTable]['fields'][$this->strPickerField]))
-		{
-			throw new InternalServerErrorException('Target field "' . $this->strPickerTable . '.' . $this->strPickerField . '" does not exist.');
-		}
-
-		$this->setPickerValue();
-
-		/** @var Widget $strClass */
-		$strClass = $GLOBALS['BE_FFL'][$GLOBALS['TL_DCA'][$this->strPickerTable]['fields'][$this->strPickerField]['inputType']];
-
-		if (is_a($strClass, DcaFilterInterface::class, true))
-		{
-			/** @var DcaFilterInterface $objWidget */
-			$objWidget = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$this->strPickerTable]['fields'][$this->strPickerField], $this->strPickerField, $this->arrPickerValue, $this->strPickerField, $this->strPickerTable));
-
-			$this->setDcaFilter($objWidget->getDcaFilter());
-		}
 
 		return true;
 	}
@@ -948,25 +932,6 @@ abstract class DataContainer extends \Backend
 		}
 
 		$this->arrPickerValue = $varValue;
-	}
-
-
-	/**
-	 * Set the DCA filter
-	 *
-	 * @param array $arrFilter
-	 */
-	protected function setDcaFilter($arrFilter)
-	{
-		if (isset($arrFilter['root']))
-		{
-			$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] = $arrFilter['root'];
-		}
-
-		if (isset($arrFilter['fieldType']))
-		{
-			$this->strPickerFieldType = $arrFilter['fieldType'];
-		}
 	}
 
 

--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -3042,34 +3042,32 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 
 
 	/**
-	 * Set the DCA filter
-	 *
-	 * @param array $arrFilter
+	 * {@inheritdoc}
 	 */
-	protected function setDcaFilter($arrFilter)
+	protected function initPicker()
 	{
-		parent::setDcaFilter($arrFilter);
-
-		$blnHideFiles = !isset($arrFilter['files']) && !isset($arrFilter['filesOnly']);
-
-		if (isset($arrFilter['files']) && $arrFilter['files'] === false)
+		if (parent::initPicker() && \System::getContainer()->get('uri_signer')->check(\Environment::get('uri')))
 		{
-			$blnHideFiles = true;
-		}
+			$blnHideFiles = !isset($_GET['files']) && !isset($_GET['filesOnly']);
 
-		$this->blnHideFiles = $blnHideFiles;
+			if (isset($_GET['files']) && \Input::get('files') !== '1')
+			{
+				$blnHideFiles = true;
+			}
 
-		if (!isset($arrFilter['filesOnly']) || $arrFilter['filesOnly'] === false)
-		{
-			$this->blnSelectFolders = true;
-		}
+			$this->blnHideFiles = $blnHideFiles;
 
-		if (isset($arrFilter['extensions']))
-		{
-			$this->arrValidFileTypes = \StringUtil::trimsplit(',', strtolower($arrFilter['extensions']));
+			if (!isset($_GET['filesOnly']) || !\Input::get('filesOnly'))
+			{
+				$this->blnSelectFolders = true;
+			}
+
+			if (isset($_GET['extensions']))
+			{
+				$this->arrValidFileTypes = \StringUtil::trimsplit(',', strtolower(Input::get('extensions')));
+			}
 		}
 	}
-
 
 	/**
 	 * Set the picker value

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -6123,4 +6123,37 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 		return $group;
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function initPicker()
+	{
+		if (parent::initPicker() && \System::getContainer()->get('uri_signer')->check(\Environment::get('uri')))
+		{
+			// Predefined node set (see #3563)
+			if (isset($_GET['rootNodes']))
+			{
+				$arrRoot = explode(',', \Input::get('rootNodes'));
+
+				// Allow only those roots that are allowed in root nodes
+				if (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']))
+				{
+					$root = array_intersect($arrRoot, $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']);
+
+					if (empty($root))
+					{
+						$root = $arrRoot;
+						$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['breadcrumb'] = ''; // hide the breadcrumb menu
+					}
+
+					$arrFilters['root'] = $this->eliminateNestedPages($root);
+				}
+				else
+				{
+					$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] = $arrRoot;
+				}
+			}
+		}
+	}
 }

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -6132,10 +6132,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		if (parent::initPicker() && \System::getContainer()->get('uri_signer')->check(\Environment::get('uri')))
 		{
 			// Predefined node set (see #3563)
-			if (isset($_GET['rootNodes']))
+			if (isset($_GET['rootNodes']) && is_array($arrRoot = \Input::get('rootNodes')))
 			{
-				$arrRoot = explode(',', \Input::get('rootNodes'));
-
 				// Allow only those roots that are allowed in root nodes
 				if (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']))
 				{

--- a/src/Resources/contao/widgets/FileTree.php
+++ b/src/Resources/contao/widgets/FileTree.php
@@ -10,7 +10,7 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\DataContainer\DcaFilterInterface;
+use Symfony\Component\Routing\Router;
 
 
 /**
@@ -28,7 +28,7 @@ use Contao\CoreBundle\DataContainer\DcaFilterInterface;
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
-class FileTree extends \Widget implements DcaFilterInterface
+class FileTree extends \Widget
 {
 
 	/**
@@ -391,6 +391,31 @@ class FileTree extends \Widget implements DcaFilterInterface
 			}
 		}
 
+		$params = array('do'=>'files', 'context'=>'file', 'target'=>$this->strTable.'.'.$this->strField.'.'.$this->activeRecord->id, 'value'=>implode(',', array_keys($arrSet)), 'popup'=>1, 'fieldType'=>$this->fieldType);
+
+		if ($this->files)
+		{
+			$params['files'] = (bool) $this->files;
+		}
+
+		if ($this->filesOnly)
+		{
+			$params['filesOnly'] = (bool) $this->filesOnly;
+		}
+
+		if ($this->path)
+		{
+			$params['path'] = (string) $this->path;
+		}
+
+		if ($this->extensions)
+		{
+			$params['extensions'] = (string) $this->extensions;
+		}
+
+		$uri = \System::getContainer()->get('router')->generate('contao_backend_picker', $params, Router::ABSOLUTE_URL);
+		$uri = \System::getContainer()->get('uri_signer')->sign($uri);
+
 		// Convert the binary UUIDs
 		$strSet = implode(',', array_map('StringUtil::binToUuid', $arrSet));
 		$strOrder = $blnHasOrder ? implode(',', array_map('StringUtil::binToUuid', $this->{$this->orderField})) : '';
@@ -407,7 +432,7 @@ class FileTree extends \Widget implements DcaFilterInterface
 		}
 
 		$return .= '</ul>
-    <p><a href="' . ampersand(\System::getContainer()->get('router')->generate('contao_backend_picker', array('do'=>'files', 'context'=>'file', 'target'=>$this->strTable.'.'.$this->strField.'.'.$this->activeRecord->id, 'value'=>implode(',', array_keys($arrSet)), 'popup'=>1))) . '" class="tl_submit" id="ft_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
+    <p><a href="' . ampersand($uri) . '" class="tl_submit" id="ft_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
     <script>
       $("ft_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();


### PR DESCRIPTION
As discussed

- removed use of DcaFilterInterface
- the Interface file still exists for BC reasons
- config for pageTree and fileTree widgets are supported, but for no other

I still want to discuss the `blnHideFiles` etc. props in DC_Folder. I think they're incorrectly implemented and the code was hard to adjust.