### PR TITLE
Fix a potential problem with image object class ambiguity in Controller::addImageToTemplate method

### DIFF
--- a/src/Resources/contao/library/Contao/Controller.php
+++ b/src/Resources/contao/library/Contao/Controller.php
@@ -1518,7 +1518,7 @@ abstract class Controller extends \System
 		}
 
 		// Image dimensions
-		if ($objFile->exists() && ($imgSize = $objFile->imageSize) !== false)
+		if (is_a($objFile, \File::class) && $objFile->exists() && ($imgSize = $objFile->imageSize) !== false)
 		{
 			$objTemplate->arrSize = $imgSize;
 			$objTemplate->imgSize = ' width="' . $imgSize[0] . '" height="' . $imgSize[1] . '"';


### PR DESCRIPTION
In the `Controller::addImageToTemplate` method if the `File` cannot be initialized it is replaced by `stdClass` instance:

https://github.com/contao/core-bundle/blob/4.4/src/Resources/contao/library/Contao/Controller.php#L1431

Thus it can result in an error because the further code assumes it is always the `File` instance and happily tries to call its methods. We have caught this error using Sentry, here is the log:

```
ErrorException: Uncaught Symfony\Component\Debug\Exception\UndefinedMethodException: Attempted to call an undefined method named "exists" of class "stdClass". in /var/www/vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:1521
Stack trace:
#0 /var/www/src/AppBundle/Resources/contao/templates/elements/rsce_slider.html5(62): Contao\Controller::addImageToTemplate(Object(stdClass), Array)
#1 /var/www/vendor/contao/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php(96): include('/var/www/...')
#2 /var/www/vendor/contao/core-bundle/src/Resources/contao/library/Contao/Template.php(268): Contao\Template->inherit()
#3 /var/www/vendor/contao/core-bundle/src/Resources/contao/classes/FrontendTem
#1 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php(1521): handleFatalError
#0 vendor/sentry/sentry/lib/Raven/ErrorHandler.php(0): null
```