### PR TITLE
Allow usage of Doctrine Entities for DCAs 

### DIFF
--- a/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -58,6 +58,10 @@ class DcaSchemaProvider
         $config = $this->getSqlDefinitions();
 
         foreach ($config as $tableName => $definitions) {
+            // Skip DCAs that are defined via a doctrine entity
+            if($schema->hasTable($tableName)) {
+                continue;
+            }
             $table = $schema->createTable($tableName);
 
             // Parse the table options first


### PR DESCRIPTION
When `DcaSchemaProvider->createSchemaFromOrm()` gets executed in the install tool, the `appendToSchema()` listener adds Contao's DCA SQL definitions to the schema. So far so good but, imho it must skip DCAs that have the same table name like any of the defined entities. 

**Why is this needed?** Define a DCA like normal, but omit the SQL definitions. Define a doctrine entity that reflect the fields with the proper types and table name to match the dca. It's basically: Use entites instead of Contao models (but keep the DCA functionality) - it would be extremly helpful when wriring extensions.

Right now this leads to a `SchemaException`:
> The table with name 'contao.tl_my_table' already exists.

The PR adds a check that eventually skips tables. It should not break anything as it only affects the install tool and those cases where an exception would have been thrown anyway.

Any objections? Or do I use a wrong approach? :smiley: 

Just thinking:  ... I'd actually consider this a bug. PR should then probably be targeted against the LTS branch. But let's hear your feedback first.