### PR TITLE
[RTM] Validate CSRF cookie

### DIFF
--- a/src/EventListener/CsrfTokenCookieListener.php
+++ b/src/EventListener/CsrfTokenCookieListener.php
@@ -107,7 +107,7 @@ class CsrfTokenCookieListener
         $tokens = [];
 
         foreach ($cookies as $key => $value) {
-            if (0 === strpos($key, $this->cookiePrefix)) {
+            if (0 === strpos($key, $this->cookiePrefix) && preg_match('/^[a-z0-9]+$/i', $value)) {
                 $tokens[substr($key, \strlen($this->cookiePrefix))] = $value;
             }
         }

--- a/tests/EventListener/CsrfTokenCookieListenerTest.php
+++ b/tests/EventListener/CsrfTokenCookieListenerTest.php
@@ -39,6 +39,7 @@ class CsrfTokenCookieListenerTest extends TestCase
         $request->cookies = new ParameterBag([
             'csrf_foo' => 'bar',
             'not_csrf' => 'baz',
+            'csrf_bar' => 'bad value with invalid characters should be ignored "<>!&',
         ]);
 
         $requestEvent = $this->createMock(GetResponseEvent::class);

--- a/tests/EventListener/CsrfTokenCookieListenerTest.php
+++ b/tests/EventListener/CsrfTokenCookieListenerTest.php
@@ -39,7 +39,7 @@ class CsrfTokenCookieListenerTest extends TestCase
         $request->cookies = new ParameterBag([
             'csrf_foo' => 'bar',
             'not_csrf' => 'baz',
-            'csrf_bar' => 'bad value with invalid characters should be ignored "<>!&',
+            'csrf_bar' => '"<>!&', // ignore invalid characters
         ]);
 
         $requestEvent = $this->createMock(GetResponseEvent::class);


### PR DESCRIPTION
CSRF tokens should only consist of charaters and numbers.