### PR TITLE
[RTM] Added insert tag for translator

### DIFF
--- a/src/EventListener/InsertTags/TranslationListener.php
+++ b/src/EventListener/InsertTags/TranslationListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2018 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\CoreBundle\EventListener\InsertTags;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TranslationListener
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * Replaces the "trans" insert tag.
+     *
+     * @param string $tag
+     *
+     * @return string|false
+     */
+    public function onReplaceInsertTags(string $tag)
+    {
+        $chunks = explode('::', $tag);
+
+        if ('trans' !== $chunks[0]) {
+            return false;
+        }
+
+        $parameters = explode(':', $chunks[2]);
+
+        return $this->translator->trans($chunks[1], $parameters, $chunks[3] ?? null);
+    }
+}

--- a/src/EventListener/InsertTags/TranslationListener.php
+++ b/src/EventListener/InsertTags/TranslationListener.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 /*
  * This file is part of Contao.
  *
- * Copyright (c) 2005-2018 Leo Feyer
+ * (c) Leo Feyer
  *
- * @license LGPL-3.0+
+ * @license LGPL-3.0-or-later
  */
 
 namespace Contao\CoreBundle\EventListener\InsertTags;

--- a/src/EventListener/InsertTags/TranslationListener.php
+++ b/src/EventListener/InsertTags/TranslationListener.php
@@ -44,8 +44,8 @@ class TranslationListener
             return false;
         }
 
-        $parameters = isset($chunks[2]) ? explode(':', $chunks[2]) : [];
+        $parameters = isset($chunks[3]) ? explode(':', $chunks[3]) : [];
 
-        return $this->translator->trans($chunks[1], $parameters, $chunks[3] ?? null);
+        return $this->translator->trans($chunks[1], $parameters, $chunks[2] ?? null);
     }
 }

--- a/src/EventListener/InsertTags/TranslationListener.php
+++ b/src/EventListener/InsertTags/TranslationListener.php
@@ -44,7 +44,7 @@ class TranslationListener
             return false;
         }
 
-        $parameters = explode(':', $chunks[2]);
+        $parameters = isset($chunks[2]) ? explode(':', $chunks[2]) : [];
 
         return $this->translator->trans($chunks[1], $parameters, $chunks[3] ?? null);
     }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -92,6 +92,13 @@ services:
         tags:
             - { name: contao.hook, hook: replaceInsertTags }
 
+    contao.listener.insert_tags.translation:
+        class: Contao\CoreBundle\EventListener\InsertTags\TranslationListener
+        arguments:
+            - "@translator"
+        tags:
+            - { name: contao.hook, hook: replaceInsertTags }
+
     contao.listener.locale:
         class: Contao\CoreBundle\EventListener\LocaleListener
         arguments:

--- a/tests/EventListener/InsertTags/TranslationListenerTest.php
+++ b/tests/EventListener/InsertTags/TranslationListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\InsertTags;
+
+use Contao\CoreBundle\EventListener\InsertTags\TranslationListener;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TranslationListenerTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $listener = new TranslationListener($this->createMock(TranslatorInterface::class));
+
+        $this->assertInstanceOf('Contao\CoreBundle\EventListener\InsertTags\TranslationListener', $listener);
+    }
+
+    /**
+     * @dataProvider insertTagsProvider
+     */
+    public function testReplacesInsertTagsWithTranslation(string $id, ?string $domain, array $parameters, string $result): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with($id, $parameters, $domain)
+            ->willReturn($result)
+        ;
+
+        $listener = new TranslationListener($translator);
+
+        if (null === $domain) {
+            $insertTag = sprintf('trans::%s', $id);
+        } elseif (empty($parameters)) {
+            $insertTag = sprintf('trans::%s::%s', $id, $domain);
+        } else {
+            $insertTag = sprintf('trans::%s::%s::%s', $id, $domain, implode(':', $parameters));
+        }
+
+        $this->assertSame($result, $listener->onReplaceInsertTags($insertTag));
+    }
+
+    public function insertTagsProvider()
+    {
+        return [
+            ['foo', null, [], 'bar'],
+            ['foo', 'bar', [], 'baz'],
+            ['foo', 'bar', ['baz', 'what'], 'else'],
+        ];
+    }
+
+    public function testIgnoresOtherInsertTags(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $translator
+            ->expects($this->never())
+            ->method('trans')
+        ;
+
+        $translator
+            ->expects($this->never())
+            ->method('transChoice')
+        ;
+
+        $listener = new TranslationListener($translator);
+
+        $this->assertFalse($listener->onReplaceInsertTags('env::pageTitle'));
+    }
+}

--- a/tests/EventListener/InsertTags/TranslationListenerTest.php
+++ b/tests/EventListener/InsertTags/TranslationListenerTest.php
@@ -26,9 +26,14 @@ class TranslationListenerTest extends TestCase
     }
 
     /**
+     * @param string      $id
+     * @param string      $result
+     * @param string|null $domain
+     * @param array       $parameters
+     *
      * @dataProvider insertTagsProvider
      */
-    public function testReplacesInsertTagsWithTranslation(string $id, ?string $domain, array $parameters, string $result): void
+    public function testReplacesInsertTagsWithTranslation(string $id, string $result, string $domain = null, array $parameters = []): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
 
@@ -52,12 +57,15 @@ class TranslationListenerTest extends TestCase
         $this->assertSame($result, $listener->onReplaceInsertTags($insertTag));
     }
 
-    public function insertTagsProvider()
+    /**
+     * @return array
+     */
+    public function insertTagsProvider(): array
     {
         return [
-            ['foo', null, [], 'bar'],
-            ['foo', 'bar', [], 'baz'],
-            ['foo', 'bar', ['baz', 'what'], 'else'],
+            ['foo', 'bar'],
+            ['foo', 'baz', 'bar'],
+            ['foo', 'else', 'bar', ['baz', 'what']],
         ];
     }
 


### PR DESCRIPTION
Contao 4.5 supports the Symfony translator, but there is no insert tag to use the Symfony translator. Here's a fix for that.

 - `{{trans::foo_bar}}` => Replace `foo_bar` with the default message domain (*messages*), mostly not useful
 - `{{trans::foo_bar::app}}` => Replace `foo_bar` from `app` message domain
 - `{{trans::foo_bar::app::param1:param2}}` => Replace `foo_bar` from `app` message domain with parameters `param1` and `param2`. The parameters are separated by single colons, like they are for the `label` insert tag.