### PR TITLE
use dcaPicker for url field

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -315,7 +315,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('mandatory'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'dcaPicker'=>true, 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'target' => array


### PR DESCRIPTION
This enables you to conveniently select news or events (or more) for external redirect pages.