### PR TITLE
[RFC] increase meta description length

### DIFF
--- a/src/Resources/contao/classes/Frontend.php
+++ b/src/Resources/contao/classes/Frontend.php
@@ -581,7 +581,7 @@ abstract class Frontend extends \Controller
 		$strText = $this->replaceInsertTags($strText, false);
 		$strText = strip_tags($strText);
 		$strText = str_replace("\n", ' ', $strText);
-		$strText = \StringUtil::substr($strText, 160);
+		$strText = \StringUtil::substr($strText, 230);
 
 		return trim($strText);
 	}


### PR DESCRIPTION
Since around November 30th Google has been showing longer snippets in the search results. According to [Rank Ranger](https://www.rankranger.com/google-serp-features) the average length has been increased from ~175 to almost 230. Other sites quote the new length being 320 characters, but I could not find a reliable source for that.

Some posts discussing this:

* https://www.inc.com/john-lincoln/googles-new-meta-description-length-what-you-need-to-know.html
* https://www.seroundtable.com/google-extends-snippets-320-characters-24862.html
* https://searchengineland.com/google-officially-increases-length-snippets-search-results-287596

I have used a character limit of 230 in this PR. I am not sure what it should be in the end though. May be this should actually also be configurable?