### PR TITLE
Fixed DoctrineMigrationsPass not working with latest Symfony 3.4+

### DIFF
--- a/src/ContaoCoreBundle.php
+++ b/src/ContaoCoreBundle.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\DoctrineMigrationsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Symfony\Component\Console\Application;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -62,7 +63,7 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new AddSessionBagsPass());
         $container->addCompilerPass(new AddResourcesPathsPass());
         $container->addCompilerPass(new AddImagineClassPass());
-        $container->addCompilerPass(new DoctrineMigrationsPass());
+        $container->addCompilerPass(new DoctrineMigrationsPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new PickerProviderPass());
     }
 }

--- a/tests/ContaoCoreBundleTest.php
+++ b/tests/ContaoCoreBundleTest.php
@@ -60,10 +60,16 @@ class ContaoCoreBundleTest extends TestCase
         $bundle->build($container);
 
         $classes = [];
+        $beforeRemovingClasses = [];
 
         foreach ($container->getCompilerPassConfig()->getPasses() as $pass) {
             $reflection = new \ReflectionClass($pass);
             $classes[] = $reflection->getName();
+        }
+
+        foreach ($container->getCompilerPassConfig()->getBeforeRemovingPasses() as $pass) {
+            $reflection = new \ReflectionClass($pass);
+            $beforeRemovingClasses[] = $reflection->getName();
         }
 
         $this->assertContains(AddPackagesPass::class, $classes);
@@ -71,5 +77,6 @@ class ContaoCoreBundleTest extends TestCase
         $this->assertContains(AddResourcesPathsPass::class, $classes);
         $this->assertContains(AddImagineClassPass::class, $classes);
         $this->assertContains(DoctrineMigrationsPass::class, $classes);
+        $this->assertContains(DoctrineMigrationsPass::class, $beforeRemovingClasses);
     }
 }


### PR DESCRIPTION
The changes in https://github.com/symfony/symfony/pull/27272 broke our support for doctrine migrations support.