### PR TITLE
[RFC] Check if service or alias exists before trying to make it public

### DIFF
--- a/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
+++ b/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
@@ -36,6 +36,10 @@ class MakeServicesPublicPass implements CompilerPassInterface
         ];
 
         foreach ($services as $service) {
+            if (!$container->hasDefinition($service)) {
+                continue;
+            }
+
             $definition = $container->getDefinition($service);
             $definition->setPublic(true);
         }
@@ -46,6 +50,10 @@ class MakeServicesPublicPass implements CompilerPassInterface
         ];
 
         foreach ($aliases as $alias) {
+            if (!$container->hasAlias($alias)) {
+                continue;
+            }
+
             $alias = $container->getAlias($alias);
             $alias->setPublic(true);
         }


### PR DESCRIPTION
The `lexik/LexikMaintenanceBundle` is only required by `require-dev`, which is therefore not installed when omitting the `--dev` in the installation process. Without a check in the`MakeServicePublicPass` the `cache:clear` command will fail with an exception.

```
You have requested a non-existent service "lexik_maintenance.driver.factory
```

By checking if the service exists beforehand, we can skip non existent services and aliases.