### PR TITLE
Fix the potential scandir() error in the helper functions

### DIFF
--- a/src/Resources/contao/helper/functions.php
+++ b/src/Resources/contao/helper/functions.php
@@ -67,10 +67,16 @@ function scan($strFolder, $blnUncached=false)
 		return $arrScanCache[$strFolder];
 	}
 
+	// Return an empty array if the directory can not be read
+	if (($arrScan = scandir($strFolder)) === false)
+	{
+		return array();
+	}
+
 	$arrReturn = array();
 
 	// Scan directory
-	foreach (scandir($strFolder) as $strFile)
+	foreach ($arrScan as $strFile)
 	{
 		if ($strFile == '.' || $strFile == '..')
 		{


### PR DESCRIPTION
We have the below exception logged in the Sentry. In fact the `scandir()` can return also a `false` according to the documentation:

```
Returns an array of filenames on success, or FALSE on failure. If directory is not a directory, then boolean FALSE is returned, and an error of level E_WARNING is generated.
```

Exception:

```
ErrorException: Invalid argument supplied for foreach()
#18 vendor/contao/core-bundle/src/Resources/contao/helper/functions.php(73): handleError
#17 vendor/contao/core-bundle/src/Resources/contao/helper/functions.php(73): scan
#16 vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Folder.php(2502): generateTree
#15 vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Folder.php(2455): ajaxTreeView
#14 vendor/contao/core-bundle/src/Resources/contao/classes/Ajax.php(195): executePostActions
#13 vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php(412): getBackendModule
#12 vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php(132): run
#11 vendor/contao/core-bundle/src/Controller/BackendController.php(55): mainAction
#10 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): handleRaw
#9 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): handle
#8 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(202): handle
#7 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(462): forward
#6 vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php(57): forward
#5 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(234): pass
#4 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(251): invalidate
#3 vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(126): invalidate
#2 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(177): handle
#1 vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(98): handle
#0 web/app.php(33): null
```