### PR TITLE
Fixed CORS headers not set correctly when rebuilding the search index

### DIFF
--- a/src/Cors/WebsiteRootsConfigProvider.php
+++ b/src/Cors/WebsiteRootsConfigProvider.php
@@ -86,14 +86,14 @@ class WebsiteRootsConfigProvider implements ProviderInterface
     }
 
     /**
-     * Checks if a database connection can be established and the table exist.
+     * Checks if the tl_page table exists.
      *
      * @return bool
      */
     private function canRunDbQuery()
     {
         try {
-            return $this->connection->isConnected() && $this->connection->getSchemaManager()->tablesExist(['tl_page']);
+            return $this->connection->getSchemaManager()->tablesExist(['tl_page']);
         } catch (DriverException $e) {
             return false;
         }

--- a/tests/Cors/WebsiteRootsConfigProviderTest.php
+++ b/tests/Cors/WebsiteRootsConfigProviderTest.php
@@ -143,32 +143,6 @@ class WebsiteRootsConfigProviderTest extends TestCase
     }
 
     /**
-     * Tests that no configuration is provided if the database is not connected.
-     */
-    public function testDoesNotProvideTheConfigurationIfTheDatabaseIsNotConnected()
-    {
-        $request = Request::create('https://foobar.com');
-        $request->headers->set('Origin', 'https://origin.com');
-
-        $connection = $this->createMock(Connection::class);
-
-        $connection
-            ->method('isConnected')
-            ->willThrowException(new DriverException('Could not connect', new MysqliException('Invalid password')))
-        ;
-
-        $connection
-            ->expects($this->never())
-            ->method('prepare')
-        ;
-
-        $configProvider = new WebsiteRootsConfigProvider($connection);
-        $result = $configProvider->getOptions($request);
-
-        $this->assertCount(0, $result);
-    }
-
-    /**
      * Tests that no configuration is provided if the table does not exist.
      */
     public function testDoesNotProvideTheConfigurationIfTheTableDoesNotExist()
@@ -185,11 +159,6 @@ class WebsiteRootsConfigProviderTest extends TestCase
         ;
 
         $connection = $this->createMock(Connection::class);
-
-        $connection
-            ->method('isConnected')
-            ->willReturn(true)
-        ;
 
         $connection
             ->method('getSchemaManager')
@@ -225,12 +194,6 @@ class WebsiteRootsConfigProviderTest extends TestCase
         ;
 
         $connection = $this->createMock(Connection::class);
-
-        $connection
-            ->expects($this->once())
-            ->method('isConnected')
-            ->willReturn(true)
-        ;
 
         $connection
             ->expects($this->once())


### PR DESCRIPTION
I noticed that rebuilding the search index does not work across domains anymore.
This PR fixes this issue.
The main reason being that `$this->connection->isConnected()` will always return `false` if nobody ever tried to connect before. `$this->connection->isConnected()` is lazy.