### PR TITLE
[RFC] Index pages other than regular pages

### DIFF
--- a/src/Resources/contao/classes/Frontend.php
+++ b/src/Resources/contao/classes/Frontend.php
@@ -616,7 +616,7 @@ abstract class Frontend extends \Controller
 		}
 
 		// Index page if searching is allowed and there is no back end user
-		if (\Config::get('enableSearch') && $objPage->type == 'regular' && !BE_USER_LOGGED_IN && !$objPage->noSearch)
+		if (\Config::get('enableSearch') && \in_array($objPage->type, $GLOBALS['TL_INDEX_PAGES']) && !BE_USER_LOGGED_IN && !$objPage->noSearch)
 		{
 			// Index protected pages if enabled
 			if (\Config::get('indexProtected') || (!FE_USER_LOGGED_IN && !$objPage->protected))

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -413,7 +413,7 @@ $GLOBALS['TL_AUTO_ITEM'] = array('items', 'events');
 
 
 /**
- * Index only the following page types
+ * Register the pages to be indexed
  */
 $GLOBALS['TL_INDEX_PAGES'] = array('regular');
 

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -413,6 +413,12 @@ $GLOBALS['TL_AUTO_ITEM'] = array('items', 'events');
 
 
 /**
+ * Index only the following page types
+ */
+$GLOBALS['TL_INDEX_PAGES'] = array('regular');
+
+
+/**
  * Do not index a page if one of the following parameters is set
  */
 $GLOBALS['TL_NOINDEX_KEYS'] = array('id', 'file', 'token', 'day', 'month', 'year', 'page', 'PHPSESSID');


### PR DESCRIPTION
This PR adds the ability to index (and search) more not just regular pages.

Only regular pages are currently indexed : 
https://github.com/contao/core-bundle/blob/10efd81c1f99094af52f518f227e7a6c9db1e5a6/src/Resources/contao/classes/Frontend.php#L618-L625


When using a global variable to set the page types to be indexed, a developer would be able to make custom page types searchable. Simply by extending the global variable in the `config.php` file:
```php
$GLOBALS['TL_INDEX_PAGES'][] = 'mypagetobeindexed';
```

Since this should also be backward compatible, it would be desirable to integrate it into the 4.4 LTS version as well.