### PR TITLE
[RTM] Display form fieldsets as wrappers in the backend view.

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -237,19 +237,20 @@ $GLOBALS['BE_FFL'] = array
  */
 $GLOBALS['TL_FFL'] = array
 (
-	'explanation' => 'FormExplanation',
-	'html'        => 'FormHtml',
-	'fieldset'    => 'FormFieldset',
-	'text'        => 'FormTextField',
-	'password'    => 'FormPassword',
-	'textarea'    => 'FormTextArea',
-	'select'      => 'FormSelectMenu',
-	'radio'       => 'FormRadioButton',
-	'checkbox'    => 'FormCheckBox',
-	'upload'      => 'FormFileUpload',
-	'hidden'      => 'FormHidden',
-	'captcha'     => 'FormCaptcha',
-	'submit'      => 'FormSubmit'
+    'explanation'   => 'FormExplanation',
+    'html'          => 'FormHtml',
+    'fieldsetStart' => 'FormFieldsetStart',
+    'fieldsetStop'  => 'FormFieldsetStop',
+    'text'          => 'FormTextField',
+    'password'      => 'FormPassword',
+    'textarea'      => 'FormTextArea',
+    'select'        => 'FormSelectMenu',
+    'radio'         => 'FormRadioButton',
+    'checkbox'      => 'FormCheckBox',
+    'upload'        => 'FormFileUpload',
+    'hidden'        => 'FormHidden',
+    'captcha'       => 'FormCaptcha',
+    'submit'        => 'FormSubmit',
 );
 
 
@@ -426,12 +427,14 @@ $GLOBALS['TL_WRAPPERS'] = array
 	'start' => array
 	(
 		'accordionStart',
-		'sliderStart'
+		'sliderStart',
+		'fieldsetStart'
 	),
 	'stop' => array
 	(
 		'accordionStop',
-		'sliderStop'
+		'sliderStop',
+		'fieldsetStop'
 	),
 	'single' => array
 	(

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -104,11 +104,11 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'__selector__'                => array('type', 'fsType', 'multiple', 'storeFile', 'imageSubmit'),
+		'__selector__'                => array('type', 'multiple', 'storeFile', 'imageSubmit'),
 		'default'                     => '{type_legend},type',
 		'explanation'                 => '{type_legend},type;{text_legend},text;{expert_legend:hide},class;{template_legend:hide},customTpl',
-		'fieldsetfsStart'             => '{type_legend},type;{fconfig_legend},fsType,label;{expert_legend:hide},class;{template_legend:hide},customTpl',
-		'fieldsetfsStop'              => '{type_legend},type;{fconfig_legend},fsType;{template_legend:hide},customTpl',
+		'fieldsetStart'               => '{type_legend},type;{fconfig_legend},label;{expert_legend:hide},class;{template_legend:hide},customTpl',
+		'fieldsetStop'                => '{type_legend},type;{template_legend:hide},customTpl',
 		'html'                        => '{type_legend},type;{text_legend},html;{template_legend:hide},customTpl',
 		'text'                        => '{type_legend},type,name,label;{fconfig_legend},mandatory,rgxp,placeholder;{expert_legend:hide},class,value,minlength,maxlength,accesskey,tabindex;{template_legend:hide},customTpl',
 		'password'                    => '{type_legend},type,name,label;{fconfig_legend},mandatory,rgxp,placeholder;{expert_legend:hide},class,value,minlength,maxlength,accesskey,tabindex;{template_legend:hide},customTpl',
@@ -324,17 +324,6 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'inputType'               => 'checkbox',
 			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "char(1) NOT NULL default ''"
-		),
-		'fsType' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['tl_form_field']['fsType'],
-			'default'                 => 'fsStart',
-			'exclude'                 => true,
-			'inputType'               => 'radio',
-			'options'                 => array('fsStart', 'fsStop'),
-			'reference'               => &$GLOBALS['TL_LANG']['tl_form_field'],
-			'eval'                    => array('helpwizard'=>true, 'submitOnChange'=>true),
-			'sql'                     => "varchar(32) NOT NULL default ''"
 		),
 		'class' => array
 		(

--- a/src/Resources/contao/forms/FormFieldsetStart.php
+++ b/src/Resources/contao/forms/FormFieldsetStart.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao;
+
+
+/**
+ * Class FormFieldsetStart
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class FormFieldsetStart extends \Widget
+{
+
+	/**
+	 * Template
+	 *
+	 * @var string
+	 */
+	protected $strTemplate = 'form_fieldsetStart';
+
+
+	/**
+	 * Do not validate
+	 */
+	public function validate()
+	{
+		return;
+	}
+
+
+	/**
+	 * Parse the template file and return it as string
+	 *
+	 * @param array $arrAttributes An optional attributes array
+	 *
+	 * @return string The template markup
+	 */
+	public function parse($arrAttributes=null)
+	{
+		// Return a wildcard in the back end
+		if (TL_MODE == 'BE')
+		{
+			/** @var BackendTemplate|object $objTemplate */
+			$objTemplate = new \BackendTemplate('be_wildcard');
+			$objTemplate->title = $this->label;
+
+			return $objTemplate->parse();
+		}
+
+		return parent::parse($arrAttributes);
+	}
+
+
+	/**
+	 * Generate the widget and return it as string
+	 *
+	 * @return string The widget markup
+	 */
+	public function generate()
+	{
+		return "  <fieldset" . ($this->strClass ? ' class="' . $this->strClass . '"' : '') . ">\n" . (($this->label != '') ? "  <legend>" . $this->label . "</legend>\n" : '');
+	}
+}

--- a/src/Resources/contao/forms/FormFieldsetStart.php
+++ b/src/Resources/contao/forms/FormFieldsetStart.php
@@ -28,15 +28,6 @@ class FormFieldsetStart extends \Widget
 
 
 	/**
-	 * Do not validate
-	 */
-	public function validate()
-	{
-		return;
-	}
-
-
-	/**
 	 * Parse the template file and return it as string
 	 *
 	 * @param array $arrAttributes An optional attributes array
@@ -66,6 +57,8 @@ class FormFieldsetStart extends \Widget
 	 */
 	public function generate()
 	{
-		return "  <fieldset" . ($this->strClass ? ' class="' . $this->strClass . '"' : '') . ">\n" . (($this->label != '') ? "  <legend>" . $this->label . "</legend>\n" : '');
+		return sprintf('<fieldset%s>%s',
+						($this->strClass ? ' class="' . $this->strClass . '"' : ''),
+						($this->label ? '<legend>' . $this->label . '</legend>' : ''));
 	}
 }

--- a/src/Resources/contao/forms/FormFieldsetStop.php
+++ b/src/Resources/contao/forms/FormFieldsetStop.php
@@ -28,15 +28,6 @@ class FormFieldsetStop extends \Widget
 
 
 	/**
-	 * Do not validate
-	 */
-	public function validate()
-	{
-		return;
-	}
-
-
-	/**
 	 * Parse the template file and return it as string
 	 *
 	 * @param array $arrAttributes An optional attributes array
@@ -65,6 +56,6 @@ class FormFieldsetStop extends \Widget
 	 */
 	public function generate()
 	{
-		return "  </fieldset>\n";
+		return '</fieldset>';
 	}
 }

--- a/src/Resources/contao/forms/FormFieldsetStop.php
+++ b/src/Resources/contao/forms/FormFieldsetStop.php
@@ -10,17 +10,13 @@
 
 namespace Contao;
 
-use Patchwork\Utf8;
-
 
 /**
- * Class FormFieldset
- *
- * @property string  $fsType
+ * Class FormFieldsetSTop
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
-class FormFieldset extends \Widget
+class FormFieldsetStop extends \Widget
 {
 
 	/**
@@ -28,7 +24,7 @@ class FormFieldset extends \Widget
 	 *
 	 * @var string
 	 */
-	protected $strTemplate = 'form_fieldset';
+	protected $strTemplate = 'form_fieldsetStop';
 
 
 	/**
@@ -55,15 +51,6 @@ class FormFieldset extends \Widget
 			/** @var BackendTemplate|object $objTemplate */
 			$objTemplate = new \BackendTemplate('be_wildcard');
 
-			if ($this->fsType == 'fsStart')
-			{
-				$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['tl_form_field']['fsStart'][0]) . ' ###' . ($this->label ? '<br>' . $this->label : '');
-			}
-			else
-			{
-				$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['tl_form_field']['fsStop'][0]) . ' ###';
-			}
-
 			return $objTemplate->parse();
 		}
 
@@ -78,13 +65,6 @@ class FormFieldset extends \Widget
 	 */
 	public function generate()
 	{
-		if ($this->fsType == 'fsStart')
-		{
-			return "  <fieldset" . ($this->strClass ? ' class="' . $this->strClass . '"' : '') . ">\n" . (($this->label != '') ? "  <legend>" . $this->label . "</legend>\n" : '');
-		}
-		else
-		{
-			return "  </fieldset>\n";
-		}
+		return "  </fieldset>\n";
 	}
 }

--- a/src/Resources/contao/languages/en/tl_form_field.xlf
+++ b/src/Resources/contao/languages/en/tl_form_field.xlf
@@ -15,16 +15,16 @@
         <source>A custom field to insert HTML code.</source>
       </trans-unit>
       <trans-unit id="FFL.fieldsetStart.0">
-        <source>Fieldset Start</source>
+        <source>Fieldset start</source>
       </trans-unit>
       <trans-unit id="FFL.fieldsetStart.1">
-        <source>Opening part of a container for form fields with an optional legend.</source>
+        <source>The opening part of a fieldset with an optional legend.</source>
       </trans-unit>
       <trans-unit id="FFL.fieldsetStop.0">
-        <source>Fieldset Stop/source>
+        <source>Fieldset stop</source>
       </trans-unit>
       <trans-unit id="FFL.fieldsetStop.1">
-        <source>Closing part of a container for form fields.</source>
+        <source>The closing part of a fieldset.</source>
       </trans-unit>
       <trans-unit id="FFL.text.0">
         <source>Text field</source>

--- a/src/Resources/contao/languages/en/tl_form_field.xlf
+++ b/src/Resources/contao/languages/en/tl_form_field.xlf
@@ -260,24 +260,6 @@
       <trans-unit id="tl_form_field.doNotOverwrite.1">
         <source>Add a numeric suffix to the new file if the file name already exists.</source>
       </trans-unit>
-      <trans-unit id="tl_form_field.fsType.0">
-        <source>Operation mode</source>
-      </trans-unit>
-      <trans-unit id="tl_form_field.fsType.1">
-        <source>Please select the operation mode of the fieldset element.</source>
-      </trans-unit>
-      <trans-unit id="tl_form_field.fsStart.0">
-        <source>Wrapper start</source>
-      </trans-unit>
-      <trans-unit id="tl_form_field.fsStart.1">
-        <source>Marks the beginning of a fieldset and can contain a legend.</source>
-      </trans-unit>
-      <trans-unit id="tl_form_field.fsStop.0">
-        <source>Wrapper stop</source>
-      </trans-unit>
-      <trans-unit id="tl_form_field.fsStop.1">
-        <source>Marks the end of a fieldset.</source>
-      </trans-unit>
       <trans-unit id="tl_form_field.value.0">
         <source>Default value</source>
       </trans-unit>

--- a/src/Resources/contao/languages/en/tl_form_field.xlf
+++ b/src/Resources/contao/languages/en/tl_form_field.xlf
@@ -14,11 +14,17 @@
       <trans-unit id="FFL.html.1">
         <source>A custom field to insert HTML code.</source>
       </trans-unit>
-      <trans-unit id="FFL.fieldset.0">
-        <source>Fieldset</source>
+      <trans-unit id="FFL.fieldsetStart.0">
+        <source>Fieldset Start</source>
       </trans-unit>
-      <trans-unit id="FFL.fieldset.1">
-        <source>A container for form fields with an optional legend.</source>
+      <trans-unit id="FFL.fieldsetStart.1">
+        <source>Opening part of a container for form fields with an optional legend.</source>
+      </trans-unit>
+      <trans-unit id="FFL.fieldsetStop.0">
+        <source>Fieldset Stop/source>
+      </trans-unit>
+      <trans-unit id="FFL.fieldsetStop.1">
+        <source>Closing part of a container for form fields.</source>
       </trans-unit>
       <trans-unit id="FFL.text.0">
         <source>Text field</source>

--- a/src/Resources/contao/templates/forms/form_fieldsetStart.html5
+++ b/src/Resources/contao/templates/forms/form_fieldsetStart.html5
@@ -1,5 +1,6 @@
 
-  <fieldset<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>
+<fieldset<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>
+
   <?php if ($this->label): ?>
     <legend><?= $this->label ?></legend>
   <?php endif; ?>

--- a/src/Resources/contao/templates/forms/form_fieldsetStart.html5
+++ b/src/Resources/contao/templates/forms/form_fieldsetStart.html5
@@ -1,13 +1,5 @@
 
-<?php if ($this->fsType == 'fsStart'): ?>
-
   <fieldset<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>
   <?php if ($this->label): ?>
     <legend><?= $this->label ?></legend>
   <?php endif; ?>
-
-<?php else: ?>
-
-  </fieldset>
-
-<?php endif; ?>

--- a/src/Resources/contao/templates/forms/form_fieldsetStop.html5
+++ b/src/Resources/contao/templates/forms/form_fieldsetStop.html5
@@ -1,2 +1,2 @@
 
-  </fieldset>
+</fieldset>

--- a/src/Resources/contao/templates/forms/form_fieldsetStop.html5
+++ b/src/Resources/contao/templates/forms/form_fieldsetStop.html5
@@ -1,0 +1,2 @@
+
+  </fieldset>


### PR DESCRIPTION
Wrapper elements provides a cleaner view of complex elements in the parent view. As the feature is not limited to CEs it would be nice to use it for form fieldsets as well.

- [x] Split fieldset into start and stop element
- [x] Update language files
- [x] Provide migration script

If this PR is accepted I'll provide the missing tasks as well.