### PR TITLE
Use the BINARY flag instead of COLLATE *_bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### DEV
 
+ * Use the `BINARY` flag instead of `COLLATE utf8mb4_bin` (see #1286).
  * Use a custom toggle parameter for content elements (see #1291).
  * Use array_key_exists() when tracking modified model fields (see #1290).
  * Dynamically register the user session response listener (see #1293).

--- a/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -17,8 +17,10 @@ use Contao\Database\Installer;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 
 class DcaSchemaProvider
@@ -73,6 +75,12 @@ class DcaSchemaProvider
                 foreach ($definitions['SCHEMA_FIELDS'] as $fieldName => $config) {
                     $options = $config;
                     unset($options['name'], $options['type']);
+
+                    // Use the binary collation if the "case_sensitive" option is set
+                    if ($this->isCaseSensitive($config)) {
+                        $options['platformOptions']['collation'] = $this->getBinaryCollation($table);
+                    }
+
                     $table->addColumn($config['name'], $config['type'], $options);
                 }
             }
@@ -148,7 +156,14 @@ class DcaSchemaProvider
      */
     private function createSchemaFromDca(): Schema
     {
-        $schema = new Schema();
+        $config = new SchemaConfig();
+        $params = $this->doctrine->getConnection()->getParams();
+
+        if (isset($params['defaultTableOptions'])) {
+            $config->setDefaultTableOptions($params['defaultTableOptions']);
+        }
+
+        $schema = new Schema([], [], $config);
 
         $this->appendToSchema($schema);
 
@@ -176,7 +191,8 @@ class DcaSchemaProvider
 
         $this->setLengthAndPrecisionByType($type, $dbType, $length, $scale, $precision, $fixed);
 
-        $type = $this->doctrine->getConnection()->getDatabasePlatform()->getDoctrineTypeMapping($type);
+        $connection = $this->doctrine->getConnection();
+        $type = $connection->getDatabasePlatform()->getDoctrineTypeMapping($type);
 
         if (0 === $length) {
             $length = null;
@@ -188,6 +204,11 @@ class DcaSchemaProvider
 
         if (preg_match('/collate ([^ ]+)/i', $def, $match)) {
             $collation = $match[1];
+        }
+
+        // Use the binary collation if the BINARY flag is set (see #1286)
+        if (preg_match('/\bbinary\b/i', $def, $match)) {
+            $collation = $this->getBinaryCollation($table);
         }
 
         $options = [
@@ -387,8 +408,8 @@ class DcaSchemaProvider
     private function getMaximumIndexLength(Table $table, string $column): int
     {
         $indexLength = $this->getDefaultIndexLength($table);
+        $collation = $table->getOption('collate');
         $connection = $this->doctrine->getConnection();
-        $collation = $connection->getParams()['defaultTableOptions']['collate'];
 
         // Read the table collation if the table exists
         if ($connection->getSchemaManager()->tablesExist([$table->getName()])) {
@@ -437,5 +458,37 @@ class DcaSchemaProvider
         }
 
         return 767;
+    }
+
+    /**
+     * Checks if a field has the case-sensitive flag.
+     *
+     * @param array $config
+     *
+     * @return bool
+     */
+    private function isCaseSensitive(array $config): bool
+    {
+        if (!isset($config['customSchemaOptions']['case_sensitive'])) {
+            return false;
+        }
+
+        return true === $config['customSchemaOptions']['case_sensitive'];
+    }
+
+    /**
+     * Returns the binary collation depending on the charset.
+     *
+     * @param Table $table
+     *
+     * @return string|null
+     */
+    private function getBinaryCollation(Table $table): ?string
+    {
+        if (!$table->hasOption('charset')) {
+            return null;
+        }
+
+        return $table->getOption('charset').'_bin';
     }
 }

--- a/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -63,8 +63,6 @@ class DcaSchemaProvider
      * Adds the DCA data to the Doctrine schema.
      *
      * @param Schema $schema
-     *
-     * @throws \LogicException
      */
     public function appendToSchema(Schema $schema): void
     {
@@ -80,10 +78,6 @@ class DcaSchemaProvider
 
                     // Use the binary collation if the "case_sensitive" option is set
                     if ($this->isCaseSensitive($config)) {
-                        if (isset($options['platformOptions']['collation'])) {
-                            throw new \LogicException('Cannot handle both a collation and the case_sensitive flag.');
-                        }
-
                         $options['platformOptions']['collation'] = $this->getBinaryCollation($table);
                     }
 
@@ -182,8 +176,6 @@ class DcaSchemaProvider
      * @param Table  $table
      * @param string $columnName
      * @param string $sql
-     *
-     * @throws \LogicException
      */
     private function parseColumnSql(Table $table, string $columnName, string $sql): void
     {
@@ -216,10 +208,6 @@ class DcaSchemaProvider
 
         // Use the binary collation if the BINARY flag is set (see #1286)
         if (0 === strncasecmp($def, 'binary ', 7)) {
-            if (null !== $collation) {
-                throw new \LogicException('Cannot handle both a collation and the binary flag.');
-            }
-
             $collation = $this->getBinaryCollation($table);
         }
 

--- a/tests/Doctrine/DoctrineTestCase.php
+++ b/tests/Doctrine/DoctrineTestCase.php
@@ -76,6 +76,7 @@ abstract class DoctrineTestCase extends TestCase
             ->willReturn(
                 [
                     'defaultTableOptions' => [
+                        'charset' => 'utf8mb4',
                         'collate' => 'utf8mb4_unicode_ci',
                     ],
                 ]

--- a/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -144,7 +144,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                         'TABLE_FIELDS' => [
                             'id' => "`id` int(10) NOT NULL default '0'",
                             'pid' => '`pid` int(10) NULL',
-                            'title' => "`title` varchar(128) COLLATE utf8mb4_bin NOT NULL default ''",
+                            'title' => "`title` varchar(128) BINARY NOT NULL default ''",
                             'uppercase' => "`uppercase` varchar(64) NOT NULL DEFAULT 'Foobar'",
                             'teaser' => '`teaser` tinytext NULL',
                             'description' => '`description` text NULL',
@@ -166,7 +166,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                         'SCHEMA_FIELDS' => [
                             ['name' => 'id', 'type' => 'integer'],
                             ['name' => 'pid', 'type' => 'integer', 'notnull' => false],
-                            ['name' => 'title', 'type' => 'string', 'length' => 128, 'platformOptions' => ['collation' => 'utf8mb4_bin']],
+                            ['name' => 'title', 'type' => 'string', 'length' => 128, 'customSchemaOptions' => ['case_sensitive' => true]],
                             ['name' => 'uppercase', 'type' => 'string', 'length' => 64, 'default' => 'Foobar'],
                             ['name' => 'teaser', 'type' => 'text', 'notnull' => false, 'length' => MySqlPlatform::LENGTH_LIMIT_TINYTEXT],
                             ['name' => 'description', 'type' => 'text', 'notnull' => false, 'length' => MySqlPlatform::LENGTH_LIMIT_TEXT],
@@ -189,7 +189,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                         'TABLE_FIELDS' => [
                             'id' => "`id` int(10) NOT NULL default '0'",
                             'pid' => '`pid` int(10) NULL',
-                            'title' => "`title` varchar(128) COLLATE utf8mb4_bin NOT NULL default ''",
+                            'title' => "`title` varchar(128) BINARY NOT NULL default ''",
                             'uppercase' => "`uppercase` varchar(64) NOT NULL DEFAULT 'Foobar'",
                             'teaser' => '`teaser` tinytext NULL',
                             'description' => '`description` text NULL',


### PR DESCRIPTION
This PR fixes #1286 as discussed with @aschempp. It handles the following cases:

* `'sql' => "varchar(128) BINARY NOT NULL default ''"`
* `'sql' => ['type' => 'string', 'length' => 128, 'not_null' => false, 'default' => '', 'customSchemaOptions' => ['case_sensitive' => true]]`
