### PR TITLE
[POC] Refactor DCA classes

### DIFF
--- a/src/EventListener/DataContainer/Theme.php
+++ b/src/EventListener/DataContainer/Theme.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CoreBundle\Exception\AccessDeniedException;
-use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\FilesModel;
 use Contao\Image;
 use Contao\StringUtil;
@@ -35,8 +35,8 @@ class Theme
     /** @var BackendUser */
     protected $user;
 
-    /** @var ImageFactory */
-    protected $image;
+    /** @var ImageFactoryInterface */
+    private $imageFactory;
 
     /**
      * Theme constructor.
@@ -44,18 +44,18 @@ class Theme
      * @param RequestStack          $requestStack
      * @param SessionInterface      $session
      * @param TokenStorageInterface $tokenStorage
-     * @param ImageFactory          $image
+     * @param ImageFactoryInterface $imageFactory
      */
     public function __construct(
         RequestStack $requestStack,
         SessionInterface $session,
         TokenStorageInterface $tokenStorage,
-        ImageFactory $image
+        ImageFactoryInterface $imageFactory
     ) {
         $this->requestStack = $requestStack;
         $this->session      = $session;
         $this->user         = $tokenStorage->getToken()->getUser();
-        $this->image        = $image;
+        $this->imageFactory = $imageFactory;
     }
 
     /**
@@ -108,7 +108,7 @@ class Theme
             return $label;
         }
 
-        $imageUrl = $this->image
+        $imageUrl = $this->imageFactory
             ->create(TL_ROOT . '/' . $objFile->path, [75, 50, 'center_top'])
             ->getUrl(TL_ROOT);
 

--- a/src/EventListener/DataContainer/Theme.php
+++ b/src/EventListener/DataContainer/Theme.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2018 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\Backend;
+use Contao\BackendUser;
+use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\FilesModel;
+use Contao\Image;
+use Contao\StringUtil;
+use Contao\StyleSheets;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class Theme
+{
+    /** @var RequestStack */
+    protected $requestStack;
+
+    /** @var SessionInterface */
+    protected $session;
+
+    /** @var BackendUser */
+    protected $user;
+
+    /** @var ImageFactory */
+    protected $image;
+
+    /**
+     * Theme constructor.
+     *
+     * @param RequestStack          $requestStack
+     * @param SessionInterface      $session
+     * @param TokenStorageInterface $tokenStorage
+     * @param ImageFactory          $image
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        SessionInterface $session,
+        TokenStorageInterface $tokenStorage,
+        ImageFactory $image
+    ) {
+        $this->requestStack = $requestStack;
+        $this->session      = $session;
+        $this->user         = $tokenStorage->getToken()->getUser();
+        $this->image        = $image;
+    }
+
+    /**
+     * Check permissions to edit the table
+     *
+     * @throws AccessDeniedException
+     */
+    public function onCheckPermission(): void
+    {
+        if ($this->user->isAdmin) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        // Check the theme import and export permissions (see #5835)
+        switch ($request->get('key')) {
+            case 'importTheme':
+                if (!$this->user->hasAccess('theme_import', 'themes')) {
+                    throw new AccessDeniedException('Not enough permissions to import themes.');
+                }
+                break;
+
+            case 'exportTheme':
+                if (!$this->user->hasAccess('theme_import', 'themes')) {
+                    throw new AccessDeniedException('Not enough permissions to export themes.');
+                }
+                break;
+        }
+    }
+
+
+    /**
+     * Add an image to each record
+     *
+     * @param array  $row
+     * @param string $label
+     *
+     * @return string
+     */
+    public function onAddPreviewImage(array $row, string $label): string
+    {
+        if (!$row['screenshot']) {
+            return $label;
+        }
+
+        $objFile = FilesModel::findByUuid($row['screenshot']);
+
+        if (null === $objFile) {
+            return $label;
+        }
+
+        $imageUrl = $this->image
+            ->create(TL_ROOT . '/' . $objFile->path, [75, 50, 'center_top'])
+            ->getUrl(TL_ROOT);
+
+        return Image::getHtml($imageUrl, '', 'class="theme_preview"') . ' ' . $label;
+    }
+
+
+    /**
+     * Check for modified style sheets and update them if necessary
+     */
+    public function onUpdateStyleSheet(): void
+    {
+        if ($this->session->get('style_sheet_update_all')) {
+            // todo: make updateStyleSheets() static
+            $styleSheets = new StyleSheets();
+            $styleSheets->updateStyleSheets();
+        }
+
+        $this->session->set('style_sheet_update_all', null);
+    }
+
+
+    /**
+     * Schedule a style sheet update
+     *
+     * This method is triggered when a single theme or multiple themes are
+     * modified (edit/editAll) or duplicated (copy/copyAll).
+     */
+    public function onScheduleUpdate(): void
+    {
+        $this->session->set('style_sheet_update_all', true);
+    }
+
+
+    /**
+     * Return all template folders as array
+     *
+     * @return array
+     */
+    public function onGetTemplateFolders(): array
+    {
+        return $this->doGetTemplateFolders('templates');
+    }
+
+
+    /**
+     * Return all template folders as array
+     *
+     * @param string  $path
+     * @param integer $level
+     *
+     * @return array
+     */
+    // todo: refactor?
+    protected function doGetTemplateFolders(string $path, int $level = 0): array
+    {
+        $return = [];
+
+        foreach (scan(TL_ROOT . '/' . $path) as $file) {
+            if (is_dir(TL_ROOT . '/' . $path . '/' . $file)) {
+                $return[$path . '/' . $file] = str_repeat(' &nbsp; &nbsp; ', $level) . $file;
+                $return                      =
+                    array_merge($return, $this->doGetTemplateFolders($path . '/' . $file, $level + 1));
+            }
+        }
+
+        return $return;
+    }
+
+
+    /**
+     * Return the "import theme" link
+     *
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $class
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onImportTheme(string $href, string $label, string $title, string $class, string $attributes): string
+    {
+        if (!$this->user->hasAccess('theme_import', 'themes')) {
+            return '';
+        }
+
+        return sprintf(
+            '<a href="%s" class="%s" title="%s"%s>%s</a> ',
+            Backend::addToUrl($href),
+            $class,
+            StringUtil::specialchars($title),
+            $attributes,
+            $label
+        );
+    }
+
+
+    /**
+     * Return the theme store link
+     *
+     * @return string
+     */
+    public function onThemeStore(): string
+    {
+        return sprintf(
+            '<a href="https://themes.contao.org" title="%s" class="header_store" target="_blank" rel="noopener">%s</a>',
+            StringUtil::specialchars($GLOBALS['TL_LANG']['tl_theme']['store'][1]),
+            $GLOBALS['TL_LANG']['tl_theme']['store'][0]
+        );
+    }
+
+
+    /**
+     * Return the "edit CSS" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onEditCss(
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ): string {
+        return $this->renderButton('css', $row, $href, $label, $title, $icon, $attributes);
+    }
+
+
+    /**
+     * Return the "edit modules" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onEditModules(
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ): string {
+        return $this->renderButton('modules', $row, $href, $label, $title, $icon, $attributes);
+    }
+
+
+    /**
+     * Return the "edit page layouts" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onEditLayout(
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ): string {
+        return $this->renderButton('layout', $row, $href, $label, $title, $icon, $attributes);
+    }
+
+
+    /**
+     * Return the "edit image sizes" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onEditImageSizes(
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ): string {
+        return $this->renderButton('image_sizes', $row, $href, $label, $title, $icon, $attributes);
+    }
+
+
+    /**
+     * Return the "export theme" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    public function onExportTheme(
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ): string {
+        return $this->renderButton('theme_export', $row, $href, $label, $title, $icon, $attributes);
+    }
+
+
+    /**
+     * Render a button if the user has access to it.
+     *
+     * @param        $field
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     */
+    private function renderButton(
+        $field,
+        array $row,
+        string $href,
+        string $label,
+        string $title,
+        string $icon,
+        string $attributes
+    ) {
+        if (!$this->user->hasAccess($field, 'themes')) {
+            return Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
+        }
+
+        return sprintf(
+            '<a href="%s" title="%s"%s>%s</a> ',
+            Backend::addToUrl($href . '&amp;id=' . $row['id']),
+            StringUtil::specialchars($title),
+            $attributes,
+            Image::getHtml($icon, $label)
+        );
+    }
+}

--- a/src/EventListener/DataContainer/Theme.php
+++ b/src/EventListener/DataContainer/Theme.php
@@ -146,7 +146,7 @@ class Theme
     public function onUpdateStyleSheet(): void
     {
         if ($this->session->get('style_sheet_update_all')) {
-            // todo: make updateStyleSheets() static
+            // todo: make stylesheet handling become a service
             $styleSheets = new StyleSheets();
             $styleSheets->updateStyleSheets();
         }

--- a/src/EventListener/DataContainer/Theme.php
+++ b/src/EventListener/DataContainer/Theme.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\FilesModel;
 use Contao\Image;
@@ -39,6 +40,9 @@ class Theme
     /** @var ImageFactoryInterface */
     private $imageFactory;
 
+    /** @var ContaoFramework */
+    private $framework;
+
     /**
      * Theme constructor.
      *
@@ -57,6 +61,14 @@ class Theme
         $this->session      = $session;
         $this->token        = $tokenStorage->getToken();
         $this->imageFactory = $imageFactory;
+    }
+
+    /**
+     * @param ContaoFramework $framework
+     */
+    public function setFramework(ContaoFramework $framework): void
+    {
+        $this->framework = $framework;
     }
 
     /**
@@ -112,7 +124,9 @@ class Theme
             return $label;
         }
 
-        $objFile = FilesModel::findByUuid($row['screenshot']);
+        /** @var FilesModel $filesModel */
+        $filesModel = $this->framework->getAdapter('Contao\FilesModel');
+        $objFile    = $filesModel::findByUuid($row['screenshot']);
 
         if (null === $objFile) {
             return $label;

--- a/src/EventListener/DataContainer/Theme.php
+++ b/src/EventListener/DataContainer/Theme.php
@@ -15,7 +15,8 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CoreBundle\Exception\AccessDeniedException;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Framework\FrameworkAwareInterface;
+use Contao\CoreBundle\Framework\FrameworkAwareTrait;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\FilesModel;
 use Contao\Image;
@@ -26,8 +27,10 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class Theme
+class Theme implements FrameworkAwareInterface
 {
+    use FrameworkAwareTrait;
+
     /** @var RequestStack */
     protected $requestStack;
 
@@ -39,9 +42,6 @@ class Theme
 
     /** @var ImageFactoryInterface */
     private $imageFactory;
-
-    /** @var ContaoFramework */
-    private $framework;
 
     /**
      * Theme constructor.
@@ -61,14 +61,6 @@ class Theme
         $this->session      = $session;
         $this->token        = $tokenStorage->getToken();
         $this->imageFactory = $imageFactory;
-    }
-
-    /**
-     * @param ContaoFramework $framework
-     */
-    public function setFramework(ContaoFramework $framework): void
-    {
-        $this->framework = $framework;
     }
 
     /**
@@ -126,7 +118,8 @@ class Theme
 
         /** @var FilesModel $filesModel */
         $filesModel = $this->framework->getAdapter('Contao\FilesModel');
-        $objFile    = $filesModel::findByUuid($row['screenshot']);
+        /** @noinspection StaticInvocationViaThisInspection */
+        $objFile = $filesModel->findByUuid($row['screenshot']);
 
         if (null === $objFile) {
             return $label;

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -187,6 +187,4 @@ services:
             - "@session"
             - "@security.token_storage"
             - "@contao.image.image_factory"
-        calls:
-            - [setFramework, ["@contao.framework"]]
         public: true

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -179,3 +179,11 @@ services:
             - "@event_dispatcher"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
+    contao.listener.datacontainer.theme:
+        class: Contao\CoreBundle\EventListener\DataContainer\Theme
+        arguments:
+            - '@request_stack'
+            - '@session'
+            - '@security.token_storage'
+            - '@contao.image.image_factory'

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -187,3 +187,4 @@ services:
             - '@session'
             - '@security.token_storage'
             - '@contao.image.image_factory'
+        public: true

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -183,8 +183,10 @@ services:
     contao.listener.datacontainer.theme:
         class: Contao\CoreBundle\EventListener\DataContainer\Theme
         arguments:
-            - '@request_stack'
-            - '@session'
-            - '@security.token_storage'
-            - '@contao.image.image_factory'
+            - "@request_stack"
+            - "@session"
+            - "@security.token_storage"
+            - "@contao.image.image_factory"
+        calls:
+            - [setFramework, ["@contao.framework"]]
         public: true

--- a/src/Resources/contao/dca/tl_theme.php
+++ b/src/Resources/contao/dca/tl_theme.php
@@ -30,16 +30,16 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		),
 		'onload_callback' => array
 		(
-			array('tl_theme', 'checkPermission'),
-			array('tl_theme', 'updateStyleSheet')
+			array('contao.listener.datacontainer.theme', 'checkPermission'),
+			array('contao.listener.datacontainer.theme', 'updateStyleSheet')
 		),
 		'oncopy_callback' => array
 		(
-			array('tl_theme', 'scheduleUpdate')
+			array('contao.listener.datacontainer.theme', 'scheduleUpdate')
 		),
 		'onsubmit_callback' => array
 		(
-			array('tl_theme', 'scheduleUpdate')
+			array('contao.listener.datacontainer.theme', 'scheduleUpdate')
 		)
 	),
 
@@ -57,7 +57,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array('tl_theme', 'addPreviewImage')
+			'label_callback'          => array('contao.listener.datacontainer.theme', 'addPreviewImage')
 		),
 		'global_operations' => array
 		(
@@ -66,14 +66,14 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['importTheme'],
 				'href'                => 'key=importTheme',
 				'class'               => 'header_theme_import',
-				'button_callback'     => array('tl_theme', 'importTheme')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'importTheme')
 			),
 			'store' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['store'],
 				'href'                => 'key=themeStore',
 				'class'               => 'header_store',
-				'button_callback'     => array('tl_theme', 'themeStore')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'themeStore')
 			),
 			'all' => array
 			(
@@ -110,35 +110,35 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['css'],
 				'href'                => 'table=tl_style_sheet',
 				'icon'                => 'css.svg',
-				'button_callback'     => array('tl_theme', 'editCss')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'editCss')
 			),
 			'modules' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['modules'],
 				'href'                => 'table=tl_module',
 				'icon'                => 'modules.svg',
-				'button_callback'     => array('tl_theme', 'editModules')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'editModules')
 			),
 			'layout' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['layout'],
 				'href'                => 'table=tl_layout',
 				'icon'                => 'layout.svg',
-				'button_callback'     => array('tl_theme', 'editLayout')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'editLayout')
 			),
 			'imageSizes' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['imageSizes'],
 				'href'                => 'table=tl_image_size',
 				'icon'                => 'sizes.svg',
-				'button_callback'     => array('tl_theme', 'editImageSizes')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'editImageSizes')
 			),
 			'exportTheme' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['exportTheme'],
 				'href'                => 'key=exportTheme',
 				'icon'                => 'theme_export.svg',
-				'button_callback'     => array('tl_theme', 'exportTheme')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'exportTheme')
 			)
 		)
 	),
@@ -230,260 +230,293 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 /**
  * Provide miscellaneous methods that are used by the data configuration array.
  *
- * @author Leo Feyer <https://github.com/leofeyer>
+ * @author     Leo Feyer <https://github.com/leofeyer>
+ *
+ * @deprecated Deprecated since Contao 4.6, to be removed in Contao 5.0
+ *             Use the datacontainer.theme listener instead.
  */
 class tl_theme extends Backend
 {
+    /**
+     * Import the back end user object
+     */
+    public function __construct()
+    {
+        @trigger_error(
+            'Using class tl_theme has been deprecated and will be removed in Contao 5.0. Use the datacontainer.theme listener instead.',
+            E_USER_DEPRECATED
+        );
 
-	/**
-	 * Import the back end user object
-	 */
-	public function __construct()
-	{
-		parent::__construct();
-		$this->import('BackendUser', 'User');
-	}
-
-
-	/**
-	 * Check permissions to edit the table
-	 *
-	 * @throws Contao\CoreBundle\Exception\AccessDeniedException
-	 */
-	public function checkPermission()
-	{
-		if ($this->User->isAdmin)
-		{
-			return;
-		}
-
-		// Check the theme import and export permissions (see #5835)
-		switch (Input::get('key'))
-		{
-			case 'importTheme':
-				if (!$this->User->hasAccess('theme_import', 'themes'))
-				{
-					throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to import themes.');
-				}
-				break;
-
-			case 'exportTheme':
-				if (!$this->User->hasAccess('theme_import', 'themes'))
-				{
-					throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to export themes.');
-				}
-				break;
-		}
-	}
+        parent::__construct();
+        $this->import('BackendUser', 'User');
+    }
 
 
-	/**
-	 * Add an image to each record
-	 *
-	 * @param array  $row
-	 * @param string $label
-	 *
-	 * @return string
-	 */
-	public function addPreviewImage($row, $label)
-	{
-		if ($row['screenshot'] != '')
-		{
-			$objFile = FilesModel::findByUuid($row['screenshot']);
-
-			if ($objFile !== null)
-			{
-				$label = Image::getHtml(\System::getContainer()->get('contao.image.image_factory')->create(TL_ROOT . '/' . $objFile->path, array(75, 50, 'center_top'))->getUrl(TL_ROOT), '', 'class="theme_preview"') . ' ' . $label;
-			}
-		}
-
-		return $label;
-	}
+    /**
+     * Check permissions to edit the table
+     *
+     * @throws Contao\CoreBundle\Exception\AccessDeniedException
+     *
+     * @deprecated
+     */
+    public function checkPermission()
+    {
+        \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onCheckPermission();
+    }
 
 
-	/**
-	 * Check for modified style sheets and update them if necessary
-	 */
-	public function updateStyleSheet()
-	{
-		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
-		$objSession = System::getContainer()->get('session');
-
-		if ($objSession->get('style_sheet_update_all'))
-		{
-			$this->import('StyleSheets');
-			$this->StyleSheets->updateStyleSheets();
-		}
-
-		$objSession->set('style_sheet_update_all', null);
-	}
-
-
-	/**
-	 * Schedule a style sheet update
-	 *
-	 * This method is triggered when a single theme or multiple themes are
-	 * modified (edit/editAll) or duplicated (copy/copyAll).
-	 */
-	public function scheduleUpdate()
-	{
-		/** @var Symfony\Component\HttpFoundation\Session\SessionInterface $objSession */
-		$objSession = System::getContainer()->get('session');
-
-		$objSession->set('style_sheet_update_all', true);
-	}
+    /**
+     * Add an image to each record
+     *
+     * @param array  $row
+     * @param string $label
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function addPreviewImage($row, $label)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onAddPreviewImage(
+            $row,
+            $label
+        );
+    }
 
 
-	/**
-	 * Return all template folders as array
-	 *
-	 * @return array
-	 */
-	public function getTemplateFolders()
-	{
-		return $this->doGetTemplateFolders('templates');
-	}
+    /**
+     * Check for modified style sheets and update them if necessary
+     *
+     * @deprecated
+     */
+    public function updateStyleSheet()
+    {
+        \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onUpdateStyleSheet();
+    }
 
 
-	/**
-	 * Return all template folders as array
-	 *
-	 * @param string  $path
-	 * @param integer $level
-	 *
-	 * @return array
-	 */
-	protected function doGetTemplateFolders($path, $level=0)
-	{
-		$return = array();
-
-		foreach (scan(TL_ROOT . '/' . $path) as $file)
-		{
-			if (is_dir(TL_ROOT . '/' . $path . '/' . $file))
-			{
-				$return[$path . '/' . $file] = str_repeat(' &nbsp; &nbsp; ', $level) . $file;
-				$return = array_merge($return, $this->doGetTemplateFolders($path . '/' . $file, $level+1));
-			}
-		}
-
-		return $return;
-	}
+    /**
+     * Schedule a style sheet update
+     *
+     * This method is triggered when a single theme or multiple themes are
+     * modified (edit/editAll) or duplicated (copy/copyAll).
+     *
+     * @deprecated
+     */
+    public function scheduleUpdate()
+    {
+        \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onScheduleUpdate();
+    }
 
 
-	/**
-	 * Return the "import theme" link
-	 *
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $class
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function importTheme($href, $label, $title, $class, $attributes)
-	{
-		return $this->User->hasAccess('theme_import', 'themes') ? '<a href="'.$this->addToUrl($href).'" class="'.$class.'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ' : '';
-	}
+    /**
+     * Return all template folders as array
+     *
+     * @return array
+     *
+     * @deprecated
+     */
+    public function getTemplateFolders()
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onGetTemplateFolders();
+    }
 
 
-	/**
-	 * Return the theme store link
-	 *
-	 * @return string
-	 */
-	public function themeStore()
-	{
-		return '<a href="https://themes.contao.org" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['tl_theme']['store'][1]) . '" class="header_store" target="_blank" rel="noopener">' . $GLOBALS['TL_LANG']['tl_theme']['store'][0] . '</a>';
-	}
+    /**
+     * Return all template folders as array
+     *
+     * @param string  $path
+     * @param integer $level
+     *
+     * @return array
+     *
+     * @deprecated
+     */
+    protected function doGetTemplateFolders($path, $level = 0)
+    {
+        $return = array();
+
+        foreach (scan(TL_ROOT . '/' . $path) as $file) {
+            if (is_dir(TL_ROOT . '/' . $path . '/' . $file)) {
+                $return[$path . '/' . $file] = str_repeat(' &nbsp; &nbsp; ', $level) . $file;
+                $return                      =
+                    array_merge($return, $this->doGetTemplateFolders($path . '/' . $file, $level + 1));
+            }
+        }
+
+        return $return;
+    }
 
 
-	/**
-	 * Return the "edit CSS" button
-	 *
-	 * @param array  $row
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $icon
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function editCss($row, $href, $label, $title, $icon, $attributes)
-	{
-		return $this->User->hasAccess('css', 'themes') ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
-	}
+    /**
+     * Return the "import theme" link
+     *
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $class
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function importTheme($href, $label, $title, $class, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onImportTheme(
+            $href,
+            $label,
+            $title,
+            $class,
+            $attributes
+        );
+    }
 
 
-	/**
-	 * Return the "edit modules" button
-	 *
-	 * @param array  $row
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $icon
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function editModules($row, $href, $label, $title, $icon, $attributes)
-	{
-		return $this->User->hasAccess('modules', 'themes') ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
-	}
+    /**
+     * Return the theme store link
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function themeStore()
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onThemeStore();
+    }
 
 
-	/**
-	 * Return the "edit page layouts" button
-	 *
-	 * @param array  $row
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $icon
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function editLayout($row, $href, $label, $title, $icon, $attributes)
-	{
-		return $this->User->hasAccess('layout', 'themes') ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
-	}
+    /**
+     * Return the "edit CSS" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function editCss($row, $href, $label, $title, $icon, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onEditCss(
+            $row,
+            $href,
+            $label,
+            $title,
+            $icon,
+            $attributes
+        );
+    }
 
 
-	/**
-	 * Return the "edit image sizes" button
-	 *
-	 * @param array  $row
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $icon
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function editImageSizes($row, $href, $label, $title, $icon, $attributes)
-	{
-		return $this->User->hasAccess('image_sizes', 'themes') ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
-	}
+    /**
+     * Return the "edit modules" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function editModules($row, $href, $label, $title, $icon, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onEditModules(
+            $row,
+            $href,
+            $label,
+            $title,
+            $icon,
+            $attributes
+        );
+    }
 
 
-	/**
-	 * Return the "export theme" button
-	 *
-	 * @param array  $row
-	 * @param string $href
-	 * @param string $label
-	 * @param string $title
-	 * @param string $icon
-	 * @param string $attributes
-	 *
-	 * @return string
-	 */
-	public function exportTheme($row, $href, $label, $title, $icon, $attributes)
-	{
-		return $this->User->hasAccess('theme_export', 'themes') ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';
-	}
+    /**
+     * Return the "edit page layouts" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function editLayout($row, $href, $label, $title, $icon, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onEditLayout(
+            $row,
+            $href,
+            $label,
+            $title,
+            $icon,
+            $attributes
+        );
+    }
+
+
+    /**
+     * Return the "edit image sizes" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function editImageSizes($row, $href, $label, $title, $icon, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onEditImageSizes(
+            $row,
+            $href,
+            $label,
+            $title,
+            $icon,
+            $attributes
+        );
+    }
+
+
+    /**
+     * Return the "export theme" button
+     *
+     * @param array  $row
+     * @param string $href
+     * @param string $label
+     * @param string $title
+     * @param string $icon
+     * @param string $attributes
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function exportTheme($row, $href, $label, $title, $icon, $attributes)
+    {
+        return \Contao\System::getContainer()->get('contao.listener.datacontainer.theme')->onExportTheme(
+            $row,
+            $href,
+            $label,
+            $title,
+            $icon,
+            $attributes
+        );
+    }
 }

--- a/src/Resources/contao/dca/tl_theme.php
+++ b/src/Resources/contao/dca/tl_theme.php
@@ -30,16 +30,16 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		),
 		'onload_callback' => array
 		(
-			array('contao.listener.datacontainer.theme', 'checkPermission'),
-			array('contao.listener.datacontainer.theme', 'updateStyleSheet')
+			array('contao.listener.datacontainer.theme', 'onCheckPermission'),
+			array('contao.listener.datacontainer.theme', 'onUpdateStyleSheet')
 		),
 		'oncopy_callback' => array
 		(
-			array('contao.listener.datacontainer.theme', 'scheduleUpdate')
+			array('contao.listener.datacontainer.theme', 'onScheduleUpdate')
 		),
 		'onsubmit_callback' => array
 		(
-			array('contao.listener.datacontainer.theme', 'scheduleUpdate')
+			array('contao.listener.datacontainer.theme', 'onScheduleUpdate')
 		)
 	),
 
@@ -57,7 +57,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array('contao.listener.datacontainer.theme', 'addPreviewImage')
+			'label_callback'          => array('contao.listener.datacontainer.theme', 'onAddPreviewImage')
 		),
 		'global_operations' => array
 		(
@@ -66,14 +66,14 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['importTheme'],
 				'href'                => 'key=importTheme',
 				'class'               => 'header_theme_import',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'importTheme')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onImportTheme')
 			),
 			'store' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['store'],
 				'href'                => 'key=themeStore',
 				'class'               => 'header_store',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'themeStore')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onThemeStore')
 			),
 			'all' => array
 			(
@@ -110,35 +110,35 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['css'],
 				'href'                => 'table=tl_style_sheet',
 				'icon'                => 'css.svg',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'editCss')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onEditCss')
 			),
 			'modules' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['modules'],
 				'href'                => 'table=tl_module',
 				'icon'                => 'modules.svg',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'editModules')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onEditModules')
 			),
 			'layout' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['layout'],
 				'href'                => 'table=tl_layout',
 				'icon'                => 'layout.svg',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'editLayout')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onEditLayout')
 			),
 			'imageSizes' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['imageSizes'],
 				'href'                => 'table=tl_image_size',
 				'icon'                => 'sizes.svg',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'editImageSizes')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onEditImageSizes')
 			),
 			'exportTheme' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_theme']['exportTheme'],
 				'href'                => 'key=exportTheme',
 				'icon'                => 'theme_export.svg',
-				'button_callback'     => array('contao.listener.datacontainer.theme', 'exportTheme')
+				'button_callback'     => array('contao.listener.datacontainer.theme', 'onExportTheme')
 			)
 		)
 	),

--- a/tests/EventListener/DataContainer/ThemeTest.php
+++ b/tests/EventListener/DataContainer/ThemeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2018 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
+
+use Contao\CoreBundle\Tests\TestCase;
+
+class ThemeTest extends TestCase
+{
+    // todo
+}


### PR DESCRIPTION
Here is a draft of how a refactoring of the old DCA classes could look like. I'd like to see the actual code that sits in the DCA files right now (mainly callbacks) being moved into it's dedicated listeners, maybe refactoring it on the go (take this as a follow up to the discussion here #1305).

To see how this could work out, I made this POC for the `tl_theme` class as this is a rather small one. If we like the concept I'm happy to add the other ones as well. :-) 

Here is what I did:
 - rewrote the DCA definition to use an event listener (`contao.listener.datacontainer.theme`)
 - moved the implementations to a new class `EventListener\DataContainer\Theme`
 - deprecated the `tl_theme` class and it's functions
 - rewired the `tl_theme`  functions to use the new listener funtions (BC)
(I did not move the class out of the dca file yet to prevent the diff being more messed up as it is already. But I think the best would be to put it somewhere else like in a `deprecated.php` so that people reading the code won't get confused.)

I also did refactor the code because I think that should be done before re-releasing legacy code in the wild (however this might be better suited in another PR) and might not yet be enough/up to best practice/ [...].

Nevertheless, that's what I did:
 - got rid of the `Backend` base class
 - injected dependencies where possible
 - did some refactoring for simplicity/clarity
    - removed duplicate code (rendering buttons)
    - flattened logic by inverting ifs / removing ternary if
    - replaced large string concats with `sprintf()`

Still there are some things that would need some action like the call to `updateStyleSheets` that either should be made static or injectable. Or the former protected method `doGetTemplateFolders` that either needs to have it's code copied to the respective deprecated method or needs to be made public (BC).

Another question would be if adding type constraints to the methods is considered a breaking change. If so there will be some logic / casts needed in the rewired (deprecated) functions as a compat layer.

But all in all it's a good bit cleaner, isn't it? Wdyt? Tests now should be feasible, I guess. And it would be one step further to config-only DCAs..

---

(btw., as you see: I'm proof-of-concepting myself through the codebase until I've learned enough or anyone tells me to please stop because I annoy the hell out of you. :grimacing: )