### PR TITLE
[RFC] Include the src/Resource/contao in contao.resource_pathes

### DIFF
--- a/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
+++ b/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
@@ -46,6 +46,10 @@ class AddResourcesPathsPass implements CompilerPassInterface
             $paths[] = $rootDir.'/app/Resources/contao';
         }
 
+        if (is_dir($rootDir.'/src/Resources/contao')) {
+            $paths[] = $rootDir.'/src/Resources/contao';
+        }
+
         return $paths;
     }
 

--- a/tests/DependencyInjection/Compiler/AddResourcesPathsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddResourcesPathsPassTest.php
@@ -54,6 +54,7 @@ class AddResourcesPathsPassTest extends TestCase
                 $path.'/Resources/contao',
                 $this->getFixturesDir().'/system/modules/foobar',
                 $this->getFixturesDir().'/app/Resources/contao',
+                $this->getFixturesDir().'/src/Resources/contao',
             ],
             $container->getParameter('contao.resources_paths')
         );


### PR DESCRIPTION
Using Symfony Flex you do not have an AppBundle anymore. Therefore it is impossible to load (for example) templates from `src/Resource/contao`. These changes will add the `src/Resource/contao` directory hard-coded to the `AddResourcePathsPass`, like `app/Resource/contao` is already.