### PR TITLE
Fix strpos() strict types error

### DIFF
--- a/src/EventListener/BackendMenuListener.php
+++ b/src/EventListener/BackendMenuListener.php
@@ -55,7 +55,7 @@ class BackendMenuListener
 
             if (!$categoryNode) {
                 $categoryNode = $this->createNode($factory, $categoryName, $categoryData);
-                $categoryNode->setDisplayChildren(false !== strpos($categoryData['class'], 'node-expanded'));
+                $categoryNode->setDisplayChildren(false !== strpos((string) $categoryData['class'], 'node-expanded'));
 
                 $tree->addChild($categoryNode);
             }


### PR DESCRIPTION
I encountered an error which I guess corresponds to the `strict_types=1`.

![screen shot 2018-04-02 at 00 05 16](https://user-images.githubusercontent.com/1284725/38178128-52c64d54-360c-11e8-8f23-08a95d9c2714.png)

```
Symfony\Component\Debug\Exception\FatalThrowableError:
Type error: strpos() expects parameter 1 to be string, null given

  at vendor/contao/core-bundle/src/EventListener/BackendMenuListener.php:58
  at strpos(null, 'node-expanded')
     (vendor/contao/core-bundle/src/EventListener/BackendMenuListener.php:58)
  at Contao\CoreBundle\EventListener\BackendMenuListener->onBuild(object(MenuEvent), 'contao.backend_menu_build', object(TraceableEventDispatcher))
  at call_user_func(array(object(BackendMenuListener), 'onBuild'), object(MenuEvent), 'contao.backend_menu_build', object(TraceableEventDispatcher))
     (vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php:104)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(MenuEvent), 'contao.backend_menu_build', object(ContainerAwareEventDispatcher))
     (vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:212)
  at Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(array(object(WrappedListener)), 'contao.backend_menu_build', object(MenuEvent))
     (vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:44)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch('contao.backend_menu_build', object(MenuEvent))
     (vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php:139)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch('contao.backend_menu_build', object(MenuEvent))
     (vendor/contao/core-bundle/src/Menu/BackendMenuBuilder.php:52)
  at Contao\CoreBundle\Menu\BackendMenuBuilder->create()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:248)
  at Contao\BackendMain->output()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:138)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:50)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app_dev.php:65)
```