### PR TITLE
set max image size in style

### DIFF
--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -2728,12 +2728,12 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 
 						if ($importantPart->getPosition()->getX() > 0 || $importantPart->getPosition()->getY() > 0 || $importantPart->getSize()->getWidth() < $objFile->width || $importantPart->getSize()->getHeight() < $objFile->height)
 						{
-							$thumbnail .= ' ' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(320)->setHeight(40)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
+							$thumbnail .= ' ' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(320)->setHeight(40)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px 0;vertical-align:bottom;max-width:320px;max-height:40px;width:auto;height:auto"');
 						}
 					}
 					catch (RuntimeException $e)
 					{
-						$thumbnail .= '<br><p class="broken-image" style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto">Broken image!</p>';
+						$thumbnail .= '<br><p class="broken-image" style="margin:0 0 2px -18px">Broken image!</p>';
 					}
 				}
 			}

--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -2717,7 +2717,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 						// Inline the image if no preview image will be generated (see #636)
 						if ($objFile->height !== null && $objFile->height <= 50 && $objFile->width !== null && $objFile->width <= 400)
 						{
-							$thumbnail .= '<br><img src="' . $objFile->dataUri . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="" style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto">';
+							$thumbnail .= '<br><img src="' . $objFile->dataUri . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="" style="margin:0 0 2px -18px">';
 						}
 						else
 						{

--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -2717,11 +2717,11 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 						// Inline the image if no preview image will be generated (see #636)
 						if ($objFile->height !== null && $objFile->height <= 50 && $objFile->width !== null && $objFile->width <= 400)
 						{
-							$thumbnail .= '<br><img src="' . $objFile->dataUri . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="" style="margin:0 0 2px -18px">';
+							$thumbnail .= '<br><img src="' . $objFile->dataUri . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="" style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto">';
 						}
 						else
 						{
-							$thumbnail .= '<br>' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), array(400, 50, ResizeConfiguration::MODE_BOX))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px -18px"');
+							$thumbnail .= '<br>' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), array(400, 50, ResizeConfiguration::MODE_BOX))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto"');
 						}
 
 						$importantPart = \System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded))->getImportantPart();
@@ -2733,7 +2733,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 					}
 					catch (RuntimeException $e)
 					{
-						$thumbnail .= '<br><p class="broken-image" style="margin:0 0 2px -18px">Broken image!</p>';
+						$thumbnail .= '<br><p class="broken-image" style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto">Broken image!</p>';
 					}
 				}
 			}

--- a/src/Resources/contao/widgets/FileSelector.php
+++ b/src/Resources/contao/widgets/FileSelector.php
@@ -572,7 +572,7 @@ class FileSelector extends \Widget
 
 					if ($importantPart->getPosition()->getX() > 0 || $importantPart->getPosition()->getY() > 0 || $importantPart->getSize()->getWidth() < $objFile->width || $importantPart->getSize()->getHeight() < $objFile->height)
 					{
-						$thumbnail .= ' ' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(320)->setHeight(40)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
+						$thumbnail .= ' ' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(320)->setHeight(40)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px 0;vertical-align:bottom;max-width:320px;max-height:40px;width:auto;height:auto"');
 					}
 				}
 

--- a/src/Resources/contao/widgets/FileSelector.php
+++ b/src/Resources/contao/widgets/FileSelector.php
@@ -567,7 +567,7 @@ class FileSelector extends \Widget
 				// Generate thumbnail
 				if ($objFile->isImage && $objFile->viewHeight > 0 && \Config::get('thumbnails') && ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')))
 				{
-					$thumbnail .= '<br>' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), array(400, 50, ResizeConfiguration::MODE_BOX))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px -18px"');
+					$thumbnail .= '<br>' . \Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded), array(400, 50, ResizeConfiguration::MODE_BOX))->getUrl(TL_ROOT), '', 'style="margin:0 0 2px -18px;max-width:400px;max-height:50px;width:auto;height:auto"');
 					$importantPart = \System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . rawurldecode($currentEncoded))->getImportantPart();
 
 					if ($importantPart->getPosition()->getX() > 0 || $importantPart->getPosition()->getY() > 0 || $importantPart->getSize()->getWidth() < $objFile->width || $importantPart->getSize()->getHeight() < $objFile->height)


### PR DESCRIPTION
Currently it can still happen that images in the file manager are displayed in their full size and thus break the layout (see https://github.com/contao/core-bundle/issues/1173 for example). Adding this inline style would at least prevent the image from breaking the layout.