### PR TITLE
Optimize the StringUtil::deserialize() method

### DIFF
--- a/src/Resources/contao/library/Contao/StringUtil.php
+++ b/src/Resources/contao/library/Contao/StringUtil.php
@@ -1050,6 +1050,7 @@ class StringUtil
 		}
 
 		// Return if definitely not a serialized string
+		// See https://github.com/php/php-src/blob/master/ext/standard/var_unserializer.c#L711-L722
 		if (!preg_match('/^[CONRSabdiors]:[0-9]+:/', $varValue))
 		{
 			return $blnForceArray ? array($varValue) : $varValue;

--- a/src/Resources/contao/library/Contao/StringUtil.php
+++ b/src/Resources/contao/library/Contao/StringUtil.php
@@ -1049,6 +1049,12 @@ class StringUtil
 			return $blnForceArray ? array() : '';
 		}
 
+		// Return if definitely not a serialized string
+		if (!preg_match('/^[CONRSabdiors]:[0-9]+:/', $varValue))
+		{
+			return $blnForceArray ? array($varValue) : $varValue;
+		}
+
 		// Potentially including an object (see #6724)
 		if (preg_match('/[OoC]:\+?[0-9]+:"/', $varValue))
 		{

--- a/src/Resources/contao/library/Contao/StringUtil.php
+++ b/src/Resources/contao/library/Contao/StringUtil.php
@@ -1049,9 +1049,8 @@ class StringUtil
 			return $blnForceArray ? array() : '';
 		}
 
-		// Return if definitely not a serialized string
-		// See https://github.com/php/php-src/blob/master/ext/standard/var_unserializer.c#L711-L722
-		if (!preg_match('/^[CONRSabdiors]:[0-9]+:/', $varValue))
+		// Not a serialized array (see #1486)
+		if (strncmp($varValue, 'a:', 2) !== 0)
 		{
 			return $blnForceArray ? array($varValue) : $varValue;
 		}


### PR DESCRIPTION
This PR uses a simple regex to filter strings which are definitely not serialized strings. It noticeably reduces the number of `unserialize()` calls and speeds up the method by up to 70% (see https://3v4l.org/F3gdM and https://3v4l.org/6oSrr).