### PR TITLE
allow override of BackendUser and FrontendUser class

### DIFF
--- a/src/Security/User/ContaoUserProvider.php
+++ b/src/Security/User/ContaoUserProvider.php
@@ -63,13 +63,13 @@ class ContaoUserProvider implements ContainerAwareInterface, UserProviderInterfa
         if ($this->isBackendUsername($username)) {
             $this->framework->initialize();
 
-            return BackendUser::getInstance();
+            return \BackendUser::getInstance();
         }
 
         if ($this->isFrontendUsername($username)) {
             $this->framework->initialize();
 
-            return FrontendUser::getInstance();
+            return \FrontendUser::getInstance();
         }
 
         throw new UsernameNotFoundException('Can only load user "frontend" or "backend".');


### PR DESCRIPTION
Overriding arbitrary core classes is deprecated but (presumably) still supported in Contao 4. However, there is an oversight in `ContaoUserProvider::loadUserByUsername`. Due to
```php
use Contao\FrontendUser;
```
and the usage of
```php
FrontendUser::getInstance();
```
and it being the first occurrence of `FrontendUser::getInstance()` it will always instantiate a `Contao\FrontendUser` object, no matter if there is actually another `FrontendUser` class present in the root name space.

Some Contao 3 extensions like [codefog/contao-facebook_login](https://github.com/codefog/contao-facebook_login) rely on being able to override the `FrontendUser` class of the core. Since `ContaoUserProvider::loadUserByUsername` will always happen first and since it specifically creates an instance of `Contao\FrontendUser`, the returned instance of `FrontendUser::getInstance()` will always be a `Contao\FrontendUser` object and not a `FacebookLogin\FrontendUser` object for example.

/cc @qzminski