### PR TITLE
Added extra values to composer.json section in the installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@ Edit your `composer.json` file and add the following:
 "config": {
     "component-dir": "assets"
 },
-"post-install-cmd": [
-    "Contao\\CoreBundle\\Composer\\ScriptHandler::addDirectories",
-    "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
-],
-"post-update-cmd": [
-    "Contao\\CoreBundle\\Composer\\ScriptHandler::addDirectories",
-    "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
-]
+"scripts": {
+    "post-install-cmd": [
+        "Contao\\CoreBundle\\Composer\\ScriptHandler::addDirectories",
+        "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
+    ],
+    "post-update-cmd": [
+        "Contao\\CoreBundle\\Composer\\ScriptHandler::addDirectories",
+        "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
+    ],
+}
+"extra": {
+    "symfony-bin-dir": "bin",
+    "symfony-var-dir": "var",
+}
 ```
 
 Then run `php composer.phar update` to install the vendor files.


### PR DESCRIPTION
In order to let the `ScriptHandler` guess where the `console` binary is found, we need to add at least the following two extra values.

```
"symfony-bin-dir": "bin",
"symfony-var-dir": "var"
```

Otherwise it will default to `app/console` and any composer process which involves `run-script` will return an error:

```
> post-install-cmd: Contao\CoreBundle\Composer\ScriptHandler::addDirectories
Could not open input file: app/console
Script Contao\CoreBundle\Composer\ScriptHandler::addDirectories handling the post-install-cmd event terminated with an exception
```