### PR TITLE
Correctly handle root nodes for the dcaPicker

### DIFF
--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -6145,6 +6145,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			// Allow only those roots that are allowed in root nodes
 			if (!empty($this->root) && $arrRoot != $this->root)
 			{
+				$arrRoot = array_merge($arrRoot, $this->Database->getChildRecords($arrRoot, $this->strTable));
 				$arrRoot = array_intersect($arrRoot, array_merge($this->root, $this->Database->getChildRecords($this->root, $this->strTable)));
 				$arrRoot = $this->eliminateNestedPages($arrRoot);
 			}

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -6147,7 +6147,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				$arrRoot = array_merge($arrRoot, $this->Database->getChildRecords($arrRoot, $this->strTable));
 				$arrRoot = array_intersect($arrRoot, array_merge($this->root, $this->Database->getChildRecords($this->root, $this->strTable)));
-				$arrRoot = $this->eliminateNestedPages($arrRoot);
+				$arrRoot = $this->eliminateNestedPages(array_unique($arrRoot, SORT_NUMERIC));
 			}
 
 			$this->root = $arrRoot;


### PR DESCRIPTION
The handling of the rootNodes in the new dcaPicker is not working right for non admin backend users.
If the backend user is restricted to a page mounts and also a rootNode from a different level is defined as attribute for the picker, no pages will be shown at all.

Little example:

Let's say we have the following page structure
![rootnodes](https://user-images.githubusercontent.com/1402434/28958148-6e010fb6-78f5-11e7-808c-a967bcd59a19.jpg)

If the user is restricted to `ID 5` and a rootNode `ID 1` is set as an attribute for the picker no pages will be shown. That's because the `ID 1` is not a child of `ID 5`. 
The same happens when the attribute rootNode for the picker is also `ID 5`. Because the rootNode itself is not included for the array intersection.

So first the given rootNode(s) have to be added for the intersection. And secondly all the children have to be traversed down for the the rootNode attribute, too.


