### PR TITLE
Fixed use of kernel service in assets packages pass

### DIFF
--- a/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
+++ b/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
@@ -59,7 +59,6 @@ class AddAssetsPackagesPass implements CompilerPassInterface
             }
 
             $packageName = $this->getBundlePackageName($name);
-
             $serviceId = 'assets._package_'.$packageName;
             $basePath = 'bundles/'.preg_replace('/bundle$/', '', strtolower($name));
 

--- a/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
+++ b/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AddAssetsPackagesPass implements CompilerPassInterface
 {
@@ -51,22 +50,18 @@ class AddAssetsPackagesPass implements CompilerPassInterface
             $version = new Reference('assets.empty_version_strategy');
         }
 
-        /** @var Bundle[] $bundles */
-        $bundles = $container->get('kernel')->getBundles();
+        $bundles = $container->getParameter('kernel.bundles');
+        $meta = $container->getParameter('kernel.bundles_metadata');
 
-        foreach ($bundles as $bundle) {
-            if (!is_dir($originDir = $bundle->getPath().'/Resources/public')) {
+        foreach ($bundles as $name => $class) {
+            if (!is_dir($originDir = $meta[$name]['path'].'/Resources/public')) {
                 continue;
             }
 
-            if ($extension = $bundle->getContainerExtension()) {
-                $packageName = $extension->getAlias();
-            } else {
-                $packageName = $this->getBundlePackageName($bundle);
-            }
+            $packageName = $this->getBundlePackageName($name);
 
             $serviceId = 'assets._package_'.$packageName;
-            $basePath = 'bundles/'.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+            $basePath = 'bundles/'.preg_replace('/bundle$/', '', strtolower($name));
 
             $container->setDefinition($serviceId, $this->createPackageDefinition($basePath, $version, $context));
             $packages->addMethodCall('addPackage', [$packageName, new Reference($serviceId)]);
@@ -149,14 +144,12 @@ class AddAssetsPackagesPass implements CompilerPassInterface
     /**
      * Returns a bundle package name emulating what a bundle extension would look like.
      *
-     * @param Bundle $bundle
+     * @param string $className
      *
      * @return string
      */
-    private function getBundlePackageName(Bundle $bundle): string
+    private function getBundlePackageName(string $className): string
     {
-        $className = $bundle->getName();
-
         if ('Bundle' === substr($className, -6)) {
             $className = substr($className, 0, -6);
         }

--- a/tests/DependencyInjection/Compiler/AddAssetsPackagesPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddAssetsPackagesPassTest.php
@@ -19,10 +19,7 @@ use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\Kernel;
 
 class AddAssetsPackagesPassTest extends TestCase
 {
@@ -55,24 +52,10 @@ class AddAssetsPackagesPassTest extends TestCase
 
     public function testIgnoresBundlesWithoutPublicFolder(): void
     {
-        $bundle = $this->mockBundle('FooBarBundle', false);
-
-        $bundle
-            ->expects($this->never())
-            ->method('getContainerExtension')
-        ;
-
-        $kernel = $this->createMock(Kernel::class);
-
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle])
-        ;
-
         $container = $this->mockContainer();
         $container->setDefinition('assets.packages', new Definition(Packages::class));
-        $container->set('kernel', $kernel);
+        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
 
         $pass = new AddAssetsPackagesPass();
         $pass->process($container);
@@ -80,74 +63,17 @@ class AddAssetsPackagesPassTest extends TestCase
         $this->assertEmpty($container->getDefinition('assets.packages')->getMethodCalls());
     }
 
-    public function testUsesTheBundleExtensionAliasAsPackageName(): void
+    public function testUsesTheBundleNameAsPackageName(): void
     {
-        $extension = $this->createMock(ExtensionInterface::class);
+        $bundlePath = static::getTempDir().'/FooBarBundle';
 
-        $extension
-            ->expects($this->once())
-            ->method('getAlias')
-            ->willReturn('foo_bar')
-        ;
-
-        $bundle = $this->mockBundle('BarBundle');
-
-        $bundle
-            ->expects($this->once())
-            ->method('getContainerExtension')
-            ->willReturn($extension)
-        ;
-
-        $kernel = $this->createMock(Kernel::class);
-
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle])
-        ;
-
-        $container = $this->mockContainer();
-        $container->setDefinition('assets.packages', new Definition(Packages::class));
-        $container->set('kernel', $kernel);
-
-        $pass = new AddAssetsPackagesPass();
-        $pass->process($container);
-
-        $calls = $container->getDefinition('assets.packages')->getMethodCalls();
-
-        $this->assertCount(1, $calls);
-        $this->assertSame('addPackage', $calls[0][0]);
-        $this->assertSame('foo_bar', $calls[0][1][0]);
-        $this->assertTrue($container->hasDefinition('assets._package_foo_bar'));
-
-        $service = $container->getDefinition('assets._package_foo_bar');
-        $this->assertSame('bundles/bar', $service->getArgument(0));
-        $this->assertSame('assets.empty_version_strategy', (string) $service->getArgument(1));
-        $this->assertSame('contao.assets.plugins_context', (string) $service->getArgument(2));
-    }
-
-    public function testFallsBackToTheBundleNameAsPackageName(): void
-    {
-        $bundle = $this->mockBundle('FooBarBundle');
-
-        $bundle
-            ->expects($this->once())
-            ->method('getContainerExtension')
-            ->willReturn(null)
-        ;
-
-        $kernel = $this->createMock(Kernel::class);
-
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle])
-        ;
+        (new Filesystem())->mkdir($bundlePath.'/Resources/public');
 
         $container = $this->mockContainer();
         $container->setDefinition('assets.packages', new Definition(Packages::class));
         $container->setDefinition('assets.empty_version_strategy', new Definition(EmptyVersionStrategy::class));
-        $container->set('kernel', $kernel);
+        $container->setParameter('kernel.bundles', ['FooBarBundle' => 'Foo\Bar\FooBarBundle']);
+        $container->setParameter('kernel.bundles_metadata', ['FooBarBundle' => ['path' => $bundlePath]]);
 
         $pass = new AddAssetsPackagesPass();
         $pass->process($container);
@@ -167,46 +93,38 @@ class AddAssetsPackagesPassTest extends TestCase
 
     public function testUsesTheDefaultVersionStrategyForBundles(): void
     {
-        $bundle = $this->mockBundle('BarBundle');
-        $kernel = $this->createMock(Kernel::class);
+        $bundlePath = static::getTempDir().'/FooBarBundle';
 
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle])
-        ;
+        (new Filesystem())->mkdir($bundlePath.'/Resources/public');
 
         $container = $this->mockContainer();
         $container->setDefinition('assets.packages', new Definition(Packages::class));
         $container->setDefinition('assets.empty_version_strategy', new Definition(EmptyVersionStrategy::class));
         $container->setDefinition('assets._version_default', new Definition(StaticVersionStrategy::class));
-        $container->set('kernel', $kernel);
+        $container->setParameter('kernel.bundles', ['FooBarBundle' => 'Foo\Bar\FooBarBundle']);
+        $container->setParameter('kernel.bundles_metadata', ['FooBarBundle' => ['path' => $bundlePath]]);
 
         $pass = new AddAssetsPackagesPass();
         $pass->process($container);
 
-        $this->assertTrue($container->hasDefinition('assets._package_bar'));
+        $this->assertTrue($container->hasDefinition('assets._package_foo_bar'));
 
-        $service = $container->getDefinition('assets._package_bar');
+        $service = $container->getDefinition('assets._package_foo_bar');
 
         $this->assertSame('assets._version_default', (string) $service->getArgument(1));
     }
 
     public function testSupportsBundlesWithWrongSuffix(): void
     {
-        $bundle = $this->mockBundle('FooBarPackage');
-        $kernel = $this->createMock(Kernel::class);
+        $bundlePath = static::getTempDir().'/FooBarPackage';
 
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle])
-        ;
+        (new Filesystem())->mkdir($bundlePath.'/Resources/public');
 
         $container = $this->mockContainer();
         $container->setDefinition('assets.packages', new Definition(Packages::class));
         $container->setDefinition('assets.empty_version_strategy', new Definition(EmptyVersionStrategy::class));
-        $container->set('kernel', $kernel);
+        $container->setParameter('kernel.bundles', ['FooBarPackage' => 'Foo\Bar\FooBarPackage']);
+        $container->setParameter('kernel.bundles_metadata', ['FooBarPackage' => ['path' => $bundlePath]]);
 
         $pass = new AddAssetsPackagesPass();
         $pass->process($container);
@@ -225,17 +143,10 @@ class AddAssetsPackagesPassTest extends TestCase
             'vendor/bar' => '3.2.1',
         ];
 
-        $kernel = $this->createMock(Kernel::class);
-
-        $kernel
-            ->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([])
-        ;
-
         $container = $this->mockContainer();
         $container->setDefinition('assets.packages', new Definition(Packages::class));
-        $container->set('kernel', $kernel);
+        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
         $container->setParameter('kernel.packages', $composer);
 
         $pass = new AddAssetsPackagesPass();
@@ -253,39 +164,5 @@ class AddAssetsPackagesPassTest extends TestCase
         $version = $container->getDefinition('assets._version_contao-components/foo');
 
         $this->assertSame('1.2.3', $version->getArgument(0));
-    }
-
-    /**
-     * Mocks a bundle.
-     *
-     * @param string $name
-     * @param bool   $addPublicFolder
-     *
-     * @return Bundle|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private function mockBundle(string $name, bool $addPublicFolder = true): Bundle
-    {
-        /** @var Bundle|\PHPUnit_Framework_MockObject_MockObject $bundle */
-        $bundle = $this
-            ->getMockBuilder(Bundle::class)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
-            ->setMockClassName($name)
-            ->getMock()
-        ;
-
-        $bundle
-            ->expects($this->once())
-            ->method('getPath')
-            ->willReturn(static::getTempDir().'/'.$bundle->getName())
-        ;
-
-        if ($addPublicFolder) {
-            (new Filesystem())->mkdir(static::getTempDir().'/'.$bundle->getName().'/Resources/public');
-        }
-
-        return $bundle;
     }
 }


### PR DESCRIPTION
This will slightly change the behavior, we're always using a name generated from bundle class instead of using the extension alias if available. It should not make a difference for correctly configured bundles, except for the core bundle where it's even better, because previously it was `contao` and now it's `contao_core`.