### PR TITLE
add missing charset parameter for database config

### DIFF
--- a/src/Resources/contao/library/Contao/Database.php
+++ b/src/Resources/contao/library/Contao/Database.php
@@ -80,7 +80,8 @@ class Database
 				'port'      => $arrConfig['dbPort'],
 				'user'      => $arrConfig['dbUser'],
 				'password'  => $arrConfig['dbPass'],
-				'dbname'    => $arrConfig['dbDatabase']
+				'dbname'    => $arrConfig['dbDatabase'],
+				'charset'   => $arrConfig['dbCharset']
 			);
 
 			$this->resConnection = DriverManager::getConnection($arrParams);


### PR DESCRIPTION
I know the usage of `\Database::getInstance(array(…))` is deprecated - but in case anyone still uses this, they might run into the following issue:

In Contao 3 the character set of the database connection was defined via `$GLOBALS['TL_CONFIG']['dbCharset']`, (which defaults to `UTF8`, see [system/config/default.php#L140](https://github.com/contao/core/blob/3.5.28/system/config/default.php#L140); In Contao 4, the default doctrine database connection also defaults to `UTF8`, see [contao-manager/doctrine.yml#L20](https://github.com/contao/manager-bundle/blob/4.4.1/src/Resources/contao-manager/doctrine.yml#L20)).

However, the character set configuration is missing when using
```php
\Database::getInstance(array
(
	'dbHost' => '…',
	'dbPort' => '…',
	'dbUser' => '…',
	'dbPass' => '…',
	'dbDatabase' => '…'
));
```
Passing `'dbCharset' => 'UTF8'` will have no effect. Without providing the `charset` to doctrine, its default connection type will be defined by the MySQL server - and this might not be `UTF8` (or whatever you want).