### PR TITLE
Removed scrutinizer-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Contao 4 core bundle
 ====================
 
 [![](https://img.shields.io/travis/contao/core-bundle/master.svg?style=flat-square)](https://travis-ci.org/contao/core-bundle/)
-[![](https://img.shields.io/scrutinizer/g/contao/core-bundle/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/contao/core-bundle/)
 [![](https://img.shields.io/coveralls/contao/core-bundle/master.svg?style=flat-square)](https://coveralls.io/github/contao/core-bundle)
 [![](https://img.shields.io/packagist/v/contao/core-bundle.svg?style=flat-square)](https://packagist.org/packages/contao/core-bundle)
 [![](https://img.shields.io/packagist/dt/contao/core-bundle.svg?style=flat-square)](https://packagist.org/packages/contao/core-bundle)


### PR DESCRIPTION
Because it's broken:
<img width="592" alt="bildschirmfoto 2017-11-17 um 20 00 17" src="https://user-images.githubusercontent.com/754921/32963982-f9813924-cbd1-11e7-9620-7cf4b6e00117.png">
