### PR TITLE
Add removeField to the palette manipulator

### DIFF
--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -93,7 +93,7 @@ class PaletteManipulator
     }
 
     /**
-     * If $parent is empty the field is removed everythere.
+     * Parent refers to the legend. If $parent is empty the field is removed everywhere.
      *
      * @param string|array               $name
      * @param string|array               $parent

--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -33,6 +33,11 @@ class PaletteManipulator
      */
     private $fields = [];
 
+    /**
+     * @var array
+     */
+    private $removes = [];
+
     public static function create(): self
     {
         return new static();
@@ -88,6 +93,22 @@ class PaletteManipulator
     }
 
     /**
+     * If $parent is empty the field is removed everythere.
+     *
+     * @param string|array               $name
+     * @param string|array               $parent
+     */
+    public function removeField($name, $parent = []): self
+    {
+        $this->removes[] = [
+            'fields' => (array) $name,
+            'parents' => (array) $parent
+        ];
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      */
     public function applyToPalette($name, string $table): self
@@ -133,6 +154,10 @@ class PaletteManipulator
 
         foreach ($this->fields as $field) {
             $this->applyField($config, $field, $skipLegends);
+        }
+
+        foreach ($this->removes as $remove) {
+            $this->applyRemove($config, $remove);
         }
 
         return $this->implode($config);
@@ -338,6 +363,15 @@ class PaletteManipulator
         // If everything fails, add to the last legend
         $offset = self::POSITION_PREPEND === $action['fallbackPosition'] ? 0 : \count($config[$fallback]['fields']);
         array_splice($config[$fallback]['fields'], $offset, 0, $action['fields']);
+    }
+
+    private function applyRemove(array &$config, array $remove)
+    {
+        foreach ($config as $legend => $group) {
+            if (empty($remove['parents']) || \in_array($legend, $remove['parents'])) {
+                $config[$legend]['fields'] = \array_diff($group['fields'], $remove['fields']);
+            }
+        }
     }
 
     /**

--- a/src/DataContainer/PaletteManipulator.php
+++ b/src/DataContainer/PaletteManipulator.php
@@ -365,7 +365,7 @@ class PaletteManipulator
         array_splice($config[$fallback]['fields'], $offset, 0, $action['fields']);
     }
 
-    private function applyRemove(array &$config, array $remove)
+    private function applyRemove(array &$config, array $remove): void
     {
         foreach ($config as $legend => $group) {
             if (empty($remove['parents']) || \in_array($legend, $remove['parents'])) {


### PR DESCRIPTION
This PR adds the ability to remove fields using the palette manipulator.

Implemented behaviour:

- The removal task can be limited to a parent (=legend). So the field would be only removed if it's in a specific legend. Useful if you want to "move" a field to another legend.
- The fields are removed after fields are added. Refer to a removed field as parent keep working in `addField`.

Removing a whole legend does not make sense to me, so it's not part of the PR.