### PR TITLE
[WIP] Twig for DC_Table / Refactoring

### DIFF
--- a/src/Resources/views/Backend/DC_Table/edit.twig
+++ b/src/Resources/views/Backend/DC_Table/edit.twig
@@ -1,0 +1,87 @@
+{{ versionDropdown|raw }}
+{{ message|raw }}
+
+{% if error is defined %}
+    <p class="tl_error">{{ error }}</p>
+{% endif %}
+
+<div id="tl_buttons">
+    {% if buttons.back is defined %}
+        <a href="{{ buttons.back.href|e('html_attr') }}" class="header_back" title="{{ buttons.back.title }}"
+           accesskey="b" onclick="Backend.getScrollOffset()">{{ buttons.back.label }}</a>
+    {% else %}
+        &nbsp;
+    {% endif %}
+</div>
+
+<form action="{{ form.action|e('html_attr') }}" id="{{ form.id }}" class="tl_form tl_edit_form" method="post"
+      enctype="{{ form.noEncoding ? 'multipart/form-data' : 'application/x-www-form-urlencoded' }}"
+        {% if form.onSubmit is defined %} onsubmit="{{ form.onSubmit }}"{% endif %}>
+
+    <div class="tl_formbody_edit">
+        <input type="hidden" name="FORM_SUBMIT" value="{{ form.id }}">
+        <input type="hidden" name="REQUEST_TOKEN" value="{{ meta.requestToken }}">
+        {% if meta.version is defined %}
+            <input type="hidden" name="VERSION_NUMBER" value="{{ meta.version }}">
+        {% endif %}
+        <input type="hidden" name="FORM_FIELDS[]" value="{{ meta.fields }}">
+
+        {% for box in boxes %}
+            <fieldset{% if box.key is defined %} id="pal_{{ box.key }}"{% endif %}
+                    class="{{ loop.first ? 'tl_tbox' : 'tl_box' }}{% if box.legend is not defined %} nolegend{% endif %}{% if box.class is defined %} {{ box.class }}{% endif %}">
+                {% if box.legend is defined %}
+                    <legend onclick="AjaxRequest.toggleFieldset(this, '{{ box.key }}', '{{ form.id }}')">{{ box.legend }}</legend>
+                {% endif %}
+
+                {{ box.rows|raw }}
+            </fieldset>
+        {% endfor %}
+    </div>
+
+    <div class="tl_formbody_submit">
+        <div class="tl_submit_container">
+            {% if buttons.submit|length < 3 %}
+                {# all buttons in a row #}
+                {% for button in buttons.submit %}
+                    <button type="submit" id="{{ button.id }}" name="{{ button.id }}" class="tl_submit"
+                            accesskey="{{ button.accessKey }}">{{ button.label }}</button>
+                {% endfor %}
+            {% else %}
+                {# first button + others grouped under second button (split) #}
+                {% set firstButton = buttons.submit[0] %}
+                {% set secondButton = buttons.submit[1] %}
+                {% set remainingButtons = buttons.submit[2:] %}
+                <button type="submit" id="{{ firstButton.id }}" name="{{ firstButton.id }}"
+                        class="tl_submit" accesskey="{{ firstButton.accessKey }}">
+                    {{ firstButton.label }}
+                </button>
+                <div class="split-button">
+                    <button type="submit" id="{{ secondButton.id }}" name="{{ secondButton.id }}"
+                            class="tl_submit" accesskey="{{ secondButton.accessKey }}">
+                        {{ secondButton.label }}
+                    </button>
+                    <button type="button" id="sbtog">
+                        <img src="system/themes/flexible/icons/navcol.svg" alt="" width="10" height="10">
+                    </button>
+                    <ul class="invisible">
+                        <li>
+                            {% for button in remainingButtons %}
+                                <button type="submit" id="{{ button.id }}" name="{{ button.id }}" class="tl_submit"
+                                        accesskey="{{ button.accessKey }}">{{ button.label }}</button>
+                            {% endfor %}
+                        </li>
+                    </ul>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+</form>
+
+{% if setFocus %}
+    <script>
+        window.addEvent('domready', function () {
+            Backend.vScrollTo(($('{{ form.id }}').getElement('label.error').getPosition().y - 20));
+        });
+    </script>
+{% endif %}

--- a/src/Resources/views/Backend/DC_Table/show.twig
+++ b/src/Resources/views/Backend/DC_Table/show.twig
@@ -1,0 +1,16 @@
+<table class="tl_show">
+    {% for entry in entries %}
+        <tr>
+            {% if entry.value is defined %}
+                <td{{ cycle([' class=tl_bg',''], loop.index) }}>
+                    <span class="tl_label">{{ entry.label }}: </span>
+                </td>
+                <td{{ cycle([' class=tl_bg',''], loop.index) }}>
+                    {{ entry.value }}
+                </td>
+            {% else %}
+                <td colspan="2" style="height:5em"></td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+</table>

--- a/src/Resources/views/Backend/DC_Table/showAll.twig
+++ b/src/Resources/views/Backend/DC_Table/showAll.twig
@@ -1,0 +1,9 @@
+{% if panel is defined %}
+    {{ panel|raw }}
+{% endif %}
+
+{{ view|raw }}
+
+{% if pagination is defined %}
+    {{ pagination|raw }}
+{% endif %}


### PR DESCRIPTION
``DC_Table`` scares me and I'd really like to tame that 6kLOC monster somehow - otherwise I find it very hard to understand what's going on in there. However, refactoring the logic is hard as well :-) because the code is permeated by HTML everywhere. 

So here is an early attempt/draft to first refactor the HTML parts out of the class into individual Twig templates. I think this is managable and would allow further refactoring (as well as an easier way to improve the markup side). In this PR I currently only did this in a rough way for the ``show()``, ``showAll()`` and ``edit()`` methods (the latter one even not fully) as I'd like to get some feedback if this would be a valuable thing to do before putting energy into it.

Problems discovered so far: 
- button callbacks that contain HTML

