### PR TITLE
Fixed argument types for AutomatorCommand in symfony/console ^4.0

### DIFF
--- a/src/Command/AutomatorCommand.php
+++ b/src/Command/AutomatorCommand.php
@@ -35,6 +35,9 @@ class AutomatorCommand extends AbstractLockedCommand
      */
     private $framework;
 
+    /**
+     * @param ContaoFrameworkInterface $framework
+     */
     public function __construct(ContaoFrameworkInterface $framework)
     {
         $this->framework = $framework;

--- a/src/Command/AutomatorCommand.php
+++ b/src/Command/AutomatorCommand.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command;
 
 use Contao\Automator;
-use Contao\CoreBundle\Framework\FrameworkAwareInterface;
-use Contao\CoreBundle\Framework\FrameworkAwareTrait;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,26 +23,23 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 /**
  * Runs Contao automator tasks on the command line.
  */
-class AutomatorCommand extends AbstractLockedCommand implements FrameworkAwareInterface
+class AutomatorCommand extends AbstractLockedCommand
 {
-    use FrameworkAwareTrait;
-
     /**
      * @var array
      */
     private $commands = [];
 
     /**
-     * Returns the help text.
-     *
-     * By using the __toString() method, we ensure that the help text is lazy loaded at
-     * a time where the autoloader is available (required by $this->getCommands()).
-     *
-     * @return string
+     * @var ContaoFrameworkInterface
      */
-    public function __toString(): string
+    private $framework;
+
+    public function __construct(ContaoFrameworkInterface $framework)
     {
-        return sprintf("The name of the task:\n  - %s", implode("\n  - ", $this->getCommands()));
+        $this->framework = $framework;
+
+        parent::__construct();
     }
 
     /**
@@ -54,7 +50,11 @@ class AutomatorCommand extends AbstractLockedCommand implements FrameworkAwareIn
         $this
             ->setName('contao:automator')
             ->setDefinition([
-                new InputArgument('task', InputArgument::OPTIONAL, $this),
+                new InputArgument(
+                    'task',
+                    InputArgument::OPTIONAL,
+                    sprintf("The name of the task:\n  - %s", implode("\n  - ", $this->getCommands()))
+                ),
             ])
             ->setDescription('Runs automator tasks on the command line.')
         ;

--- a/src/Resources/config/commands.yml
+++ b/src/Resources/config/commands.yml
@@ -9,6 +9,8 @@ services:
 
     contao.command.automator:
         class: Contao\CoreBundle\Command\AutomatorCommand
+        arguments:
+            - "@contao.framework"
 
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand

--- a/tests/Command/AutomatorCommandTest.php
+++ b/tests/Command/AutomatorCommandTest.php
@@ -21,7 +21,7 @@ class AutomatorCommandTest extends CommandTestCase
 {
     public function testCanBeInstantiated(): void
     {
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
 
         $this->assertInstanceOf('Contao\CoreBundle\Command\AutomatorCommand', $command);
         $this->assertSame('contao:automator', $command->getName());
@@ -29,9 +29,8 @@ class AutomatorCommandTest extends CommandTestCase
 
     public function testGeneratesTheTaskList(): void
     {
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
         $command->setApplication($this->mockApplication());
-        $command->setFramework($this->mockContaoFramework());
 
         $tester = new CommandTester($command);
         $tester->setInputs(["\n"]);
@@ -43,15 +42,7 @@ class AutomatorCommandTest extends CommandTestCase
         $this->assertContains('Please select a task:', $output);
         $this->assertContains('[10]', $output);
     }
-
-    public function testCanBeConvertedToString(): void
-    {
-        $command = new AutomatorCommand('contao:automator');
-        $command->setFramework($this->mockContaoFramework());
-
-        $this->assertContains('The name of the task:', $command->__toString());
-    }
-
+    
     public function testIsLockedWhileRunning(): void
     {
         $factory = new Factory(new FlockStore(sys_get_temp_dir().'/'.md5($this->getFixturesDir())));
@@ -59,9 +50,8 @@ class AutomatorCommandTest extends CommandTestCase
         $lock = $factory->createLock('contao:automator');
         $lock->acquire();
 
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
         $command->setApplication($this->mockApplication());
-        $command->setFramework($this->mockContaoFramework());
 
         $tester = new CommandTester($command);
         $tester->setInputs(["\n"]);
@@ -76,9 +66,8 @@ class AutomatorCommandTest extends CommandTestCase
 
     public function testTakesTheTaskNameAsArgument(): void
     {
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
         $command->setApplication($this->mockApplication());
-        $command->setFramework($this->mockContaoFramework());
 
         $input = [
             'command' => $command->getName(),
@@ -93,9 +82,8 @@ class AutomatorCommandTest extends CommandTestCase
 
     public function testHandlesAnInvalidSelection(): void
     {
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
         $command->setApplication($this->mockApplication());
-        $command->setFramework($this->mockContaoFramework());
 
         $tester = new CommandTester($command);
         $tester->setInputs(["4800\n"]);
@@ -108,9 +96,8 @@ class AutomatorCommandTest extends CommandTestCase
 
     public function testHandlesAnInvalidTaskName(): void
     {
-        $command = new AutomatorCommand('contao:automator');
+        $command = new AutomatorCommand($this->mockContaoFramework());
         $command->setApplication($this->mockApplication());
-        $command->setFramework($this->mockContaoFramework());
 
         $input = [
             'command' => $command->getName(),


### PR DESCRIPTION
`InputArgument` enforces its third parameter (`description`) to be of type `string`, so our nice way of assuring the lazy loading of the description (providing `$this` with a `__toString`) method does not work anymore in `symfony/console ^4.0`.

I refactored it to use a service argument.