### PR TITLE
Throw page not found if no explicit page was found but language was provided

### DIFF
--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -152,7 +152,7 @@ class FrontendIndex extends \Frontend
 			}
 
 			// Throw an exception if language was provided but no page was matched
-			elseif (isset($lang) && $lang)
+			elseif (!empty($_GET['language']))
 			{
 				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 			}

--- a/src/Resources/contao/controllers/FrontendIndex.php
+++ b/src/Resources/contao/controllers/FrontendIndex.php
@@ -150,6 +150,12 @@ class FrontendIndex extends \Frontend
 			{
 				$objPage = $objNewPage;
 			}
+
+			// Throw an exception if language was provided but no page was matched
+			elseif (isset($lang) && $lang)
+			{
+				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
+			}
 		}
 
 		// Throw a 500 error if the result is still ambiguous


### PR DESCRIPTION
This is rather an edge case issue but still a problem, especially if you configure the site structure in a extraordinary way. Both Contao 4.4 and 4.5 are affected.

Steps to reproduce on demo contao.org. Have three published website roots:

- DE
  - Alias: foobar-de
  - Language: de
- EN1
  - Domain name: demo.contao.org
  - Alias: en
  - Language: en
- EN2
  - Domain name: foobar.contao.org
  - Alias: en
  - Language: en

Now if you open the URL https://demo.contao.org/de/en.html Contao will find two website root points: EN1 and EN2. In the class `Contao\FrontendIndex` at line 96 the script will try to determine which page to use. Unfortunately both pages have the English language whereas we specified the `de/` in the URL. Thus none of the statements on lines 130-146 will be executed and `$objPage` will remain unaltered. This will lead to the `LogicException` on line 162.

According to me, this is wrong because if there is no single page or multiple pages matching the provided language, then you should definitely throw the page not found exception. The ambiguous pages logic exception makes sense if there are multiple pages that actually match the language.

https://github.com/contao/core-bundle/blob/master/src/Resources/contao/controllers/FrontendIndex.php#L90

/cc @Toflar 