### PR TITLE
Catch general exceptions during route generation

### DIFF
--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -265,7 +265,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
         try {
             $route = $this->router->generate($attributes->get('_route'), $attributes->get('_route_params'));
-        } catch (\InvalidArgumentException $e) {
+        } catch (\Exception $e) {
             return null;
         }
 


### PR DESCRIPTION
When there is an exception (such as if a route does not exist at all) during route generation, our pretty error screen listener fails because the framework does not boot properly. Is there any reason why we only catch the - global - InvalidArgumentException here?