### PR TITLE
use www.youtube-nocookie.com domain

### DIFF
--- a/src/Resources/contao/elements/ContentYouTube.php
+++ b/src/Resources/contao/elements/ContentYouTube.php
@@ -108,7 +108,7 @@ class ContentYouTube extends \ContentElement
 			$params[] = 'end=' . (int) $this->youtubeStop;
 		}
 
-		$url = 'https://www.youtube.com/embed/' . $this->youtube;
+		$url = 'https://www.youtube-nocookie.com/embed/' . $this->youtube;
 
 		if (!empty($params))
 		{


### PR DESCRIPTION
YouTube calls this the "privacy-enhanced mode" in the embed dialogue.

> When you turn on privacy-enhanced mode, YouTube won't store information about visitors on your website unless they play the video.

It doesn't do all that much, but I think there is no reason _not_ to use it.
            