### PR TITLE
[RFC] Extend \Image::getPath($src) method to return public vendor images

### DIFF
--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -677,7 +677,7 @@ class Image
 	
 			if (count($vendorAssets) > 0)
 			{
-				return StringUtil::stripRootDir($vendorAssets[0]);
+				return \StringUtil::stripRootDir($vendorAssets[0]);
 			}
 		}
 	}

--- a/src/Resources/contao/library/Contao/Image.php
+++ b/src/Resources/contao/library/Contao/Image.php
@@ -660,20 +660,25 @@ class Image
 		{
 			$theme = \Backend::getTheme();
 
-			if (pathinfo($src, PATHINFO_EXTENSION) == 'svg')
-			{
-				return 'system/themes/' . $theme . '/icons/' . $src;
-			}
-
 			$filename = pathinfo($src, PATHINFO_FILENAME);
-
+	
 			// Prefer SVG icons
 			if (file_exists(TL_ROOT . '/system/themes/' . $theme . '/icons/' . $filename . '.svg'))
 			{
 				return 'system/themes/' . $theme . '/icons/' . $filename . '.svg';
 			}
 
-			return 'system/themes/' . $theme . '/images/' . $src;
+			if (file_exists(TL_ROOT . 'system/themes/' . $theme . '/images/' . $src))
+			{
+				return 'system/themes/' . $theme . '/images/' . $src;
+			}	
+	
+			$vendorAssets = glob(TL_ROOT . '/web/bundles/*/' . $src);
+	
+			if (count($vendorAssets) > 0)
+			{
+				return StringUtil::stripRootDir($vendorAssets[0]);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds the ability to easily insert images from your vendor public folder, just like the contao theme images. This might be interesting for developers.

You will be able to insert a image from your vendors public folder into your html like so:
```php
$strOutputHTML .= \Image::getHtml('myimage.svg', 'my image', '');
```
or just fetch the path
```php
$imgUrl = \Image::getPath('myimage.svg');
```
It will return the relative path to the image (e.g. `bundles/agoatspecialbundle/myimage.svg`).


That's maybe much simpler as:
```php
\Image::getHTML('bundles/whattheheckismybundlessymlinkedname/myimage.svg');
```

The only drawback with this is, that only the first image path found is returned if the same image name is used in several bundles.

What do you think?