### PR TITLE
Fixed the SQL query error when fetching members of multiple groups for search index rebuild

### DIFF
--- a/src/Resources/contao/classes/RebuildIndex.php
+++ b/src/Resources/contao/classes/RebuildIndex.php
@@ -66,7 +66,7 @@ class RebuildIndex extends \Backend implements \executable
 
 			if (!empty($amg) && \is_array($amg))
 			{
-				$objUser = $this->Database->execute("SELECT id, username FROM tl_member WHERE (GROUPS LIKE '%\"" . implode('"%\' OR', array_map('\intval', $amg)) . "\"%') AND disable!='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'" . ($time + 60) . "') ORDER BY username");
+				$objUser = $this->Database->execute("SELECT id, username FROM tl_member WHERE (groups LIKE '%\"" . implode('"%\' OR \'%"', array_map('\intval', $amg)) . "\"%') AND disable!='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'" . ($time + 60) . "') ORDER BY username");
 			}
 		}
 


### PR DESCRIPTION
If you try to access the Maintenance backend module as a non-admin which has access to multiple member groups, you will run into the SQL query error:

```
Doctrine\DBAL\Exception\SyntaxErrorException: An exception occurred while executing 'SELECT id, username FROM tl_member WHERE (GROUPS LIKE '%"3"%' OR1"%' OR4"%') AND disable!='1' AND (start='' OR start<='1531467943') AND (stop='' OR stop>'1531468003') ORDER BY username':

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'OR1"%' OR4"%') AND disable!='1' AND (start='' OR start<='1531467943') AND (stop=' at line 1
```

This query is executed to fetch the available members that can be selected to rebuild the search index.