### PR TITLE
Add token_lifetime to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ contao:
             interlace:    plane
     security:
         disable_ip_check: false
+        token_lifetime: 3600
 ```
 
 You can also overwrite any parameter stored in the `localconfig.php` file:


### PR DESCRIPTION
Add default `token_lifetime` to example configuration.