### PR TITLE
Make sure insert tags get the same client cache time as the page

### DIFF
--- a/src/Controller/InsertTagsController.php
+++ b/src/Controller/InsertTagsController.php
@@ -58,7 +58,7 @@ class InsertTagsController extends Controller
         $it = $this->framework->createInstance(InsertTags::class);
 
         $response = Response::create($it->replace($insertTag, false));
-        $response->setPrivate(); // Always private
+        $response->setPrivate(); // always private
 
         if ($clientCache = $request->query->getInt('clientCache')) {
             $response->setMaxAge($clientCache);

--- a/src/Controller/InsertTagsController.php
+++ b/src/Controller/InsertTagsController.php
@@ -13,6 +13,7 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\InsertTags;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -44,18 +45,25 @@ class InsertTagsController extends Controller
     /**
      * Renders an insert tag.
      *
-     * @param string $insertTag
+     * @param Request $request
+     * @param string  $insertTag
      *
      * @return Response
      */
-    public function renderAction($insertTag)
+    public function renderAction(Request $request, $insertTag)
     {
         $this->framework->initialize();
 
         /** @var InsertTags $it */
         $it = $this->framework->createInstance(InsertTags::class);
 
-        // Never cache these responses
-        return (new Response($it->replace($insertTag, false)))->setPrivate();
+        $response = Response::create($it->replace($insertTag, false));
+        $response->setPrivate(); // Always private
+
+        if ($clientCache = $request->query->getInt('clientCache')) {
+            $response->setMaxAge($clientCache);
+        }
+
+        return $response;
     }
 }

--- a/src/Resources/contao/library/Contao/InsertTags.php
+++ b/src/Resources/contao/library/Contao/InsertTags.php
@@ -123,7 +123,7 @@ class InsertTags extends \Controller
 					$fragmentHandler = \System::getContainer()->get('fragment.handler');
 					$strBuffer .= $fragmentHandler->render(new ControllerReference('contao.controller.insert_tags:renderAction',
 						array('insertTag' => '{{' . $strTag . '}}'),
-						array('pageId' => $objPage->id, 'request' => \Environment::get('request'))
+						array('clientCache' => (int) $objPage->clientCache, 'pageId' => $objPage->id, 'request' => \Environment::get('request'))
 					), 'esi');
 					continue;
 				}

--- a/tests/Controller/InsertTagsControllerTest.php
+++ b/tests/Controller/InsertTagsControllerTest.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Controller\InsertTagsController;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the InsertTagsController class.
@@ -51,10 +52,23 @@ class InsertTagsControllerTest extends TestCase
         ;
 
         $controller = new InsertTagsController($this->mockFramework($insertTagAdapter));
-        $response = $controller->renderAction('{{request_token}}');
+        $request = new Request();
+
+        $response = $controller->renderAction($request, '{{request_token}}');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertNull($response->getMaxAge());
+        $this->assertSame('3858f62230ac3c915f300c664312c63f', $response->getContent());
+
+        $request = new Request();
+        $request->query->set('clientCache', 300);
+
+        $response = $controller->renderAction($request, '{{request_token}}');
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertSame(300, $response->getMaxAge());
         $this->assertSame('3858f62230ac3c915f300c664312c63f', $response->getContent());
     }
 
@@ -70,7 +84,7 @@ class InsertTagsControllerTest extends TestCase
         $framework = $this->createMock(ContaoFramework::class);
 
         $framework
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('initialize')
         ;
 

--- a/tests/Controller/InsertTagsControllerTest.php
+++ b/tests/Controller/InsertTagsControllerTest.php
@@ -52,9 +52,7 @@ class InsertTagsControllerTest extends TestCase
         ;
 
         $controller = new InsertTagsController($this->mockFramework($insertTagAdapter));
-        $request = new Request();
-
-        $response = $controller->renderAction($request, '{{request_token}}');
+        $response = $controller->renderAction(new Request(), '{{request_token}}');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertTrue($response->headers->hasCacheControlDirective('private'));
@@ -64,6 +62,7 @@ class InsertTagsControllerTest extends TestCase
         $request = new Request();
         $request->query->set('clientCache', 300);
 
+        $controller = new InsertTagsController($this->mockFramework($insertTagAdapter));
         $response = $controller->renderAction($request, '{{request_token}}');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
@@ -84,7 +83,6 @@ class InsertTagsControllerTest extends TestCase
         $framework = $this->createMock(ContaoFramework::class);
 
         $framework
-            ->expects($this->exactly(2))
             ->method('initialize')
         ;
 


### PR DESCRIPTION
Otherwise the main request will never allow for client cache as it takes the lowest value of all fragments (which is 0 at the moment for us).