### PR TITLE
[RTM] Translator

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -283,8 +283,10 @@ services:
 
     contao.translation.translator:
         class: Contao\CoreBundle\Translation\Translator
+        decorates: translator
         arguments:
-            - "@translator"
+            - "@contao.translation.translator.inner"
+            - "@contao.framework"
 
     contao.twig.template_extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -281,6 +281,11 @@ services:
         calls:
             - ["setName", ["contao_frontend"]]
 
+    contao.translation.translator:
+        class: Contao\CoreBundle\Translation\Translator
+        arguments:
+            - "@translator"
+
     contao.twig.template_extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension
         public: false

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -49,12 +49,9 @@ class Translator implements TranslatorInterface
             return $this->translator->trans($id, $parameters, $domain, $locale);
         }
 
-        if (!$this->framework->isInitialized()) {
-            return $id;
-        }
-
         $domain = substr($domain, 7);
 
+        $this->framework->initialize();
         $this->loadLanguageFile($domain);
 
         $translated = $this->getFromGlobals($id, $domain);

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -43,6 +43,10 @@ class Translator implements TranslatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array
+     * if the message domain starts with "contao_".
+     * The locale parameter is ignored in this case.
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
@@ -70,6 +74,8 @@ class Translator implements TranslatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
@@ -78,6 +84,8 @@ class Translator implements TranslatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function setLocale($locale)
     {
@@ -86,6 +94,8 @@ class Translator implements TranslatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function getLocale()
     {

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -106,8 +106,10 @@ class Translator implements TranslatorInterface
             $id = $domain.'.'.$id;
         }
 
-        preg_match_all('/(?:\\\\.|[^.])+/s', $id, $matches);
-        $parts = preg_replace('/\\\\(.)/s', '$1', $matches[0]);
+        // Split the ID into chunks separated by dots,
+        // escaped dots (\.) and backslashes (\\) are allowed.
+        preg_match_all('/(?:\\\\[.\\\\]|[^.])++/s', $id, $matches);
+        $parts = preg_replace('/\\\\([.\\\\])/s', '$1', $matches[0]);
 
         $item = &$GLOBALS['TL_LANG'];
 

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\Translation;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\System;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -127,8 +128,8 @@ class Translator implements TranslatorInterface
      */
     private function loadLanguageFile(string $name)
     {
-        /** @var \Contao\System */
-        $system = $this->framework->getAdapter('System');
+        /** @var System */
+        $system = $this->framework->getAdapter(System::class);
 
         $system->loadLanguageFile($name);
     }

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Translation;
+
+use Contao\CoreBundle\Framework\FrameworkAwareInterface;
+use Contao\CoreBundle\Framework\FrameworkAwareTrait;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Translator.
+ *
+ * @author Martin Auswöger <martin@auswoeger.com>
+ */
+class Translator implements TranslatorInterface, FrameworkAwareInterface
+{
+    use FrameworkAwareTrait;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator original translator service that gets decorated
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        $translated = $this->translator->trans($id, $parameters, $domain, $locale);
+
+        if ($translated !== $id) {
+            return $translated;
+        }
+
+        if (!$this->framework->isInitialized()) {
+            return $translated;
+        }
+
+        $this->loadLanguageFile($domain);
+
+        if (null !== $translated = $this->getFromGlobals($id, $domain)) {
+            return $translated;
+        }
+
+        return $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    {
+        return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+        return $this->translator->setLocale($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->translator->getLocale();
+    }
+
+    /**
+     * Get the translation from the $GLOBALS['TL_LANG'] array.
+     *
+     * @param string      $id     Message id, e.g. "MSC.view"
+     * @param string|null $domain Message domain, e.g. "messages" or "tl_content"
+     *
+     * @return string|null
+     */
+    private function getFromGlobals(string $id, string $domain = null)
+    {
+        if ('messages' !== $domain && null !== $domain) {
+            $id = $domain.'.'.$id;
+        }
+
+        preg_match_all('/(?:\\\\.|[^.])+/s', $id, $matches);
+        $parts = preg_replace('/\\\\(.)/s', '$1', $matches[0]);
+
+        $item = &$GLOBALS['TL_LANG'];
+
+        foreach ($parts as $part) {
+            if (!isset($item[$part])) {
+                return null;
+            }
+            $item = &$item[$part];
+        }
+
+        return $item;
+    }
+
+    /**
+     * Load a Contao framework language file.
+     *
+     * @param string $name
+     */
+    private function loadLanguageFile(string $name = null)
+    {
+        if ('messages' === $name || null === $name) {
+            $name = 'default';
+        }
+
+        /** @var \Contao\System */
+        $system = $this->framework->getAdapter('System');
+
+        $system->loadLanguageFile($name);
+    }
+}

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -58,6 +58,15 @@ class Translator implements TranslatorInterface
         $this->loadLanguageFile($domain);
 
         if (null !== $translated = $this->getFromGlobals($id, $domain)) {
+
+            if (isset($parameters["%0%"])) {
+                $values = [];
+                for ($i = 0; isset($parameters["%$i%"]); $i++) {
+                    $values[] = $parameters["%$i%"];
+                }
+                $translated = vsprintf($translated, $values);
+            }
+
             return $translated;
         }
 
@@ -120,7 +129,7 @@ class Translator implements TranslatorInterface
     /**
      * Load a Contao framework language file.
      *
-     * @param string $name
+     * @param string|null $name
      */
     private function loadLanguageFile(string $name = null)
     {

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -32,7 +32,7 @@ class Translator implements TranslatorInterface
     private $framework;
 
     /**
-     * @param TranslatorInterface      $translator Original translator service that gets decorated
+     * @param TranslatorInterface      $translator The translator to decorate
      * @param ContaoFrameworkInterface $framework
      */
     public function __construct(TranslatorInterface $translator, ContaoFrameworkInterface $framework)
@@ -44,12 +44,12 @@ class Translator implements TranslatorInterface
     /**
      * {@inheritdoc}
      *
-     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array
-     * if the message domain starts with "contao_".
-     * The locale parameter is ignored in this case.
+     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message domain starts with
+     * "contao_". The locale parameter is ignored in this case.
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
+        // Forward to the default translator
         if (null === $domain || strncmp($domain, 'contao_', 7) !== 0) {
             return $this->translator->trans($id, $parameters, $domain, $locale);
         }
@@ -74,36 +74,33 @@ class Translator implements TranslatorInterface
 
     /**
      * {@inheritdoc}
-     *
-     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
+        // Forward to the default translator
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }
 
     /**
      * {@inheritdoc}
-     *
-     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function setLocale($locale)
     {
+        // Forward to the default translator
         return $this->translator->setLocale($locale);
     }
 
     /**
      * {@inheritdoc}
-     *
-     * Forwards to the default translator, doesn’t handle $GLOBALS['TL_LANG'].
      */
     public function getLocale()
     {
+        // Forward to the default translator
         return $this->translator->getLocale();
     }
 
     /**
-     * Get the translation from the $GLOBALS['TL_LANG'] array.
+     * Returns the labels from the $GLOBALS['TL_LANG'] array.
      *
      * @param string $id     Message id, e.g. "MSC.view"
      * @param string $domain Message domain, e.g. "messages" or "tl_content"
@@ -116,8 +113,7 @@ class Translator implements TranslatorInterface
             $id = $domain.'.'.$id;
         }
 
-        // Split the ID into chunks separated by dots,
-        // escaped dots (\.) and backslashes (\\) are allowed.
+        // Split the ID into chunks allowing escaped dots (\.) and backslashes (\\)
         preg_match_all('/(?:\\\\[.\\\\]|[^.])++/s', $id, $matches);
         $parts = preg_replace('/\\\\([.\\\\])/s', '$1', $matches[0]);
 
@@ -127,6 +123,7 @@ class Translator implements TranslatorInterface
             if (!isset($item[$part])) {
                 return null;
             }
+
             $item = &$item[$part];
         }
 
@@ -134,7 +131,7 @@ class Translator implements TranslatorInterface
     }
 
     /**
-     * Load a Contao framework language file.
+     * Loads a Contao framework language file.
      *
      * @param string $name
      */

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -32,7 +32,7 @@ class Translator implements TranslatorInterface
     private $framework;
 
     /**
-     * @param TranslatorInterface      $translator Original translator service that gets decorated.
+     * @param TranslatorInterface      $translator Original translator service that gets decorated
      * @param ContaoFrameworkInterface $framework
      */
     public function __construct(TranslatorInterface $translator, ContaoFrameworkInterface $framework)

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -10,8 +10,7 @@
 
 namespace Contao\CoreBundle\Translation;
 
-use Contao\CoreBundle\Framework\FrameworkAwareInterface;
-use Contao\CoreBundle\Framework\FrameworkAwareTrait;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -19,21 +18,26 @@ use Symfony\Component\Translation\TranslatorInterface;
  *
  * @author Martin Auswöger <martin@auswoeger.com>
  */
-class Translator implements TranslatorInterface, FrameworkAwareInterface
+class Translator implements TranslatorInterface
 {
-    use FrameworkAwareTrait;
-
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
     /**
-     * @param TranslatorInterface $translator original translator service that gets decorated
+     * @var ContaoFrameworkInterface
      */
-    public function __construct(TranslatorInterface $translator)
+    private $framework;
+
+    /**
+     * @param TranslatorInterface      $translator Original translator service that gets decorated.
+     * @param ContaoFrameworkInterface $framework
+     */
+    public function __construct(TranslatorInterface $translator, ContaoFrameworkInterface $framework)
     {
         $this->translator = $translator;
+        $this->framework = $framework;
     }
 
     /**

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -140,7 +140,7 @@ class Translator implements TranslatorInterface
      */
     private function loadLanguageFile(string $name)
     {
-        /** @var System */
+        /** @var System $system */
         $system = $this->framework->getAdapter(System::class);
 
         $system->loadLanguageFile($name);

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -36,7 +36,10 @@ class TranslatorTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Translation\TranslatorInterface', $translator);
     }
 
-    public function testForwardsMethodCalls()
+    /**
+     * Tests forwarding method calls to the decorated translator.
+     */
+    public function testForwardsTheMethodCalls()
     {
         $originalTranslator = $this->createMock(TranslatorInterface::class);
 
@@ -77,13 +80,17 @@ class TranslatorTest extends TestCase
 
         $this->assertSame('trans', $translator->trans('id', ['param' => 'value'], 'domain', 'en'));
         $this->assertSame('transChoice', $translator->transChoice('id', 3, ['param' => 'value'], 'domain', 'en'));
+
         $translator->setLocale('en');
+        
         $this->assertSame('en', $translator->getLocale());
     }
 
-    public function testReadsFromGlobals()
+    /**
+     * Tests reading from $GLOBALS['TL_LANG'].
+     */
+    public function testReadsFromTheGlobalLanguageArray()
     {
-        $originalTranslator = $this->createMock(TranslatorInterface::class);
         $framework = $this->createMock(ContaoFrameworkInterface::class);
 
         $framework
@@ -105,7 +112,7 @@ class TranslatorTest extends TestCase
             ->willReturn($systemAdapter)
         ;
 
-        $translator = new Translator($originalTranslator, $framework);
+        $translator = new Translator($this->createMock(TranslatorInterface::class), $framework);
 
         $this->assertSame('MSC.foo', $translator->trans('MSC.foo', [], 'contao_default'));
 
@@ -135,9 +142,11 @@ class TranslatorTest extends TestCase
         );
     }
 
-    public function testLoadsMessageDomainWithPrefix()
+    /**
+     * Tests loading message domains with the "contao_" prefix.
+     */
+    public function testLoadsMessageDomainsWithTheContaoPrefix()
     {
-        $originalTranslator = $this->createMock(TranslatorInterface::class);
         $framework = $this->createMock(ContaoFrameworkInterface::class);
 
         $framework
@@ -159,7 +168,7 @@ class TranslatorTest extends TestCase
             ->willReturn($systemAdapter)
         ;
 
-        $translator = new Translator($originalTranslator, $framework);
+        $translator = new Translator($this->createMock(TranslatorInterface::class), $framework);
 
         $this->assertSame('foo', $translator->trans('foo', [], 'contao_tl_foobar'));
 

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -10,6 +10,7 @@
 
 namespace Contao\CoreBundle\Tests\Translation;
 
+use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\CoreBundle\Translation\Translator;
 use PHPUnit\Framework\TestCase;
@@ -29,10 +30,152 @@ class TranslatorTest extends TestCase
     {
         $originalTranslator = $this->createMock(TranslatorInterface::class);
         $framework = $this->createMock(ContaoFrameworkInterface::class);
-
         $translator = new Translator($originalTranslator, $framework);
 
         $this->assertInstanceOf('Contao\CoreBundle\Translation\Translator', $translator);
         $this->assertInstanceOf('Symfony\Component\Translation\TranslatorInterface', $translator);
+    }
+
+    public function testForwardsMethodCalls()
+    {
+        $originalTranslator = $this->createMock(TranslatorInterface::class);
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('id', ['param' => 'value'], 'domain', 'en')
+            ->willReturn('trans')
+        ;
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('transChoice')
+            ->with('id', 3, ['param' => 'value'], 'domain', 'en')
+            ->willReturn('transChoice')
+        ;
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('setLocale')
+            ->with('en')
+        ;
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('getLocale')
+            ->willReturn('en')
+        ;
+
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $translator = new Translator($originalTranslator, $framework);
+
+        $this->assertSame('trans', $translator->trans('id', ['param' => 'value'], 'domain', 'en'));
+        $this->assertSame('transChoice', $translator->transChoice('id', 3, ['param' => 'value'], 'domain', 'en'));
+        $translator->setLocale('en');
+        $this->assertSame('en', $translator->getLocale());
+    }
+
+    public function testSkipsIfFrameworkIsNotInitialized()
+    {
+        $originalTranslator = $this->createMock(TranslatorInterface::class);
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $framework
+            ->expects($this->any())
+            ->method('isInitialized')
+            ->willReturn(false)
+        ;
+
+        $translator = new Translator($originalTranslator, $framework);
+
+        $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar';
+
+        $this->assertSame('MSC.foo', $translator->trans('MSC.foo', [], 'contao_default'));
+
+        unset($GLOBALS['TL_LANG']['MSC']['foo']);
+    }
+
+    public function testReadsFromGlobals()
+    {
+        $originalTranslator = $this->createMock(TranslatorInterface::class);
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $framework
+            ->expects($this->atLeastOnce())
+            ->method('isInitialized')
+            ->willReturn(true)
+        ;
+
+        $systemAdapter = $this->createMock(Adapter::class);
+
+        $systemAdapter
+            ->expects($this->atLeastOnce())
+            ->method('__call')
+            ->with('loadLanguageFile', ['default'])
+        ;
+
+        $framework
+            ->expects($this->atLeastOnce())
+            ->method('getAdapter')
+            ->willReturn($systemAdapter)
+        ;
+
+        $translator = new Translator($originalTranslator, $framework);
+
+        $this->assertSame('MSC.foo', $translator->trans('MSC.foo', [], 'contao_default'));
+
+        $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar';
+
+        $this->assertSame('bar', $translator->trans('MSC.foo', [], 'contao_default'));
+
+        $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar %s baz %s';
+
+        $this->assertSame('bar foo1 baz foo2', $translator->trans('MSC.foo', ['foo1', 'foo2'], 'contao_default'));
+
+        $GLOBALS['TL_LANG']['MSC']['foo.bar\\baz'] = 'foo';
+
+        $this->assertSame('foo', $translator->trans('MSC.foo\.bar\\\\baz', [], 'contao_default'));
+
+        unset(
+            $GLOBALS['TL_LANG']['MSC']['foo'],
+            $GLOBALS['TL_LANG']['MSC']['foo.bar\\baz']
+        );
+    }
+
+    public function testLoadsMessageDomainWithPrefix()
+    {
+        $originalTranslator = $this->createMock(TranslatorInterface::class);
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $framework
+            ->expects($this->atLeastOnce())
+            ->method('isInitialized')
+            ->willReturn(true)
+        ;
+
+        $systemAdapter = $this->createMock(Adapter::class);
+
+        $systemAdapter
+            ->expects($this->atLeastOnce())
+            ->method('__call')
+            ->with('loadLanguageFile', ['tl_foobar'])
+        ;
+
+        $framework
+            ->expects($this->atLeastOnce())
+            ->method('getAdapter')
+            ->willReturn($systemAdapter)
+        ;
+
+        $translator = new Translator($originalTranslator, $framework);
+
+        $this->assertSame('foo', $translator->trans('foo', [], 'contao_tl_foobar'));
+
+        $GLOBALS['TL_LANG']['tl_foobar']['foo'] = 'bar';
+
+        $this->assertSame('bar', $translator->trans('foo', [], 'contao_tl_foobar'));
+
+        unset($GLOBALS['TL_LANG']['tl_foobar']['foo']);
     }
 }

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -112,6 +112,7 @@ class TranslatorTest extends TestCase
         $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar';
 
         $this->assertSame('bar', $translator->trans('MSC.foo', [], 'contao_default'));
+        $this->assertSame('MSC.foo.bar', $translator->trans('MSC.foo.bar', [], 'contao_default'));
 
         $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar %s baz %s';
 

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Tests\Translation;
+
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Tests the TokenGenerator class.
+ *
+ * @author Martin Auswöger <martin@auswoeger.com>
+ */
+class TranslatorTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testCanBeInstantiated()
+    {
+        $originalTranslator = $this->createMock(TranslatorInterface::class);
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $translator = new Translator($originalTranslator, $framework);
+
+        $this->assertInstanceOf('Contao\CoreBundle\Translation\Translator', $translator);
+        $this->assertInstanceOf('Symfony\Component\Translation\TranslatorInterface', $translator);
+    }
+}

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -120,10 +120,17 @@ class TranslatorTest extends TestCase
         $GLOBALS['TL_LANG']['MSC']['foo.bar\\baz'] = 'foo';
 
         $this->assertSame('foo', $translator->trans('MSC.foo\.bar\\\\baz', [], 'contao_default'));
+        $this->assertSame('foo', $translator->trans('MSC.foo\.bar\baz', [], 'contao_default'));
+
+        $GLOBALS['TL_LANG']['MSC']['foo\\']['bar\\baz.'] = 'foo';
+
+        $this->assertSame('foo', $translator->trans('MSC.foo\\\\.bar\baz\.', [], 'contao_default'));
+        $this->assertSame('MSC.foo\.bar\baz\.', $translator->trans('MSC.foo\.bar\baz\.', [], 'contao_default'));
 
         unset(
             $GLOBALS['TL_LANG']['MSC']['foo'],
-            $GLOBALS['TL_LANG']['MSC']['foo.bar\\baz']
+            $GLOBALS['TL_LANG']['MSC']['foo.bar\\baz'],
+            $GLOBALS['TL_LANG']['MSC']['foo\\']['bar\\baz.']
         );
     }
 

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -68,32 +68,17 @@ class TranslatorTest extends TestCase
 
         $framework = $this->createMock(ContaoFrameworkInterface::class);
 
+        $framework
+            ->expects($this->never())
+            ->method('initialize')
+        ;
+
         $translator = new Translator($originalTranslator, $framework);
 
         $this->assertSame('trans', $translator->trans('id', ['param' => 'value'], 'domain', 'en'));
         $this->assertSame('transChoice', $translator->transChoice('id', 3, ['param' => 'value'], 'domain', 'en'));
         $translator->setLocale('en');
         $this->assertSame('en', $translator->getLocale());
-    }
-
-    public function testSkipsIfFrameworkIsNotInitialized()
-    {
-        $originalTranslator = $this->createMock(TranslatorInterface::class);
-        $framework = $this->createMock(ContaoFrameworkInterface::class);
-
-        $framework
-            ->expects($this->any())
-            ->method('isInitialized')
-            ->willReturn(false)
-        ;
-
-        $translator = new Translator($originalTranslator, $framework);
-
-        $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar';
-
-        $this->assertSame('MSC.foo', $translator->trans('MSC.foo', [], 'contao_default'));
-
-        unset($GLOBALS['TL_LANG']['MSC']['foo']);
     }
 
     public function testReadsFromGlobals()
@@ -103,8 +88,7 @@ class TranslatorTest extends TestCase
 
         $framework
             ->expects($this->atLeastOnce())
-            ->method('isInitialized')
-            ->willReturn(true)
+            ->method('initialize')
         ;
 
         $systemAdapter = $this->createMock(Adapter::class);
@@ -150,8 +134,7 @@ class TranslatorTest extends TestCase
 
         $framework
             ->expects($this->atLeastOnce())
-            ->method('isInitialized')
-            ->willReturn(true)
+            ->method('initialize')
         ;
 
         $systemAdapter = $this->createMock(Adapter::class);


### PR DESCRIPTION
Can be used as following:

```php
->trans('MSC.view', [], 'contao_default');
->trans('ERR.minlength', ['My Field', 1234], 'contao_default');
->trans('websiteTitle.0', [], 'contao_tl_settings');
->trans('MSC.key\.mit\.punkt\.und\\\\backslash', 'contao_default');
```

Twig:

```twig
{% trans_default_domain 'contao_default' %}
{{ 'MSC.view'|trans }}
{{ 'ERR.minlength'|trans(['My Field', 1234]) }}
{{ 'websiteTitle.0'|trans({}, 'contao_tl_settings') }}
{{ 'MSC.key\\.mit\\.punkt\\.und\\\\backslash'|trans }}
```