### PR TITLE
[RFC] Fix: PHP files do not work in app/Resources/contao/languages

### DIFF
--- a/src/Config/Loader/PhpFileIncluder.php
+++ b/src/Config/Loader/PhpFileIncluder.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Config\Loader;
+
+use Symfony\Component\Config\Loader\Loader;
+
+/**
+ * Includes the given php file, e.g. for old php/GLOBALS based translations
+ *
+ * @author Mike vom Scheidt <https://github.com/mvscheidt>
+ */
+class PhpFileIncluder extends Loader
+{
+    /**
+     * Includes a php file
+     *
+     * @param string      $file
+     * @param string|null $type
+     *
+     * @return void
+     */
+    public function load($file, $type = null)
+    {
+        $this->includePhp($file);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'php' === pathinfo($resource, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * includes the given file
+     *
+     * @param $file
+     */
+    private function includePhp($file)
+    {
+        include $file;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -221,6 +221,29 @@ services:
             - "%contao.resources_paths%"
         public: true
 
+    contao.file_loader.xliff:
+        class: Contao\CoreBundle\Config\Loader\XliffFileLoader
+        arguments:
+            - "%kernel.project_dir%"
+            - true
+        public: true
+
+    contao.file_includer.php:
+        class: Contao\CoreBundle\Config\Loader\PhpFileIncluder
+        public: true
+
+    contao.resource_loader.resolver:
+        class: Symfony\Component\Config\Loader\LoaderResolver
+        arguments:
+            - ["@contao.file_loader.xliff", "@contao.file_includer.php"]
+        public: true
+
+    contao.resource_loader.delegator:
+        class: Symfony\Component\Config\Loader\DelegatingLoader
+        arguments:
+            - "@contao.resource_loader.resolver"
+        public: true
+
     contao.routing.frontend_loader:
         class: Contao\CoreBundle\Routing\FrontendLoader
         arguments:

--- a/tests/Config/Loader/PhpFileIncluderTest.php
+++ b/tests/Config/Loader/PhpFileIncluderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Config\Loader;
+
+use Contao\CoreBundle\Config\Loader\PhpFileIncluder;
+use Contao\CoreBundle\Tests\TestCase;
+
+/**
+ * Tests the PhpFileIncluderTest class.
+ *
+ * @author Mike vom Scheidt <https://github.com/mvscheidt>
+ */
+class PhpFileIncluderTest extends TestCase
+{
+    /**
+     * @var PhpFileIncluder
+     */
+    private $loader;
+
+    /**
+     * Creates the PhpFileIncluder object.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->loader = new PhpFileIncluder();
+    }
+
+    /**
+     * Tests the object instantiation.
+     */
+    public function testCanBeInstantiated()
+    {
+        $this->assertInstanceOf('Contao\CoreBundle\Config\Loader\PhpFileIncluder', $this->loader);
+    }
+
+    /**
+     * Tests that only PHP files are supported.
+     */
+    public function testSupportsPhpFiles()
+    {
+        $this->assertTrue(
+            $this->loader->supports(
+                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php'
+            )
+        );
+
+        $this->assertFalse(
+            $this->loader->supports(
+                $this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/default.xlf'
+            )
+        );
+    }
+
+    /**
+     * Tests loading a PHP file.
+     */
+    public function testIncludesPhpFiles()
+    {
+        $this->loader->load($this->getRootDir().'/vendor/contao/test-bundle/Resources/contao/languages/en/tl_test.php');
+
+        $this->assertArrayHasKey('TL_TEST', $GLOBALS);
+        $this->assertEquals(true, $GLOBALS['TL_TEST']);
+    }
+}


### PR DESCRIPTION
See #740 

I've replaced the old implementation which had two foreach Loops (one for php, one for xliff) with Symfonys LoaderResolver and LoaderDelegator.

The Loader Resolver is configured to Resolve xliff files with the existing `Contao\CoreBundle\Config\Loader\XliffFileLoader` - for php files I created a new Loader Class `Contao\CoreBundle\Config\Loader\PhpFileIncluder` which basically wraps the `include $file` statement that used to be in the System Class.

I didn't use the existing `Contao\CoreBundle\Config\Loader\PhpFileLoader` because it works differently (it strips some stuff from php files and writes the result to the cache files)

Technically we could turn the supported endings/loaders into a yml based configuration, but I'd say that would be a new feature request if it would be needed.

----

As I've written [here](https://github.com/contao/core-bundle/issues/740#issuecomment-384211116) this fix only needs to apply if you did NOT warmup the cache.

Warming up the cache bypasses the problem for both entrypoints (`app.php` and `app_dev.php`).

Reason for this is that the warmup command does something similar like I did here already.