### PR TITLE
Validate array keys before saving to tl_user

### DIFF
--- a/src/Resources/contao/library/Contao/User.php
+++ b/src/Resources/contao/library/Contao/User.php
@@ -566,8 +566,11 @@ abstract class User extends \System
 	 */
 	public function save()
 	{
+		$arrFields = $this->Database->getFieldNames($this->strTable);
+		$arrSet = array_intersect_key($this->arrData, array_flip($arrFields));
+
 		$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
-					   ->set($this->arrData)
+					   ->set($arrSet)
 					   ->execute($this->id);
 	}
 


### PR DESCRIPTION
This should prevent `1054 Unknown column '...' in 'field list'` errors.