### PR TITLE
[RTM] allow multi root and multi page search

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -115,7 +115,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		'lostPassword'                => '{title_legend},name,headline,type;{config_legend},reg_skipName,disableCaptcha;{redirect_legend},jumpTo;{email_legend:hide},reg_jumpTo,reg_password;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'closeAccount'                => '{title_legend},name,headline,type;{config_legend},reg_close;{redirect_legend},jumpTo;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'form'                        => '{title_legend},name,headline,type;{include_legend},form;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
-		'search'                      => '{title_legend},name,headline,type;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},searchPages;{template_legend:hide},searchTpl,customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
+		'search'                      => '{title_legend},name,headline,type;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},pages;{template_legend:hide},searchTpl,customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'articlelist'                 => '{title_legend},name,headline,type;{config_legend},skipFirst,inColumn;{reference_legend:hide},defineRoot;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'flash'                       => '{title_legend},name,headline,type;{config_legend},size,transparent,flashvars,altContent;{source_legend},source;{interact_legend:hide},interactive;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'randomImage'                 => '{title_legend},name,headline,type;{source_legend},multiSRC,imgSize,fullsize,useCaption;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
@@ -238,16 +238,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
 			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		),
-		'searchPages' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['tl_module']['searchPages'],
-			'exclude'                 => true,
-			'inputType'               => 'pageTree',
-			'foreignKey'              => 'tl_page.title',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'tl_class'=>'clr'),
-			'sql'                     => "blob NULL",
-			'relation'                => array('type'=>'hasMany', 'load'=>'lazy')
-		),
 		'navigationTpl' => array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_module']['navigationTpl'],
@@ -273,6 +263,10 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'pageTree',
 			'foreignKey'              => 'tl_page.title',
 			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'orderField'=>'orderPages', 'mandatory'=>true),
+			'load_callback' => array
+			(
+				array('tl_module', 'setPagesFlags')
+			),
 			'sql'                     => "blob NULL",
 			'relation'                => array('type'=>'hasMany', 'load'=>'lazy')
 		),
@@ -1038,6 +1032,31 @@ class tl_module extends Backend
 			{
 				$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
 				$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
+			}
+		}
+
+		return $varValue;
+	}
+
+
+	/**
+	 * Dynamically change attributes of the "pages" field
+	 *
+	 * @param mixed         $varValue
+	 * @param DataContainer $dc
+	 *
+	 * @return mixed
+	 */
+	public function setPagesFlags($varValue, DataContainer $dc)
+	{
+		if ($dc->activeRecord)
+		{
+			switch ($dc->activeRecord->type)
+			{
+				case 'search':
+					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['mandatory'] = false;
+					unset($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['orderField']);
+					break;
 			}
 		}
 

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -115,7 +115,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		'lostPassword'                => '{title_legend},name,headline,type;{config_legend},reg_skipName,disableCaptcha;{redirect_legend},jumpTo;{email_legend:hide},reg_jumpTo,reg_password;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'closeAccount'                => '{title_legend},name,headline,type;{config_legend},reg_close;{redirect_legend},jumpTo;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'form'                        => '{title_legend},name,headline,type;{include_legend},form;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
-		'search'                      => '{title_legend},name,headline,type;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},rootPage;{template_legend:hide},searchTpl,customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
+		'search'                      => '{title_legend},name,headline,type;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},searchPages;{template_legend:hide},searchTpl,customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'articlelist'                 => '{title_legend},name,headline,type;{config_legend},skipFirst,inColumn;{reference_legend:hide},defineRoot;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'flash'                       => '{title_legend},name,headline,type;{config_legend},size,transparent,flashvars,altContent;{source_legend},source;{interact_legend:hide},interactive;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
 		'randomImage'                 => '{title_legend},name,headline,type;{source_legend},multiSRC,imgSize,fullsize,useCaption;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID',
@@ -237,6 +237,16 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'eval'                    => array('fieldType'=>'radio', 'tl_class'=>'clr'),
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
 			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
+		),
+		'searchPages' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_module']['searchPages'],
+			'exclude'                 => true,
+			'inputType'               => 'pageTree',
+			'foreignKey'              => 'tl_page.title',
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'tl_class'=>'clr'),
+			'sql'                     => "blob NULL",
+			'relation'                => array('type'=>'hasMany', 'load'=>'lazy')
 		),
 		'navigationTpl' => array
 		(

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -1026,18 +1026,14 @@ class tl_module extends Backend
 	 */
 	public function setMultiSrcFlags($varValue, DataContainer $dc)
 	{
-		if ($dc->activeRecord)
+		if ($dc->activeRecord && $dc->activeRecord->type == 'randomImage')
 		{
-			if ($dc->activeRecord->type == 'randomImage')
-			{
-				$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
-				$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
-			}
+			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
+			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
 		}
 
 		return $varValue;
 	}
-
 
 	/**
 	 * Dynamically change attributes of the "pages" field
@@ -1049,15 +1045,10 @@ class tl_module extends Backend
 	 */
 	public function setPagesFlags($varValue, DataContainer $dc)
 	{
-		if ($dc->activeRecord)
+		if ($dc->activeRecord && $dc->activeRecord->type == 'search')
 		{
-			switch ($dc->activeRecord->type)
-			{
-				case 'search':
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['mandatory'] = false;
-					unset($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['orderField']);
-					break;
-			}
+			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['mandatory'] = false;
+			unset($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['orderField']);
 		}
 
 		return $varValue;

--- a/src/Resources/contao/languages/en/tl_module.xlf
+++ b/src/Resources/contao/languages/en/tl_module.xlf
@@ -56,6 +56,12 @@
       <trans-unit id="tl_module.rootPage.1">
         <source>Please choose the reference page from the site structure.</source>
       </trans-unit>
+      <trans-unit id="tl_module.searchPages.0">
+        <source>Search pages</source>
+      </trans-unit>
+      <trans-unit id="tl_module.searchPages.1">
+        <source>Please choose the pages to be searched from the site structure.</source>
+      </trans-unit>
       <trans-unit id="tl_module.navigationTpl.0">
         <source>Navigation template</source>
       </trans-unit>

--- a/src/Resources/contao/languages/en/tl_module.xlf
+++ b/src/Resources/contao/languages/en/tl_module.xlf
@@ -56,12 +56,6 @@
       <trans-unit id="tl_module.rootPage.1">
         <source>Please choose the reference page from the site structure.</source>
       </trans-unit>
-      <trans-unit id="tl_module.searchPages.0">
-        <source>Search pages</source>
-      </trans-unit>
-      <trans-unit id="tl_module.searchPages.1">
-        <source>Please choose the pages to be searched from the site structure.</source>
-      </trans-unit>
       <trans-unit id="tl_module.navigationTpl.0">
         <source>Navigation template</source>
       </trans-unit>

--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -48,7 +48,7 @@ class ModuleSearch extends Module
 			return $objTemplate->parse();
 		}
 
-		$this->pages = \StringUtil::deserialize($this->pages, true);
+		$this->pages = \StringUtil::deserialize($this->pages);
 
 		return parent::generate();
 	}

--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -48,7 +48,7 @@ class ModuleSearch extends Module
 			return $objTemplate->parse();
 		}
 
-		$this->searchPages = \StringUtil::deserialize($this->searchPages, true);
+		$this->pages = \StringUtil::deserialize($this->pages, true);
 
 		return parent::generate();
 	}
@@ -103,12 +103,12 @@ class ModuleSearch extends Module
 		if ($strKeywords != '' && $strKeywords != '*' && !$this->jumpTo)
 		{
 			// Search pages
-			if (!empty($this->searchPages) && \is_array($this->searchPages))
+			if (!empty($this->pages) && \is_array($this->pages))
 			{
-				$varRootId = \implode('-', $this->searchPages);
+				$varRootId = \implode('-', $this->pages);
 				$arrPages = [];
 
-				foreach ($this->searchPages as $intPageId)
+				foreach ($this->pages as $intPageId)
 				{
 					$arrPages[] = $intPageId;
 					$arrPages = \array_merge($arrPages, $this->Database->getChildRecords($intPageId, 'tl_page'));

--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -48,6 +48,8 @@ class ModuleSearch extends Module
 			return $objTemplate->parse();
 		}
 
+		$this->searchPages = \StringUtil::deserialize($this->searchPages, true);
+
 		return parent::generate();
 	}
 
@@ -100,12 +102,19 @@ class ModuleSearch extends Module
 		// Execute the search if there are keywords
 		if ($strKeywords != '' && $strKeywords != '*' && !$this->jumpTo)
 		{
-			// Reference page
-			if ($this->rootPage > 0)
+			// Search pages
+			if (!empty($this->searchPages) && \is_array($this->searchPages))
 			{
-				$intRootId = $this->rootPage;
-				$arrPages = $this->Database->getChildRecords($this->rootPage, 'tl_page');
-				array_unshift($arrPages, $this->rootPage);
+				$varRootId = \implode('-', $this->searchPages);
+				$arrPages = [];
+
+				foreach ($this->searchPages as $intPageId)
+				{
+					$arrPages[] = $intPageId;
+					$arrPages = \array_merge($arrPages, $this->Database->getChildRecords($intPageId, 'tl_page'));
+				}
+
+				$arrPages = \array_unique($arrPages);
 			}
 			// Website root
 			else
@@ -113,7 +122,7 @@ class ModuleSearch extends Module
 				/** @var PageModel $objPage */
 				global $objPage;
 
-				$intRootId = $objPage->rootId;
+				$varRootId = $objPage->rootId;
 				$arrPages = $this->Database->getChildRecords($objPage->rootId, 'tl_page');
 			}
 
@@ -136,7 +145,7 @@ class ModuleSearch extends Module
 			$strCachePath = \StringUtil::stripRootDir(\System::getContainer()->getParameter('kernel.cache_dir'));
 
 			$arrResult = null;
-			$strChecksum = md5($strKeywords . $strQueryType . $intRootId . $blnFuzzy);
+			$strChecksum = md5($strKeywords . $strQueryType . $varRootId . $blnFuzzy);
 			$query_starttime = microtime(true);
 			$strCacheFile = $strCachePath . '/contao/search/' . $strChecksum . '.json';
 


### PR DESCRIPTION
These changes allow you to expand/limit the search to multiple pages or website roots. This enables you to:

* limit the search to multiple pages and its children - instead of just one page and its children
* expand the search over multiple website roots - instead of being restricted to the current website root

The changes are fairly simple and straight forward. I tagged it as RFC since I am unsure whether the use of a new field called `searchPages` is really necessary. I decided to not use the existing `pages` field, since the sort order does not matter. Though may be I should simply alter the DCA in a `load_callback`, similar to `tl_content::setSingleSrcFlags`? Then the `pages` field could be reused for this.