### PR TITLE
[RTM] Enable access to nested keys in ArrayAttributeBag

### DIFF
--- a/src/Session/Attribute/ArrayAttributeBag.php
+++ b/src/Session/Attribute/ArrayAttributeBag.php
@@ -31,9 +31,9 @@ class ArrayAttributeBag extends AttributeBag implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($key)
+    public function &offsetGet($key)
     {
-        return $this->get($key);
+        return $this->attributes[$key];
     }
 
     /**

--- a/tests/Session/Attribute/ArrayAttributeBagTest.php
+++ b/tests/Session/Attribute/ArrayAttributeBagTest.php
@@ -41,8 +41,13 @@ class ArrayAttributeBagTest extends TestCase
         $bag = new ArrayAttributeBag('foobar_storageKey');
 
         $bag['foo'] = 'bar';
+        $bag['bar']['baz'] = 'foo';
+        $bag['baz'] = [];
+        $bag['baz']['foo'] = 'bar';
 
         $this->assertSame('bar', $bag->get('foo'));
+        $this->assertSame(['baz' => 'foo'], $bag->get('bar'));
+        $this->assertSame(['foo' => 'bar'], $bag->get('baz'));
     }
 
     /**
@@ -53,8 +58,11 @@ class ArrayAttributeBagTest extends TestCase
         $bag = new ArrayAttributeBag('foobar_storageKey');
 
         $bag['foo'] = 'bar';
+        $bag['bar']['baz'] = 'foo';
 
         $this->assertTrue(isset($bag['foo']));
+        $this->assertTrue(isset($bag['bar']['baz']));
+        $this->assertFalse(isset($bag['baz']));
     }
 
     /**
@@ -65,8 +73,29 @@ class ArrayAttributeBagTest extends TestCase
         $bag = new ArrayAttributeBag('foobar_storageKey');
 
         $bag['foo'] = 'bar';
+        $bag['bar']['baz'] = 'foo';
 
         $this->assertSame('bar', $bag['foo']);
+        $this->assertSame(['baz' => 'foo'], $bag['bar']);
+        $this->assertSame('foo', $bag['bar']['baz']);
+    }
+
+    /**
+     * Tests the offsetGet() method.
+     */
+    public function testCanModifyTheOffset()
+    {
+        $bag = new ArrayAttributeBag('foobar_storageKey');
+
+        $bag['foo'] = 1;
+        $bag['bar']['baz'] = 'foo';
+
+        $bag['foo']++;
+        $bag['foo'] += 1;
+        $bag['bar']['baz'] .= 'bar';
+
+        $this->assertSame(3, $bag['foo']);
+        $this->assertSame(['baz' => 'foobar'], $bag['bar']);
     }
 
     /**
@@ -76,9 +105,32 @@ class ArrayAttributeBagTest extends TestCase
     {
         $bag = new ArrayAttributeBag('foobar_storageKey');
         $bag->set('foo', 'bar');
+        $bag->set('bar', ['baz' => 'foo']);
 
         unset($bag['foo']);
+        unset($bag['bar']['baz']);
 
         $this->assertFalse($bag->has('foo'));
+        $this->assertSame([], $bag->get('bar'));
+    }
+
+    /**
+     * Tests the offsetGet() method.
+     */
+    public function testValuesAreNoReferenced()
+    {
+        $bag = new ArrayAttributeBag('foobar_storageKey');
+        $bag->set('foo', 'bar');
+        $bag->set('bar', ['baz' => 'foo']);
+
+        $foo = $bag['foo'];
+        $foo = '';
+        $baz = $bag['bar']['baz'];
+        $baz = '';
+        $bar = $bag['bar'];
+        $bar = [];
+
+        $this->assertSame('bar', $bag['foo']);
+        $this->assertSame(['baz' => 'foo'], $bag['bar']);
     }
 }


### PR DESCRIPTION
Fixes write operations on nested keys, e.g. `$_SESSION['FE_DATA']['foo']['bar'] = 'x';`.

Related #1316