### PR TITLE
Add longer cache durations

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -528,7 +528,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'select',
-			'options'                 => array(0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000),
+			'options'                 => array(0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000, 7776000, 15552000, 31536000),
 			'reference'               => &$GLOBALS['TL_LANG']['CACHE'],
 			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "int(10) unsigned NOT NULL default '0'"

--- a/src/Resources/contao/languages/en/tl_page.xlf
+++ b/src/Resources/contao/languages/en/tl_page.xlf
@@ -443,6 +443,15 @@
       <trans-unit id="CACHE.2592000">
         <source>30 days</source>
       </trans-unit>
+      <trans-unit id="CACHE.7776000">
+        <source>3 months</source>
+      </trans-unit>
+      <trans-unit id="CACHE.15552000">
+        <source>6 months</source>
+      </trans-unit>
+      <trans-unit id="CACHE.31536000">
+        <source>1 year</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Now that Contao 4.6 supports cache tagging and invalidation by cache tags, we can increase the caching settings. This is especially true for the reverse proxy cache. Not sure if we also want to allow it for the `clientCache`. I haven't added this because I think a client should probably get a new response every month.

This is an intermediary step. The ultimate goal for Contao would be to disable the settings for the server cache entirely and always cache forever (aka 1 year) on the reverse proxy. Developers should actively tag responses and invalidate the cache entries when something happens in the back end so that a user doesn't need to care about that anymore but always gets maximum performance 😄 