### PR TITLE
[RTM] Allow to register hooks listeners as tagged services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### DEV
 
+ * Allow to register hooks listeners as tagged services (see #1094).
  * Use a service to build the back end menu (see #1066).
  * Add the FilesModel::findMultipleFoldersByFolder() method (see contao/core#7942).
  * Add the fragment registry and the fragment renderers (see #700).

--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\DoctrineMigrationsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\FragmentRegistryPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHooksPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -62,5 +63,6 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new DoctrineMigrationsPass());
         $container->addCompilerPass(new PickerProviderPass());
         $container->addCompilerPass(new FragmentRegistryPass());
+        $container->addCompilerPass(new RegisterHooksPass());
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterHooksPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHooksPass.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Find hook services and store them in an parameter.
+ *
+ * @author David Molineus <https://github.com/dmolineus>
+ */
+class RegisterHooksPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $serviceIds = $container->findTaggedServiceIds('contao.hook');
+        $before     = [];
+        $after      = [];
+
+        foreach ($serviceIds as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+                $this->guardRequiredAttributesExist($serviceId, $attributes);
+
+                if (!empty($attributes['before'])) {
+                    if (!isset($before[$attributes['hook']])) {
+                        $before[$attributes['hook']] = [];
+                    }
+
+                    $before[$attributes['hook']][] = [$serviceId, $attributes['method']];
+                } else {
+                    if (!isset($after[$attributes['hook']])) {
+                        $after[$attributes['hook']] = [];
+                    }
+
+                    $after[$attributes['hook']][] = [$serviceId, $attributes['method']];
+                }
+            }
+        }
+
+        if ($before) {
+            $container->setParameter('contao.hook_listeners.before', $before);
+        }
+
+        if ($after) {
+            $container->setParameter('contao.hook_listeners.after', $after);
+        }
+    }
+
+    /**
+     * Guard that required attributes (hook and method) are defined.
+     *
+     * @param string $serviceId  Service id.
+     * @param array  $attributes Tag attributes.
+     *
+     * @throws InvalidConfigurationException When an attribute is missing.
+     */
+    private function guardRequiredAttributesExist(string $serviceId, array $attributes): void
+    {
+        if (!isset($attributes['hook'])) {
+            throw new InvalidConfigurationException(
+                sprintf('Missing hook attribute in tagged hook service with service id "%s"', $serviceId)
+            );
+        }
+
+        if (!isset($attributes['method'])) {
+            throw new InvalidConfigurationException(
+                sprintf('Missing method attribute in tagged hook service with service id "%s"', $serviceId)
+            );
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/RegisterHooksPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHooksPass.php
@@ -28,6 +28,10 @@ class RegisterHooksPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('contao.framework')) {
+            return;
+        }
+
         $serviceIds = $container->findTaggedServiceIds('contao.hook');
         $hooks      = [];
 
@@ -48,7 +52,8 @@ class RegisterHooksPass implements CompilerPassInterface
                 krsort($hooks[$hook]);
             }
 
-            $container->setParameter('contao.hook_listeners', $hooks);
+            $definition = $container->getDefinition('contao.framework');
+            $definition->setArgument(6, $hooks);
         }
     }
 

--- a/src/DependencyInjection/Compiler/RegisterHooksPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHooksPass.php
@@ -44,7 +44,9 @@ class RegisterHooksPass implements CompilerPassInterface
 
         if (count($hooks) > 0) {
             // Apply priority sorting.
-            krsort($hooks);
+            foreach (array_keys($hooks) as $hook) {
+                krsort($hooks[$hook]);
+            }
 
             $container->setParameter('contao.hook_listeners', $hooks);
         }

--- a/src/DependencyInjection/Compiler/RegisterHooksPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHooksPass.php
@@ -35,7 +35,7 @@ class RegisterHooksPass implements CompilerPassInterface
             foreach ($tags as $attributes) {
                 $this->guardRequiredAttributesExist($serviceId, $attributes);
 
-                $priority = $attributes['priority'] ?? 0;
+                $priority = (int) ($attributes['priority'] ?? 0);
                 $hook     = $attributes['hook'];
 
                 $hooks[$hook][$priority][] = [$serviceId, $attributes['method']];

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -71,6 +71,11 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     private $errorLevel;
 
     /**
+     * @var array
+     */
+    private $hookListeners = [];
+
+    /**
      * @var Request
      */
     private $request;
@@ -98,11 +103,6 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         'contao_install',
         'contao_install_redirect',
     ];
-
-    /**
-     * @var array
-     */
-    private $hookListeners;
 
     /**
      * @param RequestStack     $requestStack
@@ -312,8 +312,8 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
         // Fully load the configuration
         $config->getInstance();
-        $this->buildHookGlobals();
 
+        $this->registerHooks();
         $this->validateInstallation();
 
         Input::initialize();
@@ -481,18 +481,16 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     }
 
     /**
-     * Build hooks globals.
+     * Registers the hooks in the global hooks array.
      */
-    private function buildHookGlobals(): void
+    private function registerHooks(): void
     {
         foreach ($this->hookListeners as $hookName => $priorities) {
-            if (isset($GLOBALS['TL_HOOKS'][$hookName]) && is_array($GLOBALS['TL_HOOKS'][$hookName])) {
+            if (isset($GLOBALS['TL_HOOKS'][$hookName]) && \is_array($GLOBALS['TL_HOOKS'][$hookName])) {
                 if (isset($priorities[0])) {
                     $priorities[0] = array_merge($GLOBALS['TL_HOOKS'][$hookName], $priorities[0]);
                 } else {
                     $priorities[0] = $GLOBALS['TL_HOOKS'][$hookName];
-
-                    // Sorting priorities might gets broken by adding a new key.
                     krsort($priorities);
                 }
             }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -476,7 +476,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     /**
      * Build hooks globals.
      */
-    private function buildHookGlobals()
+    private function buildHookGlobals(): void
     {
         if ($this->container->hasParameter('contao.hook_listeners.before')) {
             $config = (array) $this->container->getParameter('contao.hook_listeners.before');

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -305,6 +305,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
         // Fully load the configuration
         $config->getInstance();
+        $this->buildHookGlobals();
 
         $this->validateInstallation();
 
@@ -470,5 +471,35 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
             || !$this->request->attributes->has('_token_check')
             || false === $this->request->attributes->get('_token_check')
         ;
+    }
+
+    /**
+     * Build hooks globals.
+     */
+    private function buildHookGlobals()
+    {
+        if ($this->container->hasParameter('contao.hook_listeners.before')) {
+            $config = (array) $this->container->getParameter('contao.hook_listeners.before');
+
+            foreach ($config as $hookName => $hooks) {
+                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
+                    $GLOBALS['TL_HOOKS'][$hookName] = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
+                } else {
+                    $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+                }
+            }
+        }
+
+        if ($this->container->hasParameter('contao.hook_listeners.after')) {
+            $config = (array) $this->container->getParameter('contao.hook_listeners.after');
+
+            foreach ($config as $hookName => $hooks) {
+                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
+                    $GLOBALS['TL_HOOKS'][$hookName] = array_merge($GLOBALS['TL_HOOKS'][$hookName], $hooks);
+                } else {
+                    $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+                }
+            }
+        }
     }
 }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -493,6 +493,12 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
                     $hooks[$hookName] = array_merge($hooks[$hookName], $listeners);
                 }
+
+                // Add legacy hook if only hook listeners with high priority are defined
+                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
+                    $hooks[$hookName] = array_merge($hooks[$hookName], $GLOBALS['TL_HOOKS'][$hookName]);
+                    unset ($GLOBALS['TL_HOOKS'][$hookName]);
+                }
             }
 
             $GLOBALS['TL_HOOKS'] = $hooks;

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -478,28 +478,24 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     private function buildHookGlobals(): void
     {
-        if ($this->container->hasParameter('contao.hook_listeners.before')) {
-            $config = (array) $this->container->getParameter('contao.hook_listeners.before');
+        if ($this->container->hasParameter('contao.hook_listeners')) {
+            $config = (array) $this->container->getParameter('contao.hook_listeners');
+            $hooks  = [];
 
-            foreach ($config as $hookName => $hooks) {
-                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                    $GLOBALS['TL_HOOKS'][$hookName] = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
-                } else {
-                    $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+            foreach ($config as $hookName => $priorities) {
+                $hooks[$hookName] = [];
+
+                foreach ($priorities as $priority => $listeners) {
+                    if ($priority <= 0 && isset ($GLOBALS['TL_HOOKS'][$hookName])) {
+                        $hooks[$hookName] = array_merge($hooks[$hookName], $GLOBALS['TL_HOOKS'][$hookName]);
+                        unset ($GLOBALS['TL_HOOKS'][$hookName]);
+                    }
+
+                    $hooks[$hookName] = array_merge($hooks[$hookName], $listeners);
                 }
             }
-        }
 
-        if ($this->container->hasParameter('contao.hook_listeners.after')) {
-            $config = (array) $this->container->getParameter('contao.hook_listeners.after');
-
-            foreach ($config as $hookName => $hooks) {
-                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                    $GLOBALS['TL_HOOKS'][$hookName] = array_merge($GLOBALS['TL_HOOKS'][$hookName], $hooks);
-                } else {
-                    $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
-                }
-            }
+            $GLOBALS['TL_HOOKS'] = $hooks;
         }
     }
 }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -486,23 +486,18 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     private function buildHookGlobals(): void
     {
         foreach ($this->hookListeners as $hookName => $priorities) {
-            $hooks = [];
+            if (isset($GLOBALS['TL_HOOKS'][$hookName]) && is_array($GLOBALS['TL_HOOKS'][$hookName])) {
+                if (isset($priorities[0])) {
+                    $priorities[0] = array_merge($GLOBALS['TL_HOOKS'][$hookName], $priorities[0]);
+                } else {
+                    $priorities[0] = $GLOBALS['TL_HOOKS'][$hookName];
 
-            foreach ($priorities as $priority => $listeners) {
-                if ($priority <= 0 && isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                    $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
-                    unset($GLOBALS['TL_HOOKS'][$hookName]);
+                    // Sorting priorities might gets broken by adding a new key.
+                    krsort($priorities);
                 }
-
-                $hooks = array_merge($hooks, $listeners);
             }
 
-            // Add legacy hook if only hook listeners with high priority are defined
-            if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
-            }
-
-            $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+            $GLOBALS['TL_HOOKS'][$hookName] = array_merge(...$priorities);
         }
     }
 }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -100,14 +100,20 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     ];
 
     /**
+     * @var array
+     */
+    private $hookListeners;
+
+    /**
      * @param RequestStack     $requestStack
      * @param RouterInterface  $router
      * @param SessionInterface $session
      * @param ScopeMatcher     $scopeMatcher
      * @param string           $rootDir
      * @param int              $errorLevel
+     * @param array            $hookListeners
      */
-    public function __construct(RequestStack $requestStack, RouterInterface $router, SessionInterface $session, ScopeMatcher $scopeMatcher, string $rootDir, int $errorLevel)
+    public function __construct(RequestStack $requestStack, RouterInterface $router, SessionInterface $session, ScopeMatcher $scopeMatcher, string $rootDir, int $errorLevel, array $hookListeners = [])
     {
         $this->requestStack = $requestStack;
         $this->router = $router;
@@ -115,6 +121,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         $this->scopeMatcher = $scopeMatcher;
         $this->rootDir = $rootDir;
         $this->errorLevel = $errorLevel;
+        $this->hookListeners = $hookListeners;
     }
 
     /**
@@ -478,10 +485,8 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     private function buildHookGlobals(): void
     {
-        if ($this->container->hasParameter('contao.hook_listeners')) {
-            $config = (array) $this->container->getParameter('contao.hook_listeners');
-
-            foreach ($config as $hookName => $priorities) {
+        if (count($this->hookListeners) > 0) {
+            foreach ($this->hookListeners as $hookName => $priorities) {
                 $hooks = [];
 
                 foreach ($priorities as $priority => $listeners) {

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -485,26 +485,24 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     private function buildHookGlobals(): void
     {
-        if (count($this->hookListeners) > 0) {
-            foreach ($this->hookListeners as $hookName => $priorities) {
-                $hooks = [];
+        foreach ($this->hookListeners as $hookName => $priorities) {
+            $hooks = [];
 
-                foreach ($priorities as $priority => $listeners) {
-                    if ($priority <= 0 && isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                        $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
-                        unset($GLOBALS['TL_HOOKS'][$hookName]);
-                    }
-
-                    $hooks = array_merge($hooks, $listeners);
-                }
-
-                // Add legacy hook if only hook listeners with high priority are defined
-                if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
+            foreach ($priorities as $priority => $listeners) {
+                if ($priority <= 0 && isset($GLOBALS['TL_HOOKS'][$hookName])) {
                     $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
+                    unset($GLOBALS['TL_HOOKS'][$hookName]);
                 }
 
-                $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+                $hooks = array_merge($hooks, $listeners);
             }
+
+            // Add legacy hook if only hook listeners with high priority are defined
+            if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
+                $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
+            }
+
+            $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
         }
     }
 }

--- a/src/Framework/ContaoFramework.php
+++ b/src/Framework/ContaoFramework.php
@@ -480,28 +480,26 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     {
         if ($this->container->hasParameter('contao.hook_listeners')) {
             $config = (array) $this->container->getParameter('contao.hook_listeners');
-            $hooks  = [];
 
             foreach ($config as $hookName => $priorities) {
-                $hooks[$hookName] = [];
+                $hooks = [];
 
                 foreach ($priorities as $priority => $listeners) {
-                    if ($priority <= 0 && isset ($GLOBALS['TL_HOOKS'][$hookName])) {
-                        $hooks[$hookName] = array_merge($hooks[$hookName], $GLOBALS['TL_HOOKS'][$hookName]);
-                        unset ($GLOBALS['TL_HOOKS'][$hookName]);
+                    if ($priority <= 0 && isset($GLOBALS['TL_HOOKS'][$hookName])) {
+                        $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
+                        unset($GLOBALS['TL_HOOKS'][$hookName]);
                     }
 
-                    $hooks[$hookName] = array_merge($hooks[$hookName], $listeners);
+                    $hooks = array_merge($hooks, $listeners);
                 }
 
                 // Add legacy hook if only hook listeners with high priority are defined
                 if (isset($GLOBALS['TL_HOOKS'][$hookName])) {
-                    $hooks[$hookName] = array_merge($hooks[$hookName], $GLOBALS['TL_HOOKS'][$hookName]);
-                    unset ($GLOBALS['TL_HOOKS'][$hookName]);
+                    $hooks = array_merge($hooks, $GLOBALS['TL_HOOKS'][$hookName]);
                 }
-            }
 
-            $GLOBALS['TL_HOOKS'] = $hooks;
+                $GLOBALS['TL_HOOKS'][$hookName] = $hooks;
+            }
         }
     }
 }

--- a/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
@@ -63,7 +63,9 @@ class RegisterHooksPassTest extends TestCase
 
         $this->assertArrayHasKey('initializeSystem', $parameter);
         $this->assertArrayHasKey(0, $parameter['initializeSystem']);
-        $this->assertEquals([['test.hook_listener.after', 'onInitializeSystem']], $parameter['initializeSystem'][0]);
+
+        $expected = [['test.hook_listener.after', 'onInitializeSystem']];
+        $this->assertTrue($expected === $parameter['initializeSystem'][0]);
     }
 
     /**
@@ -93,7 +95,9 @@ class RegisterHooksPassTest extends TestCase
 
         $this->assertArrayHasKey('initializeSystem', $parameter);
         $this->assertArrayHasKey(0, $parameter['initializeSystem']);
-        $this->assertEquals([['test.hook_listener.after', 'onInitializeSystem']], $parameter['initializeSystem'][0]);
+
+        $expected = [['test.hook_listener.after', 'onInitializeSystem']];
+        $this->assertTrue($expected === $parameter['initializeSystem'][0]);
     }
 
     /**
@@ -150,11 +154,15 @@ class RegisterHooksPassTest extends TestCase
         $this->assertArrayHasKey('generatePage', $parameter);
         $this->assertArrayHasKey(0, $parameter['generatePage']);
 
-        $this->assertEquals(
-            [['test.hook_listener', 'onInitializeSystemFirst'], ['test.hook_listener', 'onInitializeSystemSecond']],
-            $parameter['initializeSystem'][0]
-        );
-        $this->assertEquals([['test.hook_listener', 'onGeneratePage']], $parameter['generatePage'][0]);
+        $expected = [
+            ['test.hook_listener', 'onInitializeSystemFirst'],
+            ['test.hook_listener', 'onInitializeSystemSecond']
+        ];
+
+        $this->assertTrue($expected === $parameter['initializeSystem'][0]);
+
+        $expected = [['test.hook_listener', 'onGeneratePage']];
+        $this->assertTrue($expected === $parameter['generatePage'][0]);
     }
 
     /**
@@ -207,16 +215,15 @@ class RegisterHooksPassTest extends TestCase
         $this->assertArrayHasKey(10, $parameter['initializeSystem']);
         $this->assertArrayHasKey(100, $parameter['initializeSystem']);
 
-        $this->assertEquals(
-            [
-                100 => [['test.hook_listener.b', 'onInitializeSystemHigh']],
-                10  => [
-                    ['test.hook_listener.a', 'onInitializeSystem'],
-                    ['test.hook_listener.b', 'onInitializeSystemLow']
-                ],
+        $expected = [
+            100 => [['test.hook_listener.b', 'onInitializeSystemHigh']],
+            10  => [
+                ['test.hook_listener.a', 'onInitializeSystem'],
+                ['test.hook_listener.b', 'onInitializeSystemLow']
             ],
-            $parameter['initializeSystem']
-        );
+        ];
+
+        $this->assertTrue($expected === $parameter['initializeSystem']);
     }
 
     /**

--- a/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
@@ -166,7 +166,7 @@ class RegisterHooksPassTest extends TestCase
     /**
      * Test that exception is thrown for missing hook attribute.
      */
-    public function testInvalidConfigurationExceptionForMissingHookAttribute()
+    public function testInvalidConfigurationExceptionForMissingHookAttribute(): void
     {
         $container = new ContainerBuilder();
 
@@ -189,7 +189,7 @@ class RegisterHooksPassTest extends TestCase
     /**
      * Test that exception is thrown for missing method attribute.
      */
-    public function testInvalidConfigurationExceptionForMissingMethodAttribute()
+    public function testInvalidConfigurationExceptionForMissingMethodAttribute(): void
     {
         $container = new ContainerBuilder();
 

--- a/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHooksPassTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHooksPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Tests the RegisterHooksPassTest class.
+ *
+ * @author David Molineus <https://github.com/dmolineus>
+ */
+class RegisterHooksPassTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testCanBeInstantiated(): void
+    {
+        $pass = new RegisterHooksPass();
+
+        $this->assertInstanceOf(RegisterHooksPass::class, $pass);
+    }
+
+    /**
+     * Tests the after parameter is given.
+     */
+    public function testSetHookListenerAfterParameter(): void
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition('Test\HookListener\AfterListener');
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'initializeSystem',
+                'method' => 'onInitializeSystem'
+            ]
+        );
+
+        $container->setDefinition('test.hook_listener.after', $definition);
+
+        $pass = new RegisterHooksPass();
+        $pass->process($container);
+
+        $this->assertTrue($container->hasParameter('contao.hook_listeners.after'));
+        $this->assertFalse($container->hasParameter('contao.hook_listeners.before'));
+
+        $parameter = $container->getParameter('contao.hook_listeners.after');
+
+        $this->assertArrayHasKey('initializeSystem', $parameter);
+        $this->assertEquals([['test.hook_listener.after', 'onInitializeSystem']], $parameter['initializeSystem']);
+    }
+
+
+    /**
+     * Tests the after parameter is given.
+     */
+    public function testSetHookListenerBeforeParameter(): void
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition('Test\HookListener\BeforeListener');
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'initializeSystem',
+                'method' => 'onInitializeSystem',
+                'before' => true,
+            ]
+        );
+
+        $container->setDefinition('test.hook_listener.before', $definition);
+
+        $pass = new RegisterHooksPass();
+        $pass->process($container);
+
+        $this->assertTrue($container->hasParameter('contao.hook_listeners.before'));
+        $this->assertFalse($container->hasParameter('contao.hook_listeners.after'));
+
+        $parameter = $container->getParameter('contao.hook_listeners.before');
+
+        $this->assertArrayHasKey('initializeSystem', $parameter);
+        $this->assertEquals([['test.hook_listener.before', 'onInitializeSystem']], $parameter['initializeSystem']);
+    }
+
+    /**
+     * Tests that multiple tags are handled.
+     */
+    public function testMultipleTagsAreHandled(): void
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition('Test\HookListener');
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'initializeSystem',
+                'method' => 'onInitializeSystemAfter',
+            ]
+        );
+
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'generatePage',
+                'method' => 'onGeneratePage',
+            ]
+        );
+
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'initializeSystem',
+                'method' => 'onInitializeSystemBefore',
+                'before' => true,
+            ]
+        );
+
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook'   => 'parseTemplate',
+                'method' => 'onParseTemplate',
+                'before' => true,
+            ]
+        );
+
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHooksPass();
+        $pass->process($container);
+
+        // Test after parameter.
+        $this->assertTrue($container->hasParameter('contao.hook_listeners.after'));
+        $parameter = $container->getParameter('contao.hook_listeners.after');
+        $this->assertArrayHasKey('initializeSystem', $parameter);
+        $this->assertArrayHasKey('generatePage', $parameter);
+
+        $this->assertEquals([['test.hook_listener', 'onInitializeSystemAfter']], $parameter['initializeSystem']);
+        $this->assertEquals([['test.hook_listener', 'onGeneratePage']], $parameter['generatePage']);
+
+        // Test before parameter.
+        $this->assertTrue($container->hasParameter('contao.hook_listeners.before'));
+        $parameter = $container->getParameter('contao.hook_listeners.before');
+        $this->assertArrayHasKey('initializeSystem', $parameter);
+        $this->assertArrayHasKey('parseTemplate', $parameter);
+
+        $this->assertEquals([['test.hook_listener', 'onInitializeSystemBefore']], $parameter['initializeSystem']);
+        $this->assertEquals([['test.hook_listener', 'onParseTemplate']], $parameter['parseTemplate']);
+    }
+
+    /**
+     * Test that exception is thrown for missing hook attribute.
+     */
+    public function testInvalidConfigurationExceptionForMissingHookAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition('Test\HookListener');
+        $definition->addTag(
+            'contao.hook',
+            [
+                'method' => 'onInitializeSystemAfter',
+            ]
+        );
+
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $pass = new RegisterHooksPass();
+        $pass->process($container);
+    }
+
+    /**
+     * Test that exception is thrown for missing method attribute.
+     */
+    public function testInvalidConfigurationExceptionForMissingMethodAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition('Test\HookListener');
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook' => 'initializeSystem',
+            ]
+        );
+
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $pass = new RegisterHooksPass();
+        $pass->process($container);
+    }
+}

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -649,41 +649,37 @@ class ContaoFrameworkTest extends TestCase
 
         // Test hooks with high priority are added before low and legacy hooks
         // Test legacy hooks are added before hooks with priority 0
-        $this->assertEquals(
-            [
-                ['test.listener.a', 'onGetPageLayout'],
-                ['test.listener.c', 'onGetPageLayout'],
-                ['test.listener.b', 'onGetPageLayout']
-            ],
-            $GLOBALS['TL_HOOKS']['getPageLayout']
-        );
+        $expected = [
+            ['test.listener.a', 'onGetPageLayout'],
+            ['test.listener.c', 'onGetPageLayout'],
+            ['test.listener.b', 'onGetPageLayout']
+        ];
+
+        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['getPageLayout']);
 
         // Test hooks with negative priority are added at the end
-        $this->assertEquals(
-            [
-                ['test.listener.c', 'onGeneratePage'],
-                ['test.listener.b', 'onGeneratePage'],
-                ['test.listener.a', 'onGeneratePage']
-            ],
-            $GLOBALS['TL_HOOKS']['generatePage']
-        );
+        $expected = [
+            ['test.listener.c', 'onGeneratePage'],
+            ['test.listener.b', 'onGeneratePage'],
+            ['test.listener.a', 'onGeneratePage']
+        ];
+
+        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['generatePage']);
 
         // Test legacy hooks are kept when adding only hook listeners with high priority.
-        $this->assertEquals(
-            [
-                ['test.listener.a', 'onParseTemplate'],
-                ['test.listener.c', 'onParseTemplate'],
-            ],
-            $GLOBALS['TL_HOOKS']['parseTemplate']
-        );
+        $expected = [
+            ['test.listener.a', 'onParseTemplate'],
+            ['test.listener.c', 'onParseTemplate'],
+        ];
+
+        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['parseTemplate']);
 
         // Test legacy hooks are kept when adding only hook listeners with low priority.
-        $this->assertEquals(
-            [
-                ['test.listener.c', 'onIsVisibleElement'],
-                ['test.listener.a', 'onIsVisibleElement'],
-            ],
-            $GLOBALS['TL_HOOKS']['isVisibleElement']
-        );
+        $expected = [
+            ['test.listener.c', 'onIsVisibleElement'],
+            ['test.listener.a', 'onIsVisibleElement'],
+        ];
+
+        $this->assertTrue($expected ===  $GLOBALS['TL_HOOKS']['isVisibleElement']);
     }
 }

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -578,10 +578,7 @@ class ContaoFrameworkTest extends TestCase
         $this->assertSame($class, $prop->getValue($adapter));
     }
 
-    /**
-     * Tests that the hook_listeners are applied.
-     */
-    public function testHookServicesAreRegistered(): void
+    public function testRegistersTheHookServices(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'dummy');
@@ -596,33 +593,45 @@ class ContaoFrameworkTest extends TestCase
 
         $GLOBALS['TL_HOOKS'] = [
             'getPageLayout' => [
-                ['test.listener.c', 'onGetPageLayout']
+                ['test.listener.c', 'onGetPageLayout'],
             ],
             'generatePage' => [
-                ['test.listener.c', 'onGeneratePage']
+                ['test.listener.c', 'onGeneratePage'],
             ],
             'parseTemplate' => [
-                ['test.listener.c', 'onParseTemplate']
+                ['test.listener.c', 'onParseTemplate'],
             ],
             'isVisibleElement' => [
-                ['test.listener.c', 'onIsVisibleElement']
+                ['test.listener.c', 'onIsVisibleElement'],
             ],
         ];
 
         $listeners = [
             'getPageLayout' => [
-                10 => [['test.listener.a', 'onGetPageLayout']],
-                0  => [['test.listener.b', 'onGetPageLayout']],
+                10 => [
+                    ['test.listener.a', 'onGetPageLayout'],
+                ],
+                0 => [
+                    ['test.listener.b', 'onGetPageLayout'],
+                ],
             ],
-            'generatePage'  => [
-                0 => [['test.listener.b', 'onGeneratePage']],
-                -10 => [['test.listener.a', 'onGeneratePage']],
+            'generatePage' => [
+                0 => [
+                    ['test.listener.b', 'onGeneratePage'],
+                ],
+                -10 => [
+                    ['test.listener.a', 'onGeneratePage'],
+                ],
             ],
             'parseTemplate' => [
-                10 => [['test.listener.a', 'onParseTemplate']]
+                10 => [
+                    ['test.listener.a', 'onParseTemplate'],
+                ],
             ],
             'isVisibleElement' => [
-                -10 => [['test.listener.a', 'onIsVisibleElement']]
+                -10 => [
+                    ['test.listener.a', 'onIsVisibleElement'],
+                ],
             ],
         ];
 
@@ -638,7 +647,7 @@ class ContaoFrameworkTest extends TestCase
 
         if ($framework->isInitialized()) {
             $reflection = new \ReflectionObject($framework);
-            $reflectionMethod = $reflection->getMethod('buildHookGlobals');
+            $reflectionMethod = $reflection->getMethod('registerHooks');
             $reflectionMethod->setAccessible(true);
             $reflectionMethod->invoke($framework);
         } else {
@@ -653,37 +662,41 @@ class ContaoFrameworkTest extends TestCase
 
         // Test hooks with high priority are added before low and legacy hooks
         // Test legacy hooks are added before hooks with priority 0
-        $expected = [
-            ['test.listener.a', 'onGetPageLayout'],
-            ['test.listener.c', 'onGetPageLayout'],
-            ['test.listener.b', 'onGetPageLayout']
-        ];
-
-        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['getPageLayout']);
+        $this->assertSame(
+            [
+                ['test.listener.a', 'onGetPageLayout'],
+                ['test.listener.c', 'onGetPageLayout'],
+                ['test.listener.b', 'onGetPageLayout'],
+            ],
+            $GLOBALS['TL_HOOKS']['getPageLayout']
+        );
 
         // Test hooks with negative priority are added at the end
-        $expected = [
-            ['test.listener.c', 'onGeneratePage'],
-            ['test.listener.b', 'onGeneratePage'],
-            ['test.listener.a', 'onGeneratePage']
-        ];
-
-        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['generatePage']);
+        $this->assertSame(
+            [
+                ['test.listener.c', 'onGeneratePage'],
+                ['test.listener.b', 'onGeneratePage'],
+                ['test.listener.a', 'onGeneratePage'],
+            ],
+            $GLOBALS['TL_HOOKS']['generatePage']
+        );
 
         // Test legacy hooks are kept when adding only hook listeners with high priority.
-        $expected = [
-            ['test.listener.a', 'onParseTemplate'],
-            ['test.listener.c', 'onParseTemplate'],
-        ];
-
-        $this->assertTrue($expected === $GLOBALS['TL_HOOKS']['parseTemplate']);
+        $this->assertSame(
+            [
+                ['test.listener.a', 'onParseTemplate'],
+                ['test.listener.c', 'onParseTemplate'],
+            ],
+            $GLOBALS['TL_HOOKS']['parseTemplate']
+        );
 
         // Test legacy hooks are kept when adding only hook listeners with low priority.
-        $expected = [
-            ['test.listener.c', 'onIsVisibleElement'],
-            ['test.listener.a', 'onIsVisibleElement'],
-        ];
-
-        $this->assertTrue($expected ===  $GLOBALS['TL_HOOKS']['isVisibleElement']);
+        $this->assertSame(
+            [
+                ['test.listener.c', 'onIsVisibleElement'],
+                ['test.listener.a', 'onIsVisibleElement'],
+            ],
+            $GLOBALS['TL_HOOKS']['isVisibleElement']
+        );
     }
 }

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -602,6 +602,12 @@ class ContaoFrameworkTest extends TestCase
                       0 => [['test.listener.b', 'onGeneratePage']],
                     -10 => [['test.listener.a', 'onGeneratePage']],
                 ],
+                'parseTemplate' => [
+                    10 => [['test.listener.a', 'onParseTemplate']]
+                ],
+                'isVisibleElement' => [
+                    -10 => [['test.listener.a', 'onIsVisibleElement']]
+                ],
             ]
         );
 
@@ -614,6 +620,12 @@ class ContaoFrameworkTest extends TestCase
             ],
             'generatePage' => [
                 ['test.listener.c', 'onGeneratePage']
+            ],
+            'parseTemplate' => [
+                ['test.listener.c', 'onParseTemplate']
+            ],
+            'isVisibleElement' => [
+                ['test.listener.c', 'onIsVisibleElement']
             ],
         ];
 
@@ -632,6 +644,8 @@ class ContaoFrameworkTest extends TestCase
         $this->assertArrayHasKey('TL_HOOKS', $GLOBALS);
         $this->assertArrayHasKey('getPageLayout', $GLOBALS['TL_HOOKS']);
         $this->assertArrayHasKey('generatePage', $GLOBALS['TL_HOOKS']);
+        $this->assertArrayHasKey('parseTemplate', $GLOBALS['TL_HOOKS']);
+        $this->assertArrayHasKey('isVisibleElement', $GLOBALS['TL_HOOKS']);
 
         // Test hooks with high priority are added before low and legacy hooks
         // Test legacy hooks are added before hooks with priority 0
@@ -652,6 +666,24 @@ class ContaoFrameworkTest extends TestCase
                 ['test.listener.a', 'onGeneratePage']
             ],
             $GLOBALS['TL_HOOKS']['generatePage']
+        );
+
+        // Test legacy hooks are kept when adding only hook listeners with high priority.
+        $this->assertEquals(
+            [
+                ['test.listener.a', 'onParseTemplate'],
+                ['test.listener.c', 'onParseTemplate'],
+            ],
+            $GLOBALS['TL_HOOKS']['parseTemplate']
+        );
+
+        // Test legacy hooks are kept when adding only hook listeners with low priority.
+        $this->assertEquals(
+            [
+                ['test.listener.c', 'onIsVisibleElement'],
+                ['test.listener.a', 'onIsVisibleElement'],
+            ],
+            $GLOBALS['TL_HOOKS']['isVisibleElement']
         );
     }
 }

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -591,26 +591,6 @@ class ContaoFrameworkTest extends TestCase
 
         $container = $this->mockContainerWithContaoScopes();
         $container->get('request_stack')->push($request);
-        $container->setParameter(
-            'contao.hook_listeners',
-            [
-                'getPageLayout' => [
-                    10 => [['test.listener.a', 'onGetPageLayout']],
-                    0  => [['test.listener.b', 'onGetPageLayout']],
-                ],
-                'generatePage'  => [
-                      0 => [['test.listener.b', 'onGeneratePage']],
-                    -10 => [['test.listener.a', 'onGeneratePage']],
-                ],
-                'parseTemplate' => [
-                    10 => [['test.listener.a', 'onParseTemplate']]
-                ],
-                'isVisibleElement' => [
-                    -10 => [['test.listener.a', 'onIsVisibleElement']]
-                ],
-            ]
-        );
-
         $container->set('test.listener', new \stdClass());
         $container->set('test.listener2', new \stdClass());
 
@@ -629,7 +609,31 @@ class ContaoFrameworkTest extends TestCase
             ],
         ];
 
-        $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/index.html'));
+        $listeners = [
+            'getPageLayout' => [
+                10 => [['test.listener.a', 'onGetPageLayout']],
+                0  => [['test.listener.b', 'onGetPageLayout']],
+            ],
+            'generatePage'  => [
+                0 => [['test.listener.b', 'onGeneratePage']],
+                -10 => [['test.listener.a', 'onGeneratePage']],
+            ],
+            'parseTemplate' => [
+                10 => [['test.listener.a', 'onParseTemplate']]
+            ],
+            'isVisibleElement' => [
+                -10 => [['test.listener.a', 'onIsVisibleElement']]
+            ],
+        ];
+
+        $framework = $this->mockContaoFramework(
+            $container->get('request_stack'),
+            $this->mockRouter('/index.html'),
+            [],
+            [],
+            $listeners
+        );
+
         $framework->setContainer($container);
 
         if ($framework->isInitialized()) {

--- a/tests/Framework/ContaoFrameworkTest.php
+++ b/tests/Framework/ContaoFrameworkTest.php
@@ -603,9 +603,6 @@ class ContaoFrameworkTest extends TestCase
             ]
         );
 
-        $container->set('test.listener', new \stdClass());
-        $container->set('test.listener2', new \stdClass());
-
         $container->setParameter(
             'contao.hook_listeners.after',
             [
@@ -617,6 +614,9 @@ class ContaoFrameworkTest extends TestCase
                 ]
             ]
         );
+
+        $container->set('test.listener', new \stdClass());
+        $container->set('test.listener2', new \stdClass());
 
         $GLOBALS['TL_HOOKS'] = [
             'parseTemplate' => [
@@ -632,7 +632,15 @@ class ContaoFrameworkTest extends TestCase
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), $this->mockRouter('/index.html'));
         $framework->setContainer($container);
-        $framework->initialize();
+
+        if ($framework->isInitialized()) {
+            $reflection = new \ReflectionObject($framework);
+            $reflectionMethod = $reflection->getMethod('buildHookGlobals');
+            $reflectionMethod->setAccessible(true);
+            $reflectionMethod->invoke($framework);
+        } else {
+            $framework->initialize();
+        }
 
         $this->assertArrayHasKey('TL_HOOKS', $GLOBALS);
         $this->assertArrayHasKey('getPageLayout', $GLOBALS['TL_HOOKS']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,10 +69,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param RouterInterface|null $router
      * @param array                $adapters
      * @param array                $instances
+     * @param array                $hookListeners
      *
-     * @return ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
+     * @return ContaoFramework
      */
-    public function mockContaoFramework(RequestStack $requestStack = null, RouterInterface $router = null, array $adapters = [], array $instances = []): ContaoFramework
+    public function mockContaoFramework(RequestStack $requestStack = null, RouterInterface $router = null, array $adapters = [], array $instances = [], array $hookListeners = []): ContaoFramework
     {
         $container = $this->mockContainerWithContaoScopes();
 
@@ -106,6 +107,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 $this->mockScopeMatcher(),
                 $this->getRootDir(),
                 error_reporting(),
+                $hookListeners,
             ])
             ->setMethods(['getAdapter', 'createInstance'])
             ->getMock()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,7 +71,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param array                $instances
      * @param array                $hookListeners
      *
-     * @return ContaoFramework
+     * @return ContaoFramework|\PHPUnit_Framework_MockObject_MockObject
      */
     public function mockContaoFramework(RequestStack $requestStack = null, RouterInterface $router = null, array $adapters = [], array $instances = [], array $hookListeners = []): ContaoFramework
     {


### PR DESCRIPTION
Since https://github.com/contao/core-bundle/pull/376 it's possible to use services for hooks. This is a great step to using services within Contao.

This PR completes this step by allowing to register hooks as services without using the `config.php`. You don't have to manage your hook registration at two places anymore.

```yaml

services:
  my.custom.hook_listener:
    class: 'My\Custom\Hook\Listener'
    tags:
      - { name: 'contao.hook', hook: 'parseTemplate', method: 'onParseTemplate'}
      - { name: 'contao.hook', hook: 'initializeSystem', method: 'onInitializeSystem', before: true}
```

I'm aware of the above mentioned PR discussed it before and this feature wasn't added because of lack of control the position of the hook.

To gain more control of the position it's possible to set the `before` attribute so that the hook is registered before the legacy hooks. If you really need more control, well, just use the globals.

To keep backward compatibility the registered hooks are added to the `$GLOBALS['TL_HOOKS']` array.

