### PR TITLE
Do not merge HTTP headers upon header replay

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -13,6 +13,7 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Terminal42\HeaderReplay\EventListener\HeaderReplayListener;
 
 /**
  * Adds HTTP headers sent by Contao to the Symfony response.
@@ -111,7 +112,13 @@ class MergeHttpHeadersListener
             return;
         }
 
-        $event->setResponse($this->mergeHttpHeaders($event->getResponse()));
+        $response = $event->getResponse();
+
+        if (HeaderReplayListener::CONTENT_TYPE === $response->headers->get('Content-Type')) {
+            return;
+        }
+
+        $event->setResponse($this->mergeHttpHeaders($response));
     }
 
     /**


### PR DESCRIPTION
When replaying HTTP headers, the `kernel.response` event is triggered twice, first with the `application/vnd.t42.header-replay` content type and then with the `text/html` content type.

The problem is that the `MergeHttpListeners` class adds the HTTP headers to the first response and then unsets them, so the second response (the actual response) ends up with no merged headers. This prevents tools like Blackfire from working correctly, because the `X-Blackfire-Query` header is not present.