### PR TITLE
Allow to override the mailer configuration in Email class

### DIFF
--- a/src/Resources/contao/library/Contao/Email.php
+++ b/src/Resources/contao/library/Contao/Email.php
@@ -42,6 +42,12 @@ class Email
 {
 
 	/**
+	 * Mailer object
+	 * @var \Swift_Mailer
+	 */
+	protected $objMailer;
+
+	/**
 	 * Message object
 	 * @var \Swift_Message
 	 */
@@ -116,9 +122,12 @@ class Email
 
 	/**
 	 * Instantiate the object and load the mailer framework
+	 *
+	 * @param \Swift_Mailer|null $objMailer
 	 */
-	public function __construct()
+	public function __construct(\Swift_Mailer $objMailer = null)
 	{
+		$this->objMailer = $objMailer ?: \System::getContainer()->get('swiftmailer.mailer');
 		$this->strCharset = \Config::get('characterSet');
 
 		// Instantiate Swift_Message
@@ -459,7 +468,7 @@ class Email
 		$this->objMessage->setReturnPath($this->strSender);
 
 		// Send the e-mail
-		$intSent = \System::getContainer()->get('swiftmailer.mailer')->send($this->objMessage, $this->arrFailures);
+		$intSent = $this->objMailer->send($this->objMessage, $this->arrFailures);
 
 		// Log failures
 		if (!empty($this->arrFailures))


### PR DESCRIPTION
In Contao 3 it was possible to override the mailer configuration by replacing the global constants. We did such things in Notification Center (see #128).

In Contao 4 this no longer works because the container mailer is used. It should be possible to override this. Ideally, this could be merged as a bugfix because otherwise a few extensions will have issues to fix such bugs until the next minor 😶 