### PR TITLE
[RFC] Fix failing tests on Windows

### DIFF
--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -30,10 +30,12 @@ class InstallCommandTest extends TestCase
     public function setUp()
     {
         $tcpdfPath = $this->getRootDir().'/vendor/contao/core-bundle/src/Resources/contao/config/tcpdf.php';
+
         if (!file_exists($tcpdfPath)) {
             if (!file_exists(dirname($tcpdfPath))) {
                 mkdir(dirname($tcpdfPath), 0777, true);
             }
+
             file_put_contents($tcpdfPath, '');
         }
     }

--- a/tests/Command/InstallCommandTest.php
+++ b/tests/Command/InstallCommandTest.php
@@ -27,6 +27,20 @@ class InstallCommandTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    public function setUp()
+    {
+        $tcpdfPath = $this->getRootDir().'/vendor/contao/core-bundle/src/Resources/contao/config/tcpdf.php';
+        if (!file_exists($tcpdfPath)) {
+            if (!file_exists(dirname($tcpdfPath))) {
+                mkdir(dirname($tcpdfPath), 0777, true);
+            }
+            file_put_contents($tcpdfPath, '');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function tearDown()
     {
         $fs = new Filesystem();
@@ -44,6 +58,7 @@ class InstallCommandTest extends TestCase
         $fs->remove($this->getRootDir().'/templates');
         $fs->remove($this->getRootDir().'/web/share');
         $fs->remove($this->getRootDir().'/web/system');
+        $fs->remove($this->getRootDir().'/vendor/contao/core-bundle/src/Resources/contao/config/tcpdf.php');
     }
 
     /**

--- a/tests/Picker/FilePickerProviderTest.php
+++ b/tests/Picker/FilePickerProviderTest.php
@@ -324,9 +324,9 @@ class FilePickerProviderTest extends TestCase
             [
                 'fieldType' => 'radio',
                 'filesOnly' => true,
-                'value' => '/foobar',
+                'value' => 'foo/bar.jpg',
             ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '/foobar'))
+            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, 'foo/bar.jpg'))
         );
 
         $this->assertSame(
@@ -336,6 +336,15 @@ class FilePickerProviderTest extends TestCase
                 'value' => '/foobar',
             ],
             $this->provider->getDcaAttributes(new PickerConfig('link', [], '/foobar'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => 'foo/b%C3%A4r%20baz.jpg',
+            ],
+            $this->provider->getDcaAttributes(new PickerConfig('link', [], 'foo/bär baz.jpg'))
         );
     }
 

--- a/tests/Picker/FilePickerProviderTest.php
+++ b/tests/Picker/FilePickerProviderTest.php
@@ -324,9 +324,9 @@ class FilePickerProviderTest extends TestCase
             [
                 'fieldType' => 'radio',
                 'filesOnly' => true,
-                'value' => __DIR__.'/foobar',
+                'value' => '/foobar',
             ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, __DIR__.'/foobar'))
+            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '/foobar'))
         );
 
         $this->assertSame(


### PR DESCRIPTION
See #1061 

@aschempp Is my change in *FilePickerProviderTest.php* correct? I think the `PickerConfig` only handles relative paths, not absolute ones.