### PR TITLE
[RFC] Remove obsolete fulltext index

### DIFF
--- a/src/Resources/contao/dca/tl_search.php
+++ b/src/Resources/contao/dca/tl_search.php
@@ -24,8 +24,7 @@ $GLOBALS['TL_DCA']['tl_search'] = array
 			(
 				'id' => 'primary',
 				'url' => 'unique',
-				'checksum,pid' => 'unique',
-				'text' => 'fulltext'
+				'checksum,pid' => 'unique'
 			)
 		)
 	),


### PR DESCRIPTION
AFAIK we don’t use the fulltext index but only `WHERE text REGEXP ?` in the search module.