### PR TITLE
Cache tags for new abstract controllers

### DIFF
--- a/src/Controller/AbstractFragmentController.php
+++ b/src/Controller/AbstractFragmentController.php
@@ -99,6 +99,20 @@ abstract class AbstractFragmentController extends Controller implements Fragment
     }
 
     /**
+     * Tags the current response with given cache tags.
+     *
+     * @param array $tags
+     */
+    protected function tagResponse(array $tags): void
+    {
+        if (!$this->has('fos_http_cache.http.symfony_response_tagger')) {
+            return;
+        }
+
+        $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
+    }
+
+    /**
      * Returns the type from the class name.
      *
      * @return string

--- a/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/src/Controller/ContentElement/AbstractContentElementController.php
@@ -38,6 +38,7 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes);
         $this->addSectionToTemplate($template, $section);
+        $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 
         return $this->getResponse($template, $model, $request);
     }

--- a/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -43,6 +43,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes);
         $this->addSectionToTemplate($template, $section);
+        $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 
         return $this->getResponse($template, $model, $request);
     }

--- a/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -16,6 +16,7 @@ use Contao\ContentModel;
 use Contao\CoreBundle\Tests\Fixtures\Controller\ContentElement\TestController;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
+use FOS\HttpCache\ResponseTagger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -119,6 +120,27 @@ class ContentElementControllerTest extends TestCase
         $template = json_decode($response->getContent());
 
         $this->assertSame('ce_test first last', $template->class);
+    }
+
+    public function testSetsCacheTags(): void
+    {
+        $model = new ContentModel();
+        $model->id = 42;
+
+        $responseTagger = $this->createMock(ResponseTagger::class);
+        $responseTagger
+                ->expects($this->once())
+                ->method('addTags')
+                ->with(['contao.db.tl_content.42'])
+        ;
+
+        $container = $this->mockContainerWithFrameworkTemplate('ce_test');
+        $container->set('fos_http_cache.http.symfony_response_tagger', $responseTagger);
+
+        $controller = new TestController();
+        $controller->setContainer($container);
+
+        $controller(new Request(), $model, 'main');
     }
 
     /**

--- a/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -122,12 +122,13 @@ class ContentElementControllerTest extends TestCase
         $this->assertSame('ce_test first last', $template->class);
     }
 
-    public function testSetsCacheTags(): void
+    public function testAddsTheCacheTags(): void
     {
         $model = new ContentModel();
         $model->id = 42;
 
         $responseTagger = $this->createMock(ResponseTagger::class);
+
         $responseTagger
                 ->expects($this->once())
                 ->method('addTags')

--- a/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Tests\Fixtures\Controller\FrontendModule\TestController;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
 use Contao\ModuleModel;
+use FOS\HttpCache\ResponseTagger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -108,6 +109,27 @@ class FrontendModuleControllerTest extends TestCase
         $template = json_decode($response->getContent());
 
         $this->assertSame('left', $template->inColumn);
+    }
+
+    public function testSetsCacheTags(): void
+    {
+        $model = new ModuleModel();
+        $model->id = 42;
+
+        $responseTagger = $this->createMock(ResponseTagger::class);
+        $responseTagger
+            ->expects($this->once())
+            ->method('addTags')
+            ->with(['contao.db.tl_module.42'])
+        ;
+
+        $container = $this->mockContainerWithFrameworkTemplate('mod_test');
+        $container->set('fos_http_cache.http.symfony_response_tagger', $responseTagger);
+
+        $controller = new TestController();
+        $controller->setContainer($container);
+
+        $controller(new Request(), $model, 'main');
     }
 
     /**

--- a/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -111,12 +111,13 @@ class FrontendModuleControllerTest extends TestCase
         $this->assertSame('left', $template->inColumn);
     }
 
-    public function testSetsCacheTags(): void
+    public function testAddsTheCacheTags(): void
     {
         $model = new ModuleModel();
         $model->id = 42;
 
         $responseTagger = $this->createMock(ResponseTagger::class);
+
         $responseTagger
             ->expects($this->once())
             ->method('addTags')


### PR DESCRIPTION
Added support for automatically tagging the elements created using the new abstract controllers. That was still missing 😄 