### PR TITLE
Never merge cache-control headers

### DIFF
--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -147,7 +147,7 @@ class MergeHttpHeadersListener
 
             $uniqueKey = $this->getUniqueKey($name);
             
-            // Never merge cache-control headers, see https://github.com/contao/core-bundle/issues/1246
+            // Never merge cache-control headers (see #1246)
             if ('cache-control' === $uniqueKey) {
                 continue;
             }

--- a/src/EventListener/MergeHttpHeadersListener.php
+++ b/src/EventListener/MergeHttpHeadersListener.php
@@ -146,6 +146,11 @@ class MergeHttpHeadersListener
             list($name, $content) = explode(':', $header, 2);
 
             $uniqueKey = $this->getUniqueKey($name);
+            
+            // Never merge cache-control headers, see https://github.com/contao/core-bundle/issues/1246
+            if ('cache-control' === $uniqueKey) {
+                continue;
+            }
 
             if (\in_array($uniqueKey, $this->multiHeaders, true)) {
                 $response->headers->set($uniqueKey, trim($content), false);


### PR DESCRIPTION
This is the quick fix for Contao 4.4.
I'm working on a better solution for Contao 4.5 (which is not possible to merge in 4.4 because of security and request token handling).