### PR TITLE
[RFC] Quick draft of event helper

### DIFF
--- a/src/DataContainer/EventHelper.php
+++ b/src/DataContainer/EventHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Contao\CoreBundle\DataContainer;
+
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\System;
+
+class EventHelper
+{
+    /**
+     * @var System
+     */
+    private $system;
+
+    /**
+     * Constructor.
+     *
+     * @param ContaoFrameworkInterface $framework
+     */
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->system = $framework->getAdapter(System::class);
+    }
+
+    /**
+     * Triggers a callback whilte handling singleton and service classes.
+     *
+     * @param array|callable $callback
+     * @param array          $arguments
+     *
+     * @return mixed
+     */
+    public function trigger($callback, array $arguments = [])
+    {
+        if (\is_array($callback)) {
+            return call_user_func_array(
+                [$this->system->importStatic($callback[0]), $callback[1]],
+                $arguments
+            );
+        }
+
+        if (\is_callable($callback)) {
+            return call_user_func_array($callback, $arguments);
+        }
+
+        throw new \InvalidArgumentException(sprintf('Cannot trigger "%s"', var_export($callback, true)));
+    }
+
+    /**
+     * Triggers an array of callback.
+     *
+     * @param array         $callbacks
+     * @param array         $arguments
+     * @param mixed|null    $returnArgument
+     * @param callable|null $returnIf
+     *
+     * @return mixed
+     */
+    public function triggerAll(array $callbacks, array $arguments = [], $returnArgument = null, callable $returnIf = null)
+    {
+        $result = null;
+
+        foreach ($callbacks as $callback) {
+            $result = $this->trigger($callback, $arguments);
+
+            if (null !== $returnIf && true === $returnIf($result)) {
+                return $result;
+            }
+
+            if (null !== $returnArgument) {
+                $arguments[$returnArgument] = $result;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -459,3 +459,6 @@ services:
             - "@contao.routing.scope_matcher"
         tags:
             - { name: twig.extension }
+
+    Contao\CoreBundle\DataContainer\EventHelper:
+        arguments: ['@contao.framework']


### PR DESCRIPTION
Just a quick idea I came up with to deal with the repetitive code when calling hooks and callbacks.

Example usage:

Call simple hook (https://github.com/contao/core-bundle/blob/fa05410fbd75cca7655599e59972475fe371ca0e/src/Resources/contao/pages/PageRegular.php#L77-L85)
```php
if (isset($GLOBALS['TL_HOOKS']['getPageLayout']) && \is_array($GLOBALS['TL_HOOKS']['getPageLayout']))
{
	$helper->triggerAll(
		$GLOBALS['TL_HOOKS']['getPageLayout'],
		[$objPage, $objLayout, $this]
	);
}
```

Call hook with return value (https://github.com/contao/core-bundle/blob/60403e47690ffcc253096750719a7d310f5f4561/src/Resources/contao/classes/FrontendTemplate.php#L56-L64)
```php
// HOOK: add custom parse filters
if (isset($GLOBALS['TL_HOOKS']['parseFrontendTemplate']) && \is_array($GLOBALS['TL_HOOKS']['parseFrontendTemplate']))
{
	$strBuffer = $helper->triggerAll(
		$GLOBALS['TL_HOOKS']['parseFrontendTemplate'],
		[$strBuffer, $this->strTemplate],
		0
	];
}
```

Call hook with return validation (https://github.com/contao/core-bundle/blob/5a411a7383e7ef24289bc6a739269ae572a52db1/src/Resources/contao/library/Contao/InsertTags.php#L985-L999)
```php
if (isset($GLOBALS['TL_HOOKS']['replaceInsertTags']) && \is_array($GLOBALS['TL_HOOKS']['replaceInsertTags']))
{
	$varValue = $helper->triggerAll(
		$GLOBALS['TL_HOOKS']['replaceInsertTags'],
		[$tag, $blnCache, $arrCache[$strTag], $flags, $tags, $arrCache, $_rit, $_cnt],
		null,
		function ($result) { return $varValue !== false; }
	);

	if ($varValue !== false)
	{
		$arrCache[$strTag] = $varValue;
		break 2;
	}
}
```

The same works for every DCA callback. We could also add a quick helper to call `isset` and `is_array` on hooks, but that won't work for callbacks.