### PR TITLE
[RFC] Add the possibility to save hidden version data

### DIFF
--- a/src/Resources/contao/classes/Versions.php
+++ b/src/Resources/contao/classes/Versions.php
@@ -632,7 +632,7 @@ class Versions extends \Controller
 		$objDatabase = \Database::getInstance();
 
 		// Get the total number of versions
-		$objTotal = $objDatabase->prepare("SELECT COUNT(*) AS count FROM tl_version WHERE version>1" . (!$objUser->isAdmin ? " AND userid=?" : ""))
+		$objTotal = $objDatabase->prepare("SELECT COUNT(*) AS count FROM tl_version WHERE version>1 AND editUrl IS NOT NULL" . (!$objUser->isAdmin ? " AND userid=?" : ""))
 								->execute($objUser->id);
 
 		$intLast   = ceil($objTotal->count / 30);
@@ -650,7 +650,7 @@ class Versions extends \Controller
 		$objTemplate->pagination = $objPagination->generate();
 
 		// Get the versions
-		$objVersions = $objDatabase->prepare("SELECT pid, tstamp, version, fromTable, username, userid, description, editUrl, active FROM tl_version" . (!$objUser->isAdmin ? " WHERE userid=?" : "") . " ORDER BY tstamp DESC, pid, version DESC")
+		$objVersions = $objDatabase->prepare("SELECT pid, tstamp, version, fromTable, username, userid, description, editUrl, active FROM tl_version WHERE editUrl IS NOT NULL" . (!$objUser->isAdmin ? " AND userid=?" : "") . " ORDER BY tstamp DESC, pid, version DESC")
 								   ->limit(30, $intOffset)
 								   ->execute($objUser->id);
 


### PR DESCRIPTION
With this PR I want to add the possibility to save versions in the `tl_version` table, which are not directly editable and therefore should not be  shown on the welcome page.

This makes the version table useable for extensions to save versions for extra data.

As far as I understand, the editUrl is always saved when a new version is created. So I simply added an extra WHERE statement. Another solution would be to have an extra `hide` column.

**To give an example for a use case:**
I have an extension which saves extra data related (and edited) with content elements in an extra table. When the content element is saved, a version is created and I use the `oncreate_version_callback` to save a version for the extra data, too. But these are not directly editable and makes the 'Last changes' overview unreadable.