### PR TITLE
require terminal42/header-replay-bundle ^1.3 instead of 1.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/yaml": "^3.3",
         "tecnickcom/tcpdf": "^6.0",
-        "terminal42/header-replay-bundle": "1.3.*",
+        "terminal42/header-replay-bundle": "^1.3",
         "true/punycode": "^2.1",
         "twig/twig": "^1.26",
         "webmozart/path-util": "^2.0"


### PR DESCRIPTION
See https://github.com/composer/composer/issues/7042

Why was it changed to `1.3.*` anyway?