### PR TITLE
remove mandatory from html

### DIFF
--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -314,7 +314,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'textarea',
-			'eval'                    => array('mandatory'=>true, 'allowHtml'=>true, 'class'=>'monospace', 'rte'=>'ace|html', 'helpwizard'=>true),
+			'eval'                    => array('allowHtml'=>true, 'class'=>'monospace', 'rte'=>'ace|html', 'helpwizard'=>true),
 			'explanation'             => 'insertTags',
 			'sql'                     => "mediumtext NULL"
 		),


### PR DESCRIPTION
I often use `ce_html_*` templates for custom PHP code or HTML that is inserted on just one page as a content element. However, since the field is mandatory, I also always have to insert some content into the `html` field, which will then never be rendered in the front end anyway in the custom templates (unless you specifically do that of course).

In `tl_module` the field isn't mandatory either. Wouldn't it be more consistent to not make it mandatory in `tl_content` too?