### PR TITLE
RFC DcaSchemaProvider: use default collation when setting custom charset

### DIFF
--- a/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -96,6 +96,8 @@ class DcaSchemaProvider
 
                 if (preg_match('/DEFAULT CHARSET=([^ ]+)/i', $definitions['TABLE_OPTIONS'], $match)) {
                     $table->addOption('charset', $match[1]);
+                    // reset table option to default collation to prevent conflicts 
+                    $table->addOption('collate', 'DEFAULT');
                 }
 
                 if (preg_match('/COLLATE ([^ ]+)/i', $definitions['TABLE_OPTIONS'], $match)) {


### PR DESCRIPTION
If an extension sets a character set in the table options without a collation ([like Haste does](https://github.com/codefog/contao-haste/blob/master/library/Haste/Model/Relations.php#L507)) this might lead to an invalid data definition statement in the install tool like the following

`SQLSTATE[42000]: Syntax error or access violation: 1253 COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8'`

The character set and collation are set by the config defaults and then overwritten individually if the respective table options are set. So setting one without unsetting the other (or resetting to default) is probably a bad thing.

If setting a collation without a character set is a valid use case this should be handled as well.
If setting a charset without a collation isn't a valid use case and this is no bug we should document that somewhere. :-)

