### PR TITLE
[RTM] Minimum password length enhancement

### DIFF
--- a/src/Resources/contao/forms/FormPassword.php
+++ b/src/Resources/contao/forms/FormPassword.php
@@ -125,7 +125,7 @@ class FormPassword extends \Widget
 		}
 
 		// Check password length either from DCA or use Config as fallback (#1087)
-		$intLength = ($this->minlength > 0) ? $this->minlength : \Config::get('minPasswordLength');
+		$intLength = $this->minlength ?: \Config::get('minPasswordLength');
 
 		if (Utf8::strlen($varInput) < $intLength)
 		{

--- a/src/Resources/contao/forms/FormPassword.php
+++ b/src/Resources/contao/forms/FormPassword.php
@@ -124,9 +124,12 @@ class FormPassword extends \Widget
 			return '';
 		}
 
-		if (Utf8::strlen($varInput) < \Config::get('minPasswordLength'))
+		// Check password length either from DCA or use Config as fallback (#1087)
+		$intLength = ($this->minlength > 0) ? $this->minlength : \Config::get('minPasswordLength');
+
+		if (Utf8::strlen($varInput) < $intLength)
 		{
-			$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['passwordLength'], \Config::get('minPasswordLength')));
+			$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['passwordLength'], $intLength));
 		}
 
 		if ($varInput != $this->getPost($this->strName . '_confirm'))

--- a/src/Resources/contao/widgets/Password.php
+++ b/src/Resources/contao/widgets/Password.php
@@ -114,9 +114,12 @@ class Password extends \Widget
 			return '*****';
 		}
 
-		if (Utf8::strlen($varInput) < \Config::get('minPasswordLength'))
+		// Check password length either from DCA or use Config as fallback (#1086)
+		$intLength = ($this->arrConfiguration['minlength'] > 0) ? $this->arrConfiguration['minlength'] : \Config::get('minPasswordLength');
+
+		if (Utf8::strlen($varInput) < $intLength)
 		{
-			$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['passwordLength'], \Config::get('minPasswordLength')));
+			$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['passwordLength'], $intLength));
 		}
 
 		if ($varInput != $this->getPost($this->strName . '_confirm'))

--- a/src/Resources/contao/widgets/Password.php
+++ b/src/Resources/contao/widgets/Password.php
@@ -115,7 +115,7 @@ class Password extends \Widget
 		}
 
 		// Check password length either from DCA or use Config as fallback (#1086)
-		$intLength = ($this->arrConfiguration['minlength'] > 0) ? $this->arrConfiguration['minlength'] : \Config::get('minPasswordLength');
+		$intLength = ($this->minlength > 0) ? $this->minlength : \Config::get('minPasswordLength');
 
 		if (Utf8::strlen($varInput) < $intLength)
 		{

--- a/src/Resources/contao/widgets/Password.php
+++ b/src/Resources/contao/widgets/Password.php
@@ -115,7 +115,7 @@ class Password extends \Widget
 		}
 
 		// Check password length either from DCA or use Config as fallback (#1086)
-		$intLength = ($this->minlength > 0) ? $this->minlength : \Config::get('minPasswordLength');
+		$intLength = $this->minlength ?: \Config::get('minPasswordLength');
 
 		if (Utf8::strlen($varInput) < $intLength)
 		{


### PR DESCRIPTION
Check the minimum password length first from DCA 'eval' value, if it does not exists use the value from Config as fallback.