### PR TITLE
Fixed numeric aliases 404 handling

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -168,16 +168,10 @@ class FrontendIndex extends \Frontend
 		// If the page has an alias, it can no longer be called via ID (see #7661)
 		if ($objPage->alias != '')
 		{
-			if (\Config::get('addLanguageToUrl'))
-			{
-				$regex = '#^[a-z]{2}(-[A-Z]{2})?/' . $objPage->id . '[$/.]#';
-			}
-			else
-			{
-				$regex = '#^' . $objPage->id . '[$/.]#';
-			}
+			$language = \Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
+			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '$';
 
-			if (preg_match($regex, \Environment::get('relativeRequest')))
+			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '|/)#', \Environment::get('relativeRequest')))
 			{
 				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 			}


### PR DESCRIPTION
When you don't have an url suffix configured or it does not start by a `.`, the current regex does not match and thus the 404 page is not shown but instead the content of the page is loaded.

Steps to reproduce:

1. Configure `urlSuffix` to be an empty string `''`.
2. Add some regular content page with the alias `foobar` and note your id (e.g. `42`).
3. Call `/42`.

Expected:

I expect to be redirected to the configured 404 page because the page id 42 has a configured alias `foobar`.

What happens:

I can see the content of page ID `42`.