### PR TITLE
[RFC] Fetch file attributes only if file exists

### DIFF
--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -173,7 +173,7 @@ class File extends \System
 		{
 			case 'size':
 			case 'filesize':
-				return filesize(TL_ROOT . '/' . $this->strFile);
+				return ($this->exist) ? filesize(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'name':
@@ -227,15 +227,15 @@ class File extends \System
 				break;
 
 			case 'ctime':
-				return filectime(TL_ROOT . '/' . $this->strFile);
+				return ($this->exist) ? filectime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'mtime':
-				return filemtime(TL_ROOT . '/' . $this->strFile);
+				return ($this->exist) ? filemtime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'atime':
-				return fileatime(TL_ROOT . '/' . $this->strFile);
+				return ($this->exist) ? fileatime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'icon':

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -223,7 +223,7 @@ class File extends \System
 				break;
 
 			case 'hash':
-				return $this->getHash();
+				return ($this->exist) ? $this->getHash() : null;
 				break;
 
 			case 'ctime':

--- a/src/Resources/contao/library/Contao/File.php
+++ b/src/Resources/contao/library/Contao/File.php
@@ -173,7 +173,7 @@ class File extends \System
 		{
 			case 'size':
 			case 'filesize':
-				return ($this->exist) ? filesize(TL_ROOT . '/' . $this->strFile) : null;
+				return ($this->exists()) ? filesize(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'name':
@@ -223,19 +223,19 @@ class File extends \System
 				break;
 
 			case 'hash':
-				return ($this->exist) ? $this->getHash() : null;
+				return ($this->exists()) ? $this->getHash() : null;
 				break;
 
 			case 'ctime':
-				return ($this->exist) ? filectime(TL_ROOT . '/' . $this->strFile) : null;
+				return ($this->exists()) ? filectime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'mtime':
-				return ($this->exist) ? filemtime(TL_ROOT . '/' . $this->strFile) : null;
+				return ($this->exists()) ? filemtime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'atime':
-				return ($this->exist) ? fileatime(TL_ROOT . '/' . $this->strFile) : null;
+				return ($this->exists()) ? fileatime(TL_ROOT . '/' . $this->strFile) : null;
 				break;
 
 			case 'icon':


### PR DESCRIPTION
When creating a new file instance with 
```php
$file = new File('image.jpg')
``` 
and then calling 
```php
$file->get('mtime')
```
it will result in a **'ContextErrorException'** (HTTP 500 Internal Server Error in the FE) when trying to get `filemtime()` from a file that doesn't exist.

This PR adds a check to see if a file exist before it tries to fetch a file attribute.
