### PR TITLE
[RFC] File accessibility check for various content elements

### DIFF
--- a/src/Resources/contao/languages/de/tl_content.xlf
+++ b/src/Resources/contao/languages/de/tl_content.xlf
@@ -845,6 +845,14 @@
         <source>Import table items from a CSV file</source>
         <target>Tabelleneinträge aus einer CSV-Datei importieren</target>
       </trans-unit>
+      <trans-unit id="tl_content.fileAccessibility">
+        <source>Warning: Your selected source file isn't public and therefore won't be accessible in the frontend.</source>
+        <target>Warnung: Die gewählte Quelldatei ist nicht öffentlich und somit im Frontend nicht erreichbar.</target>
+      </trans-unit>
+      <trans-unit id="tl_content.filesAccessibility">
+        <source>Warning: You have selected %s source files/folders which aren't public and therefore won't be accessible in the frontend.</source>
+        <target>Warnung: %s der gewählten Quelldateien/Ordner sind nicht öffentlich und somit im Frontend nicht erreichbar.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/contao/languages/en/tl_content.xlf
+++ b/src/Resources/contao/languages/en/tl_content.xlf
@@ -698,6 +698,12 @@
       <trans-unit id="tl_content.table.1">
         <source>Import table items from a CSV file</source>
       </trans-unit>
+      <trans-unit id="tl_content.fileAccessibility">
+        <source>Warning: Your selected source file isn't public and therefore won't be accessible in the frontend.</source>
+      </trans-unit>
+      <trans-unit id="tl_content.filesAccessibility">
+        <source>Warning: You have selected %s source files/folders which aren't public and therefore won't be accessible in the frontend.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
as requested in  #1531 

Checks are now made on load of  `text`, `accordionSingle`, `hyperlink`, `image` (single source) as well as `gallery` and `player` (multi source) content elements: a  message gets show if any of the selected sources is protected. 

![screenshot_file_access](https://user-images.githubusercontent.com/5305677/42034956-f150cc64-7ae1-11e8-8813-0da5ca0062cb.png)

Open questions:
- Should we rather target all content elements and explicitly remove `download` / `downloads` instead so that it also applies to extensions that are using these fields?
- Or: Which core extension content elements should be added?
- The grammar for selecting one protected element in the multi source case is a bit off but I didn't want to add even more language strings  - any better solution?

Remarks:
- The functionality for `isProtectedPath()` is identical to this function inside `DC_Folder`
https://github.com/contao/core-bundle/blob/ac908c6f16bc1cd110569be8661043cbf02d74ae/src/Resources/contao/drivers/DC_Folder.php#L2984-L3005
It wouldn't make any sense to make the `DC_Folder` function public/static (wrong responsibility) so this should probably be factored out some day (DRY). 