### PR TITLE
Pass search result data to the search template

### DIFF
--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -260,6 +260,7 @@ class ModuleSearch extends Module
 			{
 				/** @var FrontendTemplate|object $objTemplate */
 				$objTemplate = new \FrontendTemplate($this->searchTpl);
+				$objTemplate->setData($arrResult[$i]);
 
 				$objTemplate->href = $arrResult[$i]['url'];
 				$objTemplate->link = $arrResult[$i]['title'];
@@ -267,8 +268,6 @@ class ModuleSearch extends Module
 				$objTemplate->title = \StringUtil::specialchars(\StringUtil::stripInsertTags($arrResult[$i]['title']));
 				$objTemplate->class = (($i == ($from - 1)) ? 'first ' : '') . (($i == ($to - 1) || $i == ($count - 1)) ? 'last ' : '') . (($i % 2 == 0) ? 'even' : 'odd');
 				$objTemplate->relevance = sprintf($GLOBALS['TL_LANG']['MSC']['relevance'], number_format($arrResult[$i]['relevance'] / $arrResult[0]['relevance'] * 100, 2) . '%');
-				$objTemplate->filesize = $arrResult[$i]['filesize'];
-				$objTemplate->matches = $arrResult[$i]['matches'];
 
 				$arrContext = array();
 				$strText = \StringUtil::stripInsertTags($arrResult[$i]['text']);


### PR DESCRIPTION
At the moment it's not possible to access enriched search result data in the `search_*` template. Such data could be added using the `indexPage` hook, f.e. a preview image or additional descriptions. 

This pull requests provides access to all data being stored in the `tl_search` dataset.