### PR TITLE
[RTM] increase imageWidth/Height default

### DIFF
--- a/src/Resources/contao/config/default.php
+++ b/src/Resources/contao/config/default.php
@@ -67,8 +67,8 @@ $GLOBALS['TL_CONFIG']['uploadTypes']
 	. 'ttf,ttc,otf,eot,woff,woff2,'
 	. 'css,scss,less,js,html,htm,txt,zip,rar,7z,cto';
 $GLOBALS['TL_CONFIG']['maxFileSize']    = 2048000;
-$GLOBALS['TL_CONFIG']['imageWidth']     = 1280;
-$GLOBALS['TL_CONFIG']['imageHeight']    = 1280;
+$GLOBALS['TL_CONFIG']['imageWidth']     = 0;
+$GLOBALS['TL_CONFIG']['imageHeight']    = 0;
 $GLOBALS['TL_CONFIG']['gdMaxImgWidth']  = 3000;
 $GLOBALS['TL_CONFIG']['gdMaxImgHeight'] = 3000;
 

--- a/src/Resources/contao/config/default.php
+++ b/src/Resources/contao/config/default.php
@@ -67,8 +67,8 @@ $GLOBALS['TL_CONFIG']['uploadTypes']
 	. 'ttf,ttc,otf,eot,woff,woff2,'
 	. 'css,scss,less,js,html,htm,txt,zip,rar,7z,cto';
 $GLOBALS['TL_CONFIG']['maxFileSize']    = 2048000;
-$GLOBALS['TL_CONFIG']['imageWidth']     = 800;
-$GLOBALS['TL_CONFIG']['imageHeight']    = 600;
+$GLOBALS['TL_CONFIG']['imageWidth']     = 1280;
+$GLOBALS['TL_CONFIG']['imageHeight']    = 1280;
 $GLOBALS['TL_CONFIG']['gdMaxImgWidth']  = 3000;
 $GLOBALS['TL_CONFIG']['gdMaxImgHeight'] = 3000;
 


### PR DESCRIPTION
The old defaults for the `imageWidth` and `imageHeight` setting seem a bit low to me, especially in these modern times, with responsive images and high DPI display devices.

I recently forgot to change these values and now a customer needs to re-upload all pictures again, since they all got automatically downscaled to 800x600 -_-

Not sure what the new defaults should be though. 1280? 1680? 1920?