### PR TITLE
Allow asset cache busting if not combining assets

### DIFF
--- a/src/Resources/contao/classes/BackendTemplate.php
+++ b/src/Resources/contao/classes/BackendTemplate.php
@@ -78,7 +78,7 @@ class BackendTemplate extends \Template
 				}
 				else
 				{
-					$strStyleSheets .= \Template::generateStyleTag($this->addStaticUrlTo($stylesheet), $options->media);
+					$strStyleSheets .= \Template::generateStyleTag($this->addStaticUrlTo($stylesheet), $options->media, $options->mtime);
 				}
 			}
 
@@ -107,7 +107,7 @@ class BackendTemplate extends \Template
 				}
 				else
 				{
-					$strJavaScripts .= \Template::generateScriptTag($this->addStaticUrlTo($javascript), $options->async);
+					$strJavaScripts .= \Template::generateScriptTag($this->addStaticUrlTo($javascript), $options->async, $options->mtime);
 				}
 			}
 

--- a/src/Resources/contao/library/Contao/Combiner.php
+++ b/src/Resources/contao/library/Contao/Combiner.php
@@ -216,6 +216,8 @@ class Combiner extends \System
 					$objFile->close();
 				}
 
+				$strPath .= '?' . substr(md5(filemtime(TL_ROOT . '/' . $strPath)), 0, 8);
+
 				$return[] = $strPath;
 			}
 			else
@@ -227,6 +229,8 @@ class Combiner extends \System
 				{
 					$name = substr($name, \strlen($this->strWebDir) + 1);
 				}
+
+				$name .= '?' . substr(md5($arrFile['version']), 0, 8);
 
 				// Add the media query (see #7070)
 				if ($this->strMode == self::CSS && $arrFile['media'] != '' && $arrFile['media'] != 'all' && !$this->hasMediaTag($arrFile['name']))

--- a/src/Resources/contao/library/Contao/Template.php
+++ b/src/Resources/contao/library/Contao/Template.php
@@ -506,11 +506,18 @@ abstract class Template extends \Controller
 	 *
 	 * @param string $href  The script path
 	 * @param string $media The media type string
+	 * @param int    $mtime File mtime
 	 *
 	 * @return string The markup string
 	 */
-	public static function generateStyleTag($href, $media=null)
+	public static function generateStyleTag($href, $media=null, $mtime=null)
 	{
+		if (file_exists(TL_ROOT . '/' . $href))
+		{
+			$mtime = $mtime ?? filemtime(TL_ROOT . '/' . $href);
+			$href .= '?' . substr(md5($mtime), 0, 8);
+		}
+
 		return '<link rel="stylesheet" href="' . $href . '"' . (($media && $media != 'all') ? ' media="' . $media . '"' : '') . '>';
 	}
 
@@ -533,11 +540,18 @@ abstract class Template extends \Controller
 	 *
 	 * @param string  $src   The script path
 	 * @param boolean $async True to add the async attribute
+	 * @param int     $mtime File mtime
 	 *
 	 * @return string The markup string
 	 */
-	public static function generateScriptTag($src, $async=false)
+	public static function generateScriptTag($src, $async=false, $mtime=null)
 	{
+		if (file_exists(TL_ROOT . '/' . $src))
+		{
+			$mtime = $mtime ?? filemtime(TL_ROOT . '/' . $src);
+			$src .= '?' . substr(md5($mtime), 0, 8);
+		}
+
 		return '<script src="' . $src . '"' . ($async ? ' async' : '') . '></script>';
 	}
 


### PR DESCRIPTION
If you do not enable the checkbox to combine scripts in the layout, I think we should add a simple string to the file urls so we can benefit from cache busting. I'll add another PR for the manager-bundle to renable asset caching again for all assets by default.