### PR TITLE
Don't handle exceptions when the request it isn't a Contao request

### DIFF
--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -115,6 +115,7 @@ services:
             - "@twig"
             - "@contao.framework"
             - "@security.token_storage"
+            - "@contao.routing.scope_matcher"
             - "@logger"
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: -96 }

--- a/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -351,7 +351,8 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('twig', (string) $definition->getArgument(1));
         $this->assertSame('contao.framework', (string) $definition->getArgument(2));
         $this->assertSame('security.token_storage', (string) $definition->getArgument(3));
-        $this->assertSame('logger', (string) $definition->getArgument(4));
+        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(4));
+        $this->assertSame('logger', (string) $definition->getArgument(5));
 
         $tags = $definition->getTags();
 

--- a/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -294,7 +294,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     /**
      * Tests that the listener is bypassed if the request is not a Contao request.
      */
-    public function testDoesNothingIfItsNotAContaoRequest(): void
+    public function testDoesNothingIfItsNotAContaoRequest()
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
@@ -311,7 +311,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     /**
      * Tests that the listener is bypassed if the request is not a master request.
      */
-    public function testDoesNothingIfItsNotAMasterRequest(): void
+    public function testDoesNothingIfItsNotAMasterRequest()
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
@@ -358,7 +358,7 @@ class PrettyErrorScreenListenerTest extends TestCase
      *
      * @return Request
      */
-    private function mockContaoRequest(string $scope = 'frontend'): Request
+    private function mockContaoRequest($scope = 'frontend')
     {
         $request = new Request();
         $request->attributes->set('_scope', $scope);

--- a/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -68,6 +68,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             $twig,
             $this->mockContaoFramework(),
             $this->mockTokenStorage(),
+            $this->mockScopeMatcher(),
             $logger
         );
     }
@@ -93,12 +94,13 @@ class PrettyErrorScreenListenerTest extends TestCase
             $twig,
             $this->mockContaoFramework(),
             $this->mockTokenStorage(BackendUser::class),
+            $this->mockScopeMatcher(),
             $logger
         );
 
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('backend'),
             HttpKernelInterface::MASTER_REQUEST,
             new InternalServerErrorHttpException('', new InternalServerErrorException())
         );
@@ -127,7 +129,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('frontend'),
             HttpKernelInterface::MASTER_REQUEST,
             $exception
         );
@@ -164,7 +166,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('frontend'),
             HttpKernelInterface::MASTER_REQUEST,
             new ServiceUnavailableHttpException('', new ServiceUnavailableException())
         );
@@ -186,7 +188,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('frontend'),
             HttpKernelInterface::MASTER_REQUEST,
             new ConflictHttpException()
         );
@@ -208,7 +210,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('frontend'),
             HttpKernelInterface::MASTER_REQUEST,
             new InternalServerErrorHttpException('', new ForwardPageNotFoundException())
         );
@@ -238,6 +240,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             $twig,
             $this->mockContaoFramework(),
             $this->mockTokenStorage(),
+            $this->mockScopeMatcher(),
             $logger
         );
 
@@ -256,7 +259,7 @@ class PrettyErrorScreenListenerTest extends TestCase
      */
     public function testDoesNothingIfTheFormatIsNotHtml()
     {
-        $request = new Request();
+        $request = $this->mockContaoRequest('frontend');
         $request->attributes->set('_format', 'json');
 
         $event = new GetResponseForExceptionEvent(
@@ -266,20 +269,9 @@ class PrettyErrorScreenListenerTest extends TestCase
             new InternalServerErrorHttpException('', new InsecureInstallationException())
         );
 
-        /** @var PrettyErrorScreenListener|\PHPUnit_Framework_MockObject_MockObject $listener */
-        $listener = $this
-            ->getMockBuilder(PrettyErrorScreenListener::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['handleException'])
-            ->getMock()
-        ;
+        $this->listener->onKernelException($event);
 
-        $listener
-            ->expects($this->never())
-            ->method('handleException')
-        ;
-
-        $listener->onKernelException($event);
+        $this->assertFalse($event->hasResponse());
     }
 
     /**
@@ -289,9 +281,43 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $event = new GetResponseForExceptionEvent(
             $this->mockKernel(),
-            new Request(),
+            $this->mockContaoRequest('frontend'),
             HttpKernelInterface::MASTER_REQUEST,
             new AccessDeniedHttpException('', new AccessDeniedException())
+        );
+
+        $this->listener->onKernelException($event);
+
+        $this->assertFalse($event->hasResponse());
+    }
+
+    /**
+     * Tests that the listener is bypassed if the request is not a Contao request.
+     */
+    public function testDoesNothingIfItsNotAContaoRequest(): void
+    {
+        $event = new GetResponseForExceptionEvent(
+            $this->mockKernel(),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            new InternalServerErrorHttpException('', new InternalServerErrorHttpException())
+        );
+
+        $this->listener->onKernelException($event);
+
+        $this->assertFalse($event->hasResponse());
+    }
+
+    /**
+     * Tests that the listener is bypassed if the request is not a master request.
+     */
+    public function testDoesNothingIfItsNotAMasterRequest(): void
+    {
+        $event = new GetResponseForExceptionEvent(
+            $this->mockKernel(),
+            $this->mockContaoRequest('frontend'),
+            HttpKernelInterface::SUB_REQUEST,
+            new InternalServerErrorHttpException('', new InternalServerErrorHttpException())
         );
 
         $this->listener->onKernelException($event);
@@ -323,5 +349,20 @@ class PrettyErrorScreenListenerTest extends TestCase
         ;
 
         return $tokenStorage;
+    }
+
+    /**
+     * Mocks a Contao request.
+     *
+     * @param string $scope
+     *
+     * @return Request
+     */
+    private function mockContaoRequest(string $scope = 'frontend'): Request
+    {
+        $request = new Request();
+        $request->attributes->set('_scope', $scope);
+
+        return $request;
     }
 }


### PR DESCRIPTION
Let exceptions be exceptions if the exceptions are not originating from a Contao request.

There is also a fix ready for the `develop` branch: https://github.com/bytehead/core-bundle/tree/fix/pretty-error-screen-listener