### PR TITLE
Fix MooTools version for googleapis.

### DIFF
--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -428,7 +428,9 @@ class PageRegular extends \Frontend
 			{
 				try
 				{
-					$version = PackageUtil::getVersion('contao-components/jquery');
+                    $version = PackageUtil::getVersion('contao-components/mootools');
+                    // Trim mootools version number to major.minor.patch
+                    $version = implode('.', array_slice(explode('.', $version), 0, 3));
 
 					if (version_compare($version, '1.5.1', '>'))
 					{


### PR DESCRIPTION
MooTools gets not loaded in the frontend because the ajax.googleapis.com server replied with an 404.

1. There is obviously a typo / copy-paste error.
2. I had to trim version 1.6.0.5 (package version of contao-components/mootools) to 1.6.0 in order to have a valid URI.
3. This is a Contao 4.5 exclusive bug.