### PR TITLE
[RFC] Fix breadcrumb schema

### DIFF
--- a/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/src/Resources/contao/templates/frontend/fe_page.html5
@@ -34,7 +34,7 @@
 
       <?php $this->block('header'); ?>
         <?php if ($this->header): ?>
-          <header id="header" itemscope itemtype="http://schema.org/WPHeader">
+          <header id="header">
             <div class="inside">
               <?= $this->header ?>
             </div>
@@ -48,7 +48,7 @@
         <div id="container">
 
           <?php $this->block('main'); ?>
-            <main id="main" itemscope itemtype="http://schema.org/WebPageElement" itemprop="mainContentOfPage">
+            <main id="main">
               <div class="inside">
                 <?= $this->main ?>
               </div>
@@ -83,7 +83,7 @@
 
       <?php $this->block('footer'); ?>
         <?php if ($this->footer): ?>
-          <footer id="footer" itemscope itemtype="http://schema.org/WPFooter">
+          <footer id="footer">
             <div class="inside">
               <?= $this->footer ?>
             </div>

--- a/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -2,7 +2,7 @@
 
 <?php $this->block('content'); ?>
 
-  <ul itemscope itemtype="http://schema.org/BreadcrumbList">
+  <ul itemprop="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
     <?php foreach ($this->items as $item): ?>
       <?php if ($item['isActive']): ?>
         <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><span itemprop="name"><?= $item['link'] ?></span></li>


### PR DESCRIPTION
This should fix #1421 and #1429.

I think the problem why Google does not show the breadcrumb in the search results is because of a missing link between the webpage and the breadcrumb. This can be fixed by adding `itemprop="breadcrumb"` to mod_breadcrumb and removing the header, main and footer `itemscope`s from fe_page.

![breadcrumbs](https://user-images.githubusercontent.com/367169/40192687-6212883c-5a05-11e8-9898-f19b35be0de8.png)

@Xendiadyon can you test in one of your pages if the changes from this pull request fix the issue?