### PR TITLE
remove frameborder attribute from media iframes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "contao-components/colorbox": "^1.6",
         "contao-components/colorpicker": "^1.4.0.1",
         "contao-components/compass": "^0.12",
-        "contao-components/contao": "^7.1",
+        "contao-components/contao": "^7.1.4",
         "contao-components/datepicker": "^2.2.0.2",
         "contao-components/dropzone": "^4.1.1",
         "contao-components/highlight": "^8.9",

--- a/src/Resources/contao/templates/elements/ce_vimeo.html5
+++ b/src/Resources/contao/templates/elements/ce_vimeo.html5
@@ -2,6 +2,6 @@
 
 <?php $this->block('content'); ?>
 
-  <iframe<?= $this->size ?> src="<?= $this->src ?>" frameborder="0" allowfullscreen></iframe>
+  <iframe<?= $this->size ?> src="<?= $this->src ?>" allowfullscreen></iframe>
 
 <?php $this->endblock(); ?>

--- a/src/Resources/contao/templates/elements/ce_youtube.html5
+++ b/src/Resources/contao/templates/elements/ce_youtube.html5
@@ -2,6 +2,6 @@
 
 <?php $this->block('content'); ?>
 
-  <iframe<?= $this->size ?> src="<?= $this->src ?>" frameborder="0" allowfullscreen></iframe>
+  <iframe<?= $this->size ?> src="<?= $this->src ?>" allowfullscreen></iframe>
 
 <?php $this->endblock(); ?>


### PR DESCRIPTION
Having `frameborder="0"` on iframes produces the following validation error:
```
The frameborder attribute on the iframe element is obsolete. Use CSS instead.
```
See https://validator.w3.org/nu/?doc=https%3A%2F%2Fdemo.contao.org%2Fen%2Fmedia-elements.html

_Note:_ there are a few places in the back end where `frameborder="0"` is used on iframes as well (`be_preview.html5`, `core.js`). Those are not changed with this PR.