### PR TITLE
Delete parent tag on create and edit

### DIFF
--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -1221,7 +1221,8 @@ abstract class DataContainer extends Backend
 			$tags[] = $ns . $table . '.' . $id;
 		}
 
-		if ($parentTable != '' && $parentId > 0) {
+		if ($parentTable && $parentId > 0)
+		{
 			$tags[] = $ns . $parentTable;
 			$tags[] = $ns . $parentTable . '.' . $parentId;
 		}

--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -1201,9 +1201,8 @@ abstract class DataContainer extends Backend
 	}
 
 	/**
-	 * Returns an array of cache tags.
-	 * Optionally including the parent table (which is useful when creating new
-	 * elements or editing a certain element).
+	 * Return an array of cache tags, optionally including the parent table
+	 * (which is useful when creating new elements or editing a certain element)
 	 *
 	 * @param string $table
 	 * @param array  $ids

--- a/src/Resources/contao/classes/DataContainer.php
+++ b/src/Resources/contao/classes/DataContainer.php
@@ -1201,14 +1201,18 @@ abstract class DataContainer extends Backend
 	}
 
 	/**
-	 * Returns an array of cache tags with all parent tables included.
+	 * Returns an array of cache tags.
+	 * Optionally including the parent table (which is useful when creating new
+	 * elements or editing a certain element).
 	 *
 	 * @param string $table
 	 * @param array  $ids
+	 * @param string $parentTable
+	 * @param int    $parentId
 	 *
 	 * @return array
 	 */
-	protected function getCacheTags($table, array $ids = array())
+	protected function getCacheTags($table, array $ids = array(), $parentTable = '', $parentId = 0)
 	{
 		$ns = 'contao.db.';
 		$tags = array($ns . $table);
@@ -1216,6 +1220,11 @@ abstract class DataContainer extends Backend
 		foreach ($ids as $id)
 		{
 			$tags[] = $ns . $table . '.' . $id;
+		}
+
+		if ($parentTable != '' && $parentId > 0) {
+			$tags[] = $ns . $parentTable;
+			$tags[] = $ns . $parentTable . '.' . $parentId;
 		}
 
 		return array_unique($tags);

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -1753,7 +1753,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							   ->execute($row[1]['sorting'], $row[0]['id']);
 
 				// Invalidate cache tags
-				$this->invalidateCacheTags($this->getCacheTags($this->strTable, array($row[1]['id'], $row[0]['id']), (string) $this->ptable, (int) $this->activeRecord->pid));
+				$this->invalidateCacheTags($this->getCacheTags($this->strTable, array($row[1]['id'], $row[0]['id']), $this->ptable, $this->activeRecord->pid));
 			}
 		}
 
@@ -2158,7 +2158,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Invalidate cache tags
-			$this->invalidateCacheTags($this->getCacheTags($this->table, array($this->id), (string) $this->ptable, (int) $this->activeRecord->pid));
+			$this->invalidateCacheTags($this->getCacheTags($this->table, array($this->id), $this->ptable, $this->activeRecord->pid));
 
 			// Redirect
 			if (isset($_POST['saveNclose']))

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -1544,7 +1544,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 								   ->limit(1)
 								   ->execute($v);
 
-					// Invalidate cache tags
+					// Invalidate cache tags (no need to invalidate the parent)
 					$this->invalidateCacheTags($this->getCacheTags($table, array($v)));
 				}
 			}
@@ -1753,7 +1753,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							   ->execute($row[1]['sorting'], $row[0]['id']);
 
 				// Invalidate cache tags
-				$this->invalidateCacheTags($this->getCacheTags($this->strTable, array($row[1]['id'], $row[0]['id'])));
+				$this->invalidateCacheTags($this->getCacheTags($this->strTable, array($row[1]['id'], $row[0]['id']), (string) $this->ptable, (int) $this->activeRecord->pid));
 			}
 		}
 
@@ -2158,7 +2158,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Invalidate cache tags
-			$this->invalidateCacheTags($this->getCacheTags($this->table, array($this->id)));
+			$this->invalidateCacheTags($this->getCacheTags($this->table, array($this->id), (string) $this->ptable, (int) $this->activeRecord->pid));
 
 			// Redirect
 			if (isset($_POST['saveNclose']))
@@ -3310,7 +3310,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$ids = array_map('\intval', $new_records[$this->strTable]);
 				$objStmt = $this->Database->execute("DELETE FROM " . $this->strTable . " WHERE id IN(" . implode(',', $ids) . ") AND tstamp=0");
 
-				// Invalidate cache tags
+				// Invalidate cache tags (no need to invalidate the parent)
 				$this->invalidateCacheTags($this->getCacheTags($this->strTable, $ids));
 
 				if ($objStmt->affectedRows > 0)


### PR DESCRIPTION
This is because a new entry (or an unpublished entry) might have not been shown and thus not tagged in the FE. We need to invalidate the direct parent to ensure these entries appear after changing them.