### PR TITLE
fixed GLOB_BRACE warning on alpine linux systems

### DIFF
--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -101,7 +101,7 @@ abstract class Controller extends \System
 		}
 
 		$strBrace = '{' . implode(',', \StringUtil::trimsplit(',', strtolower(\Config::get('templateFiles')))) . '}';
-		$arrCustomized = glob(TL_ROOT . '/templates/' . $strPrefix . '*.' . $strBrace, GLOB_BRACE);
+		$arrCustomized = glob(TL_ROOT . '/templates/' . $strPrefix . '*.' . $strBrace, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
 
 		// Add the customized templates
 		if (is_array($arrCustomized))
@@ -133,7 +133,7 @@ abstract class Controller extends \System
 				{
 					if ($objTheme->templates != '')
 					{
-						$arrThemeTemplates = glob(TL_ROOT . '/' . $objTheme->templates . '/' . $strPrefix . '*.' . $strBrace, GLOB_BRACE);
+						$arrThemeTemplates = glob(TL_ROOT . '/' . $objTheme->templates . '/' . $strPrefix . '*.' . $strBrace, defined('GLOB_BRACE') ? GLOB_BRACE : 0);
 
 						if (is_array($arrThemeTemplates))
 						{


### PR DESCRIPTION
"Note: The GLOB_BRACE flag is not available on some non GNU systems, like Solaris." <= php.net

Docker based alpine systems do not support "GLOB_BRACE". The simple fix is done with this merge request, so that apline linux systems can work nevertheless.

See
- http://php.net/manual/de/function.glob.php#refsect1-function.glob-notes
- https://symfony.com/blog/new-in-symfony-3-3-psr-4-based-service-discovery#comment-21379
- https://github.com/symfony/symfony/pull/21289/files#diff-ad1ed76aba6a80df5a48dfa4585adcf3R115