### PR TITLE
Cachecheck for uncombined scss files and adding TL_ASSETS_URL

### DIFF
--- a/src/Resources/contao/library/Contao/Combiner.php
+++ b/src/Resources/contao/library/Contao/Combiner.php
@@ -196,10 +196,17 @@ class Combiner extends \System
 	/**
 	 * Generates the files and returns the URLs.
 	 *
+	 * @param string $strUrl An optional URL to prepend
+	 *
 	 * @return array The file URLs
 	 */
-	public function getFileUrls()
+	public function getFileUrls($strUrl=null)
 	{
+		if ($strUrl === null)
+		{
+			$strUrl = TL_ASSETS_URL;
+		}
+		
 		$return = array();
 		$strTarget = substr($this->strMode, 1);
 
@@ -215,7 +222,7 @@ class Combiner extends \System
 				// Load the existing file
 				if (file_exists(TL_ROOT . '/' . $strPath))
 				{
-					$return[] = $strPath;
+					$return[] = $strUrl . $strPath;
 					continue;
 				}
 
@@ -223,7 +230,7 @@ class Combiner extends \System
 				$objFile->write($this->handleScssLess($content, $arrFile));
 				$objFile->close();
 
-				$return[] = $strPath;
+				$return[] = $strUrl . $strPath;
 			}
 			else
 			{
@@ -241,7 +248,7 @@ class Combiner extends \System
 					$name .= '" media="' . $arrFile['media'];
 				}
 
-				$return[] = $name;
+				$return[] = $strUrl . $name;
 			}
 		}
 

--- a/src/Resources/contao/library/Contao/Combiner.php
+++ b/src/Resources/contao/library/Contao/Combiner.php
@@ -212,6 +212,13 @@ class Combiner extends \System
 			{
 				$strPath = 'assets/' . $strTarget . '/' . str_replace('/', '_', $arrFile['name']) . $this->strMode;
 
+				// Load the existing file
+				if (file_exists(TL_ROOT . '/' . $strPath))
+				{
+					$return[] = $strPath;
+					continue;
+				}
+
 				$objFile = new \File($strPath);
 				$objFile->write($this->handleScssLess($content, $arrFile));
 				$objFile->close();


### PR DESCRIPTION
This PR is a solution for the problem mentioned in #987.

Before a combined scss (and css) file is generated, we look for an already existing cache file. Let's do the same for every single (not combined) scss file.

I also found another issue (IMO it's one). The TL_ASSETS_URL is only used when combining the asset files (css and js) and not when returning the single files. 