### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "contao-components/tablesorter": "^2.0.5.3",
         "contao-components/tinymce4": "^4.7",
         "contao/image": "^0.3.5",
-        "contao/imagine-svg": "^0.1.2|^0.2",
+        "contao/imagine-svg": "^0.1.2 || ^0.2",
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.3",
@@ -53,7 +53,7 @@
         "oyejorge/less.php": "^1.7",
         "patchwork/utf8": "^1.2",
         "phpspec/php-diff": "^1.0",
-        "phpunit/php-token-stream": "^1.4|^2.0|^3.0",
+        "phpunit/php-token-stream": "^1.4 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
         "sensio/framework-extra-bundle": "^5.0",
         "simplepie/simplepie": "^1.3",
@@ -71,7 +71,7 @@
         "tecnickcom/tcpdf": "^6.0",
         "terminal42/header-replay-bundle": "^1.4",
         "true/punycode": "^2.1",
-        "twig/twig": "^1.26|^2.0"
+        "twig/twig": "^1.26 || ^2.0"
     },
     "conflict": {
         "contao/core": "*",
@@ -80,7 +80,7 @@
         "doctrine/doctrine-migrations-bundle": "<1.1",
         "doctrine/orm": "<2.4",
         "lexik/maintenance-bundle": "2.1.4",
-        "symfony/finder": "3.4.7|4.0.7",
+        "symfony/finder": "3.4.7 || 4.0.7",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2"
     },
     "require-dev": {


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).