### PR TITLE
Fixed merge http headers listener not working with Symfony's request stack

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -29,7 +29,7 @@ class MergeHttpHeadersListener
     /**
      * @var array|null
      */
-    private $headers = null;
+    private $headers;
 
     /**
      * @var array
@@ -46,8 +46,7 @@ class MergeHttpHeadersListener
      * Constructor.
      *
      * @param ContaoFrameworkInterface $framework
-     * @param array                    $headers Do not pass this argument in your code;
-     *                                          It is meant for unit testing only.
+     * @param array                    $headers   Meant for unit testing only!
      */
     public function __construct(ContaoFrameworkInterface $framework, array $headers = null)
     {
@@ -151,7 +150,6 @@ class MergeHttpHeadersListener
     private function getHeaders()
     {
         if (null === $this->headers) {
-
             return headers_list();
         }
 

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -50,7 +50,6 @@ class MergeHttpHeadersListener
     public function __construct(ContaoFrameworkInterface $framework)
     {
         $this->framework = $framework;
-        $this->setHeaders(headers_list());
     }
 
     /**
@@ -60,6 +59,11 @@ class MergeHttpHeadersListener
      */
     public function getHeaders()
     {
+        if ([] === $this->headers) {
+
+            return headers_list();
+        }
+
         return $this->headers;
     }
 
@@ -67,6 +71,9 @@ class MergeHttpHeadersListener
      * Sets the headers.
      *
      * @param array $headers
+     *
+     * @internal Do not use this in userland code. This is for unit test purposes
+     *           only because mocking header_*() functions is tedious work.
      */
     public function setHeaders(array $headers)
     {

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -71,7 +71,7 @@ class MergeHttpHeadersListener
      *
      * @param array $headers
      *
-     * @internal Do not call this method in your code; it is meant for unit test only
+     * @internal Do not call this method in your code; it is meant for unit testing only
      */
     public function setHeaders(array $headers)
     {

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -27,9 +27,9 @@ class MergeHttpHeadersListener
     private $framework;
 
     /**
-     * @var array
+     * @var array|null
      */
-    private $headers = [];
+    private $headers = null;
 
     /**
      * @var array
@@ -46,35 +46,12 @@ class MergeHttpHeadersListener
      * Constructor.
      *
      * @param ContaoFrameworkInterface $framework
+     * @param array                    $headers Do not pass this argument in your code;
+     *                                          It is meant for unit testing only.
      */
-    public function __construct(ContaoFrameworkInterface $framework)
+    public function __construct(ContaoFrameworkInterface $framework, array $headers = null)
     {
         $this->framework = $framework;
-    }
-
-    /**
-     * Returns the headers.
-     *
-     * @return array
-     */
-    public function getHeaders()
-    {
-        if ([] === $this->headers) {
-            return headers_list();
-        }
-
-        return $this->headers;
-    }
-
-    /**
-     * Sets the headers.
-     *
-     * @param array $headers
-     *
-     * @internal Do not call this method in your code; it is meant for unit testing only
-     */
-    public function setHeaders(array $headers)
-    {
         $this->headers = $headers;
     }
 
@@ -164,6 +141,21 @@ class MergeHttpHeadersListener
         }
 
         return $response;
+    }
+
+    /**
+     * Returns the headers.
+     *
+     * @return array
+     */
+    private function getHeaders()
+    {
+        if (null === $this->headers) {
+
+            return headers_list();
+        }
+
+        return $this->headers;
     }
 
     /**

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -60,7 +60,6 @@ class MergeHttpHeadersListener
     public function getHeaders()
     {
         if ([] === $this->headers) {
-
             return headers_list();
         }
 
@@ -72,8 +71,7 @@ class MergeHttpHeadersListener
      *
      * @param array $headers
      *
-     * @internal Do not use this in userland code. This is for unit test purposes
-     *           only because mocking header_*() functions is tedious work.
+     * @internal Do not call this method in your code; it is meant for unit test only
      */
     public function setHeaders(array $headers)
     {

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -149,11 +149,7 @@ class MergeHttpHeadersListener
      */
     private function getHeaders()
     {
-        if (null === $this->headers) {
-            $this->headers = headers_list();
-        }
-
-        return $this->headers;
+        return $this->headers ?: headers_list();
     }
 
     /**

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -150,7 +150,7 @@ class MergeHttpHeadersListener
     private function getHeaders()
     {
         if (null === $this->headers) {
-            return headers_list();
+            $this->headers = headers_list();
         }
 
         return $this->headers;

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -56,8 +56,7 @@ class MergeHttpHeadersListenerTest extends TestCase
             ->willReturn(false)
         ;
 
-        $listener = new MergeHttpHeadersListener($framework);
-        $listener->setHeaders(['Content-Type: text/html']);
+        $listener = new MergeHttpHeadersListener($framework, ['Content-Type: text/html']);
         $listener->onKernelResponse($responseEvent);
 
         $this->assertFalse($responseEvent->getResponse()->headers->has('Content-Type'));
@@ -83,8 +82,7 @@ class MergeHttpHeadersListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $listener = new MergeHttpHeadersListener($framework);
-        $listener->setHeaders(['Content-Type: text/html']);
+        $listener = new MergeHttpHeadersListener($framework, ['Content-Type: text/html']);
         $listener->onKernelResponse($responseEvent);
 
         $response = $responseEvent->getResponse();
@@ -116,8 +114,7 @@ class MergeHttpHeadersListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $listener = new MergeHttpHeadersListener($framework);
-        $listener->setHeaders(['set-cookie: new-content=foobar']); // test a lower-case key here
+        $listener = new MergeHttpHeadersListener($framework, ['set-cookie: new-content=foobar']); // test a lower-case key here
         $listener->onKernelResponse($responseEvent);
 
         $response = $responseEvent->getResponse();

--- a/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -114,7 +114,7 @@ class MergeHttpHeadersListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $listener = new MergeHttpHeadersListener($framework, ['set-cookie: new-content=foobar']); // test a lower-case key here
+        $listener = new MergeHttpHeadersListener($framework, ['set-cookie: new-content=foobar']); // lower-case key
         $listener->onKernelResponse($responseEvent);
 
         $response = $responseEvent->getResponse();


### PR DESCRIPTION
After hours of debugging @aschempp and me finally found the issue for some redirect and cookie issues in Contao 4.4. They were introduced by using our header-replay-bundle but it was actually not the reason for the bug. The bug is that the listener instance is created once and we do not lazily fetch the headers using `headers_list()`. Now when you are using multiple request->response iterations within the same php process (which is one big advantage of Symfony and which was not noticed before because nobody did that apparently) the headers that are sent in between these iterations are ignored. We have to always fetch them lazily. 