### PR TITLE
[RTM] Generate the method name from hook

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -97,6 +97,6 @@ class RegisterHookListenersPass implements CompilerPassInterface
             return (string) $attributes['method'];
         }
 
-        return 'on' . ucfirst($attributes['hook']);
+        return 'on'.ucfirst($attributes['hook']);
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -56,12 +56,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
 
         foreach ($serviceIds as $serviceId => $tags) {
             foreach ($tags as $attributes) {
-                $this->checkRequiredAttributes($serviceId, $attributes);
-
-                $priority = (int) ($attributes['priority'] ?? 0);
-                $hook = $attributes['hook'];
-
-                $hooks[$hook][$priority][] = [$serviceId, $attributes['method']];
+                $this->addHookCallback($hooks, $serviceId, $attributes);
             }
         }
 
@@ -69,14 +64,14 @@ class RegisterHookListenersPass implements CompilerPassInterface
     }
 
     /**
-     * Checks that required attributes (hook and method) are set.
+     * Adds hook for given service and attributes.
      *
      * @param string $serviceId
      * @param array  $attributes
      *
      * @throws InvalidConfigurationException
      */
-    private function checkRequiredAttributes(string $serviceId, array $attributes): void
+    private function addHookCallback(array &$hooks, string $serviceId, array $attributes): void
     {
         if (!isset($attributes['hook'])) {
             throw new InvalidConfigurationException(
@@ -84,10 +79,24 @@ class RegisterHookListenersPass implements CompilerPassInterface
             );
         }
 
-        if (!isset($attributes['method'])) {
-            throw new InvalidConfigurationException(
-                sprintf('Missing method attribute in tagged hook service with service id "%s"', $serviceId)
-            );
+        $priority = (int) ($attributes['priority'] ?? 0);
+
+        $hooks[$attributes['hook']][$priority][] = [$serviceId, $this->getMethod($attributes)];
+    }
+
+    /**
+     * Gets the method name from config or hook name.
+     *
+     * @param array $attributes
+     *
+     * @return string
+     */
+    private function getMethod(array $attributes): string
+    {
+        if (isset($attributes['method'])) {
+            return (string) $attributes['method'];
         }
+
+        return 'on' . ucfirst($attributes['hook']);
     }
 }

--- a/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -57,6 +57,35 @@ class RegisterHookListenersPassTest extends TestCase
         );
     }
 
+    public function testGeneratesMethodNameIfNoneGiven(): void
+    {
+        $definition = new Definition('Test\HookListener');
+
+        $definition->addTag(
+            'contao.hook',
+            [
+                'hook' => 'initializeSystem',
+            ]
+        );
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'initializeSystem' => [
+                    0 => [
+                        ['test.hook_listener', 'onInitializeSystem'],
+                    ],
+                ],
+            ],
+            $this->getHookListenersFromDefinition($container)[0]
+        );
+    }
+
     public function testSetsTheDefaultPriorityIfNoPriorityGiven(): void
     {
         $attributes = [
@@ -210,21 +239,6 @@ class RegisterHookListenersPassTest extends TestCase
     {
         $definition = new Definition('Test\HookListener');
         $definition->addTag('contao.hook', ['method' => 'onInitializeSystemAfter']);
-
-        $container = $this->getContainerBuilder();
-        $container->setDefinition('test.hook_listener', $definition);
-
-        $pass = new RegisterHookListenersPass();
-
-        $this->expectException(InvalidConfigurationException::class);
-
-        $pass->process($container);
-    }
-
-    public function testFailsIfTheMethodAttributeIsMissing(): void
-    {
-        $definition = new Definition('Test\HookListener');
-        $definition->addTag('contao.hook', ['hook' => 'initializeSystem']);
 
         $container = $this->getContainerBuilder();
         $container->setDefinition('test.hook_listener', $definition);

--- a/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -59,14 +59,12 @@ class RegisterHookListenersPassTest extends TestCase
 
     public function testGeneratesMethodNameIfNoneGiven(): void
     {
-        $definition = new Definition('Test\HookListener');
+        $attributes = [
+            'hook' => 'generatePage',
+        ];
 
-        $definition->addTag(
-            'contao.hook',
-            [
-                'hook' => 'initializeSystem',
-            ]
-        );
+        $definition = new Definition('Test\HookListener');
+        $definition->addTag('contao.hook', $attributes);
 
         $container = $this->getContainerBuilder();
         $container->setDefinition('test.hook_listener', $definition);
@@ -76,9 +74,9 @@ class RegisterHookListenersPassTest extends TestCase
 
         $this->assertSame(
             [
-                'initializeSystem' => [
+                'generatePage' => [
                     0 => [
-                        ['test.hook_listener', 'onInitializeSystem'],
+                        ['test.hook_listener', 'onGeneratePage'],
                     ],
                 ],
             ],


### PR DESCRIPTION
This will remove the need to set a method name for hook event listeners. The name is automatically generated from hook name, if it is not set in the tag.

```
// config.yml
services:
    App\EventListener\MyListener:
        tags:
            - { name: contao.hook, hook: generatePage }
```

```php
// MyListener.php

class MyListener
{
    public function onGeneratePage(…$foo)
    {
    }
}
```