### PR TITLE
[RFC] Use the Intl extension to split words

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.1",
         "ext-dom": "*",
         "ext-gd": "*",
+        "ext-intl": "*",
         "ext-pcre": "*",
         "ausi/slug-generator": "^1.0.1",
         "bacon/bacon-qr-code": "^2.0",

--- a/src/Resources/contao/library/Contao/Search.php
+++ b/src/Resources/contao/library/Contao/Search.php
@@ -343,7 +343,7 @@ class Search
 				case '"':
 					if ($strKeyword = trim(substr($strKeyword, 1, -1)))
 					{
-						$arrPhrases[] = '[[:<:]]' . str_replace(array(' ', '*'), array('[^[:alnum:]]+', ''), $strKeyword) . '[[:>:]]';
+						$arrPhrases[] = str_replace(' ', '[^[:alnum:]]+', preg_quote($strKeyword));
 					}
 					break;
 
@@ -447,7 +447,7 @@ class Search
 		{
 			foreach ($arrPhrases as $strPhrase)
 			{
-				$arrWords = self::splitIntoWords(str_replace('[^[:alnum:]]+', ' ', Utf8::substr($strPhrase, 7, -7)), $GLOBALS['TL_LANGUAGE']);
+				$arrWords = self::splitIntoWords(str_replace('[^[:alnum:]]+', ' ', $strPhrase), $GLOBALS['TL_LANGUAGE']);
 				$arrAllKeywords[] = implode(' OR ', array_fill(0, \count($arrWords), 'word=?'));
 				$arrValues = array_merge($arrValues, $arrWords);
 				$intKeywords += \count($arrWords);

--- a/src/Resources/contao/library/Contao/Search.php
+++ b/src/Resources/contao/library/Contao/Search.php
@@ -275,12 +275,12 @@ class Search
 	/**
 	 * @return string[]
 	 */
-	private function splitIntoWords(string $strText, string $strLocale): array
+	private function splitIntoWords(string $strText, string $strLocale)
 	{
 		$iterator = \IntlBreakIterator::createWordInstance($strLocale);
 		$iterator->setText($strText);
 
-		$words = [];
+		$words = array();
 
 		foreach ($iterator->getPartsIterator() as $part)
 		{

--- a/src/Resources/contao/library/Contao/Search.php
+++ b/src/Resources/contao/library/Contao/Search.php
@@ -233,9 +233,6 @@ class Search
 
 		unset($arrSet);
 
-		// Remove special characters
-		$strText = preg_replace(array('/- /', '/ -/', "/' /", "/ '/", '/\. /', '/\.$/', '/: /', '/:$/', '/, /', '/,$/', '/[^\w\'.:+-]/u'), ' ', $strText);
-
 		// Split words
 		$arrWords = self::splitIntoWords(Utf8::strtolower($strText), $arrData['language']);
 		$arrIndex = array();
@@ -275,6 +272,9 @@ class Search
 		return true;
 	}
 
+	/**
+	 * @return string[]
+	 */
 	private function splitIntoWords(string $strText, string $strLocale): array
 	{
 		$iterator = \IntlBreakIterator::createWordInstance($strLocale);
@@ -310,9 +310,8 @@ class Search
 	public static function searchFor($strKeywords, $blnOrSearch=false, $arrPid=array(), $intRows=0, $intOffset=0, $blnFuzzy=false)
 	{
 		// Clean the keywords
-		$strKeywords = Utf8::strtolower($strKeywords);
 		$strKeywords = \StringUtil::decodeEntities($strKeywords);
-		$strKeywords = preg_replace(array('/\. /', '/\.$/', '/: /', '/:$/', '/, /', '/,$/', '/[^\w\' *+".:,-]/u'), ' ', $strKeywords);
+		$strKeywords = Utf8::strtolower($strKeywords);
 
 		// Check keyword string
 		if (!\strlen($strKeywords))

--- a/src/Resources/contao/modules/ModuleSearch.php
+++ b/src/Resources/contao/modules/ModuleSearch.php
@@ -277,7 +277,7 @@ class ModuleSearch extends Module
 				foreach ($arrMatches as $strWord)
 				{
 					$arrChunks = array();
-					preg_match_all('/(^|\b.{0,'.$this->contextLength.'}\PL)' . str_replace('+', '\\+', $strWord) . '(\PL.{0,'.$this->contextLength.'}\b|$)/ui', $strText, $arrChunks);
+					preg_match_all('/(^|\b.{0,'.$this->contextLength.'}(?:\PL|\p{Hiragana}|\p{Katakana}|\p{Han}|\p{Myanmar}|\p{Khmer}|\p{Lao}|\p{Thai}|\p{Tibetan}))' . preg_quote($strWord, '/') . '((?:\PL|\p{Hiragana}|\p{Katakana}|\p{Han}|\p{Myanmar}|\p{Khmer}|\p{Lao}|\p{Thai}|\p{Tibetan}).{0,'.$this->contextLength.'}\b|$)/ui', $strText, $arrChunks);
 
 					foreach ($arrChunks[0] as $strContext)
 					{
@@ -289,7 +289,7 @@ class ModuleSearch extends Module
 				if (!empty($arrContext))
 				{
 					$objTemplate->context = trim(\StringUtil::substrHtml(implode('…', $arrContext), $this->totalLength));
-					$objTemplate->context = preg_replace('/(?<=^|\PL)(' . implode('|', $arrMatches) . ')(?=\PL|$)/ui', '<mark class="highlight">$1</mark>', $objTemplate->context);
+					$objTemplate->context = preg_replace('/(?<=^|\PL|\p{Hiragana}|\p{Katakana}|\p{Han}|\p{Myanmar}|\p{Khmer}|\p{Lao}|\p{Thai}|\p{Tibetan})(' . implode('|', array_map('preg_quote', $arrMatches)) . ')(?=\PL|\p{Hiragana}|\p{Katakana}|\p{Han}|\p{Myanmar}|\p{Khmer}|\p{Lao}|\p{Thai}|\p{Tibetan}|$)/ui', '<mark class="highlight">$1</mark>', $objTemplate->context);
 
 					$objTemplate->hasContext = true;
 				}


### PR DESCRIPTION
As discussed in contao/core#2769.

This is a work in progress.

One problem I encountered is that it is currently possible to search in pages with different languages but we have to know the language in advance to know how to split the serch term. How should we do that?