### PR TITLE
check if third size parameter is actually a string

### DIFF
--- a/src/Image/PictureFactory.php
+++ b/src/Image/PictureFactory.php
@@ -102,7 +102,7 @@ class PictureFactory implements PictureFactoryInterface
             $image = $this->imageFactory->create($path);
         }
 
-        if (\is_array($size) && isset($size[2]) && 1 === substr_count($size[2], '_')) {
+        if (\is_array($size) && isset($size[2]) && \is_string($size[2]) && 1 === substr_count($size[2], '_')) {
             $image->setImportantPart($this->imageFactory->getImportantPartFromLegacyMode($image, $size[2]));
             $size[2] = ResizeConfigurationInterface::MODE_CROP;
         }


### PR DESCRIPTION
If the third element of the `$size` parameter for `PictureFactory::create` is an actual integer (an image size ID) instead of a string, the following error will occur:
```
Symfony\Component\Debug\Exception\FatalThrowableError:
Type error: substr_count() expects parameter 1 to be string, integer given

  at vendor\contao\core-bundle\src\Image\PictureFactory.php:100
  at substr_count(5, '_')
     (vendor\contao\core-bundle\src\Image\PictureFactory.php:100)
  at Contao\CoreBundle\Image\PictureFactory->create('files/foo.jpg', array('', '', 5))
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:1527)
  at Contao\Controller::addImageToTemplate(object(FrontendTemplate), array('id' => '16', 'pid' => '1', 'tstamp' => '1515681465', 'headline' => 'Lorem ipsum', 'alias' => 'lorem-ipsum', 'author' => '2', 'date' => '1515492660', 'time' => '1515492660', 'subheadline' => 'Lorem ipsum dolor sit amet, consetetur sadipscing', 'teaser' => '…', 'addImage' => '1', 'overwriteMeta' => '', 'singleSRC' => 'files/foo.jpg', 'alt' => '', 'imageTitle' => '', 'size' => array('', '', 5), …), 0, null, object(FilesModel))
     (src\Intomedia\WebsiteBundle\EventListener\HookListener.php:46)
  at Intomedia\WebsiteBundle\EventListener\HookListener->onParseArticles(object(FrontendTemplate), array('id' => '16', 'pid' => '1', 'tstamp' => '1515681465', 'headline' => 'Lorem ipsum', 'alias' => 'lorem-ipsum', 'author' => '2', 'date' => '1515492660', 'time' => '1515492660', 'subheadline' => 'Lorem ipsum dolor sit amet, consetetur sadipscing', 'teaser' => '…', 'addImage' => '1', 'overwriteMeta' => '', 'singleSRC' => 'files/foo.jpg', 'alt' => '', 'imageTitle' => '', 'size' => array('', '', 5), …), object(NewsListModule))
     (vendor\contao\news-bundle\src\Resources\contao\modules\ModuleNews.php:204)
  at Contao\ModuleNews->parseArticle(object(NewsModel), false, ' featured odd', 2)
     (vendor\contao\news-bundle\src\Resources\contao\modules\ModuleNews.php:237)
  at Contao\ModuleNews->parseArticles(object(Collection))
     (vendor\contao\news-bundle\src\Resources\contao\modules\ModuleNewsList.php:150)
  at Contao\ModuleNewsList->compile()
     (vendor\contao\core-bundle\src\Resources\contao\modules\Module.php:227)
  at Contao\Module->generate()
     (vendor\contao\news-bundle\src\Resources\contao\modules\ModuleNewsList.php:65)
  at Contao\ModuleNewsList->generate()
     (vendor\codefog\contao-news_categories\src\FrontendModule\NewsListModule.php:42)
  at Codefog\NewsCategoriesBundle\FrontendModule\NewsListModule->generate()
     (vendor\contao\core-bundle\src\Resources\contao\elements\ContentModule.php:69)
  at Contao\ContentModule->generate()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:486)
  at Contao\Controller::getContentElement(object(ContentModel), 'main')
     (vendor\contao\core-bundle\src\Resources\contao\modules\ModuleArticle.php:186)
  at Contao\ModuleArticle->compile()
     (vendor\contao\core-bundle\src\Resources\contao\modules\Module.php:227)
  at Contao\Module->generate()
     (vendor\contao\core-bundle\src\Resources\contao\modules\ModuleArticle.php:67)
  at Contao\ModuleArticle->generate(false)
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:425)
  at Contao\Controller::getArticle(object(ArticleModel), false, false, 'main')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:283)
  at Contao\Controller::getFrontendModule('0', 'main')
     (vendor\contao\core-bundle\src\Resources\contao\pages\PageRegular.php:178)
  at Contao\PageRegular->prepare(object(PageModel))
     (vendor\contao\core-bundle\src\Resources\contao\pages\PageRegular.php:50)
  at Contao\PageRegular->getResponse(object(PageModel), true)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\FrontendIndex.php:329)
  at Contao\FrontendIndex->renderPage(object(Collection))
     (vendor\contao\core-bundle\src\Resources\contao\controllers\FrontendIndex.php:77)
  at Contao\FrontendIndex->run()
     (vendor\contao\core-bundle\src\Controller\FrontendController.php:40)
  at Contao\CoreBundle\Controller\FrontendController->indexAction()
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web\app_dev.php:65)
```
/cc @ausi 