### PR TITLE
[RFC] Fix abandoned packages on composer install/update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ script:
   - php vendor/bin/phpunit $COVERAGE
 
 after_script:
-  - if [[ $COVERAGE ]]; then php vendor/bin/coveralls; fi
+  - if [[ $COVERAGE ]]; then php vendor/bin/php-coveralls; fi

--- a/composer.json
+++ b/composer.json
@@ -94,10 +94,10 @@
         "leofeyer/optimize-native-functions-fixer": "^1.0",
         "lexik/maintenance-bundle": "^2.0",
         "monolog/monolog": "^1.22",
+        "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
         "phpunit/phpunit": "^6.1",
-        "php-coveralls/php-coveralls": "^2.0",
         "symfony/phpunit-bridge": "^3.3.11"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
         "phpunit/phpunit": "^6.1",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.0",
         "symfony/phpunit-bridge": "^3.3.11"
     },
     "suggest": {


### PR DESCRIPTION
```
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Package satooshi/php-coveralls is abandoned, you should avoid using it. Use php-coveralls/php-coveralls instead.
```
Don't know if we can use `php-coveralls/php-coveralls` in version `2.x`.