### PR TITLE
[RFC] Fix namespaced paths in Contao DataCollector

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -61,7 +61,7 @@ services:
         arguments:
             - "%kernel.packages%"
         tags:
-            - { name: data_collector, template: "ContaoCoreBundle:Collector:contao", id: "contao" }
+            - { name: data_collector, template: "@ContaoCore/Collector/contao.html.twig", id: "contao" }
 
     contao.doctrine.schema_provider:
         class: Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider

--- a/src/Resources/views/Collector/contao.html.twig
+++ b/src/Resources/views/Collector/contao.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}

--- a/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -595,7 +595,7 @@ class ContaoCoreExtensionTest extends TestCase
         $tags = $definition->getTags();
 
         $this->assertArrayHasKey('data_collector', $tags);
-        $this->assertSame('ContaoCoreBundle:Collector:contao', $tags['data_collector'][0]['template']);
+        $this->assertSame('@ContaoCore/Collector/contao.html.twig', $tags['data_collector'][0]['template']);
         $this->assertSame('contao', $tags['data_collector'][0]['id']);
     }
 


### PR DESCRIPTION
The Contao DataCollector used an outdated method for referencing templates which
seen to have been remove recently. Update to the modern @-prefixed way of referencing
templates.

Fixes the following error (occures when opening the debugger, or even just show the debug toolbar).

```
The profiler template "ContaoCore:Collector:contao.html.twig" for data collector "contao" does not exist.

UnexpectedValueException
in vendor/symfony/symfony/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php (line 108)
```

> In the past, Symfony used a different syntax to refer to templates. This format, which uses colons (:) to separate each template path section, is less consistent and has worse performance than the Twig syntax. (https://symfony.com/doc/3.4/templating/namespaced_paths.html)

> [...] but you must prefix the @ character when using it in templates (that's how Twig can differentiate namespaces from regular paths). (https://symfony.com/doc/current/templating/namespaced_paths.html)

There is one open question (thus tagged as RFC). It does seem to work in the managed edition. Any idea why?