### PR TITLE
Copy child tables without setting tstamp if no tstamp column exist

### DIFF
--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -1142,7 +1142,11 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					}
 
 					$copy[$v][$objCTable->id]['pid'] = $insertID;
-					$copy[$v][$objCTable->id]['tstamp'] = $time;
+
+					if ($objCTable->tstamp)
+					{
+						$copy[$v][$objCTable->id]['tstamp'] = $time;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
An SQL error occurs when copying an entry in a table that has a child table **without a tstamp column** in the 'ctable' array.

There should be a check if a tstamp column exists before setting a tstamp value in the insert dataset.