### PR TITLE
Show layout modules that are disabled in frontend preview

### DIFF
--- a/src/Resources/contao/pages/PageRegular.php
+++ b/src/Resources/contao/pages/PageRegular.php
@@ -140,7 +140,7 @@ class PageRegular extends Frontend
 			foreach ($arrModules as $arrModule)
 			{
 				// Disabled module
-				if (!$arrModule['enable'])
+				if (!$arrModule['enable'] && true !== BE_USER_LOGGED_IN)
 				{
 					continue;
 				}


### PR DESCRIPTION
I never understood why layout modules are not shown if they are disabled, even if frontend preview is enabled. I think we should change this, so this PR is for 4.6 as bugfix, but I don't think we need to backport this to 4.4