### PR TITLE
Use the modern @-notation when referencing twig templates for Menu

### DIFF
--- a/src/Menu/BackendMenuRenderer.php
+++ b/src/Menu/BackendMenuRenderer.php
@@ -36,6 +36,6 @@ class BackendMenuRenderer implements RendererInterface
      */
     public function render(ItemInterface $tree, array $options = []): string
     {
-        return $this->twig->render('ContaoCoreBundle:Backend:be_menu.html.twig', ['tree' => $tree]);
+        return $this->twig->render('@ContaoCore/Backend/be_menu.html.twig', ['tree' => $tree]);
     }
 }

--- a/tests/Menu/BackendMenuRendererTest.php
+++ b/tests/Menu/BackendMenuRendererTest.php
@@ -52,7 +52,7 @@ class BackendMenuRendererTest extends TestCase
         $this->templating
             ->expects($this->once())
             ->method('render')
-            ->with('ContaoCoreBundle:Backend:be_menu.html.twig', ['tree' => $tree])
+            ->with('@ContaoCore/Backend/be_menu.html.twig', ['tree' => $tree])
             ->willReturn('')
         ;
 


### PR DESCRIPTION
Details available in [this PR](https://github.com/contao/core-bundle/pull/1379).

> Update to the modern @-prefixed way of referencing templates.
