### PR TITLE
fix mode 1 sorting by flag for multiple fields

### DIFF
--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -4606,6 +4606,14 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				list($key, $direction) = explode(' ', $v, 2);
 
+				if ($direction === null)
+                {
+                    if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 1 && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0)
+                    {
+                        $direction = "DESC";
+                    }
+                }
+
 				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['findInSet'])
 				{
 					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback']))
@@ -4659,11 +4667,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				$query .= " ORDER BY " . implode(', ', $orderBy);
 			}
-		}
-
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 1 && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0)
-		{
-			$query .= " DESC";
 		}
 
 		$objRowStmt = $this->Database->prepare($query);

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -4606,11 +4606,21 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				list($key, $direction) = explode(' ', $v, 2);
 
-				if ($direction === null)
+				if ($direction === null && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 1)
                 {
-                    if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 1 && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0)
+                    if (isset($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag']))
                     {
-                        $direction = "DESC";
+                        $direction = (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0) ? "DESC" : "ASC";
+                    }
+
+                    if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['flag']))
+                    {
+                        $direction = (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['flag'] % 2) == 0) ? "DESC" : "ASC";
+                    }
+
+                    if ($direction)
+                    {
+                        $orderBy[$k] = "$key $direction";
                     }
                 }
 


### PR DESCRIPTION
WIth the following dca configuration
```
    ...
    'list' => [
        'sorting' => [
            'mode' => 1,
            'fields' => ['date_start', 'date_stop'],
            'flag' => 8, // sort descending by month
        ],
        ...
```
I'd expect the records to be sorted first descending by `date_start` then descending by `date_stop`, instead they are sorted ascending by `date_start` and descending by `date_stop`.

This is caused by https://github.com/contao/core-bundle/blob/4.4/src/Resources/contao/drivers/DC_Table.php#L4664 where the SQL for the sorting direction is only added once at the end, instead of being added to every field.

This PR fixes this issue by setting the sorting for each field according to the chosen flag, except where it was set explicitly (e.g. `'fields' => ['date_start', 'date_stop ASC'],`).


It also fixes an SQL syntax error when neither sorting fields nor sorting flag are given (`DESC` was added to the query string, although there was no `ORDER BY ...` part).
Futher it fixes another SQL syntax error, when an even flag or no flag at all is given, and the last field has its sorting set explicitly (`DESC` was added twice in this case).