### PR TITLE
add download attribute to download elements

### DIFF
--- a/src/Resources/contao/templates/elements/ce_download.html5
+++ b/src/Resources/contao/templates/elements/ce_download.html5
@@ -3,7 +3,7 @@
 <?php $this->block('content'); ?>
 
   <p class="download-element ext-<?= $this->extension ?>">
-    <a href="<?= $this->href ?>" title="<?= $this->title ?>"><?= $this->link ?> <span class="size">(<?= $this->filesize ?>)</span></a>
+    <a href="<?= $this->href ?>" title="<?= $this->title ?>" download><?= $this->link ?> <span class="size">(<?= $this->filesize ?>)</span></a>
   </p>
 
 <?php $this->endblock(); ?>

--- a/src/Resources/contao/templates/elements/ce_downloads.html5
+++ b/src/Resources/contao/templates/elements/ce_downloads.html5
@@ -5,7 +5,7 @@
   <ul>
     <?php foreach ($this->files as $file): ?>
       <li class="download-element ext-<?= $file['extension'] ?>">
-        <a href="<?= $file['href'] ?>" title="<?= $file['title'] ?>"><?= $file['link'] ?> <span class="size">(<?= $file['filesize'] ?>)</span></a>
+        <a href="<?= $file['href'] ?>" title="<?= $file['title'] ?>" download><?= $file['link'] ?> <span class="size">(<?= $file['filesize'] ?>)</span></a>
       </li>
     <?php endforeach; ?>
   </ul>


### PR DESCRIPTION
prevent errors like:
Resource interpreted as Document but transferred with MIME type application/pdf: "*?file=*.pdf". (Chrome) or [Error] Failed to load resource: Das Laden des Frames wurde unterbrochen (*, line 0) *?file=*.pdf (Safari)
see more https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download