### PR TITLE
change isset to array_key_exists

### DIFF
--- a/src/Resources/contao/library/Contao/Model.php
+++ b/src/Resources/contao/library/Contao/Model.php
@@ -394,7 +394,7 @@ abstract class Model
 	 */
 	public function markModified($strKey)
 	{
-		if (!isset($this->arrModified[$strKey]) && isset($this->arrData[$strKey]))
+		if (!array_key_exists($strKey,$this->arrModified) && array_key_exists($strKey,$this->arrData))
 		{
 			$this->arrModified[$strKey] = $this->arrData[$strKey];
 		}


### PR DESCRIPTION
isset returns _false_ if the array key value is _NULL_. This is an issue by updating fields with value _NULL_, because they don't get marked as modified.
At this point it is only necessary to check if this key is present in those arrays. The value doesn't matter.

Bonus: No NOTICE logs for undefined array index.