### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "ext-dom": "*",
         "ext-gd": "*",
         "ext-pcre": "*",
@@ -36,11 +36,11 @@
         "contao-components/tablesorter": "^2.0.5.3",
         "contao-components/tinymce4": "4.6.*",
         "contao/image": "^0.3.1",
-        "contao/imagine-svg": "^0.1.2|^0.2",
+        "contao/imagine-svg": "^0.1.2 || ^0.2",
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.3",
-        "imagine/imagine": "^0.6|^0.7",
+        "imagine/imagine": "^0.6 || ^0.7",
         "knplabs/knp-menu-bundle": "^2.1",
         "knplabs/knp-time-bundle": "^1.5.2",
         "leafo/scssphp": "^0.6",
@@ -75,8 +75,8 @@
         "doctrine/doctrine-migrations-bundle": "<1.1",
         "doctrine/orm": "<2.4",
         "lexik/maintenance-bundle": "2.1.4",
-        "symfony/finder": "3.4.7|4.0.7",
-        "symfony/security": "3.4.7|4.0.7",
+        "symfony/finder": "3.4.7 || 4.0.7",
+        "symfony/security": "3.4.7 || 4.0.7",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2"
     },
     "require-dev": {


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range). See also https://github.com/composer/composer/issues/6755.