### PR TITLE
[RFC] change lock file directory

### DIFF
--- a/src/Command/AbstractLockedCommand.php
+++ b/src/Command/AbstractLockedCommand.php
@@ -29,7 +29,7 @@ abstract class AbstractLockedCommand extends ContainerAwareCommand
     {
         $lock = new LockHandler(
             $this->getName(),
-            sys_get_temp_dir().'/'.md5($this->getContainer()->getParameter('kernel.project_dir'))
+            $this->getContainer()->getParameter('kernel.project_dir').'/var/locks'
         );
 
         if (!$lock->lock()) {


### PR DESCRIPTION
Due to the [ongoing problems](https://github.com/contao/core-bundle/issues/1551) with the `AbstractLockedCommand` on Strato, I propose at least the following change: use a `/var/locks` directory within the project instead of the `sys_get_temp_dir()` location.

Since we need a read and write file handle for file locks on Solaris, the file permissions of the lock files need to be changed from `0444` to `0666` (see https://github.com/symfony/symfony/pull/27903). Any lock files generated prior to this change will still cause problems. Thus, if the lock files are at least within the user's reach (i.e. in the project directory) such errors would be easier to handle.

Also there is a small bug in PHP that causes the `sys_get_temp_dir()` function to return the temp path with a trailing slash on Solaris. So all the lock file paths will contain a double slash. But this is just a cosmetic discrepancy and doesn't affect the functionality.