### PR TITLE
Prevent message-stack from being consumed before reload

### DIFF
--- a/src/Resources/contao/drivers/DC_File.php
+++ b/src/Resources/contao/drivers/DC_File.php
@@ -299,7 +299,7 @@ class DC_File extends \DataContainer implements \editable
 </form>';
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)
-		$return = \Message::generate() . ($this->noReload ? '
+		$return = ((\Environment::get('requestMethod') !== 'POST') ? \Message::generate() : '') . ($this->noReload ? '
 <p class="tl_error">'.$GLOBALS['TL_LANG']['ERR']['general'].'</p>' : '') . '
 <div id="tl_buttons">
 <a href="'.$this->getReferer(true).'" class="header_back" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b" onclick="Backend.getScrollOffset()">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>

--- a/src/Resources/contao/drivers/DC_Folder.php
+++ b/src/Resources/contao/drivers/DC_Folder.php
@@ -1431,7 +1431,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 </form>';
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)
-		$return = $version . \Message::generate() . ($this->noReload ? '
+		$return = $version . ((\Environment::get('requestMethod') !== 'POST') ? \Message::generate() : '') . ($this->noReload ? '
 <p class="tl_error">'.$GLOBALS['TL_LANG']['ERR']['general'].'</p>' : '') . '
 <div id="tl_buttons">
 <a href="'.$this->getReferer(true).'" class="header_back" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b" onclick="Backend.getScrollOffset()">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>

--- a/src/Resources/contao/drivers/DC_Table.php
+++ b/src/Resources/contao/drivers/DC_Table.php
@@ -2080,7 +2080,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		}
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)
-		$return = $version . \Message::generate() . ($this->noReload ? '
+		$return = $version . ((\Environment::get('requestMethod') !== 'POST') ? \Message::generate() : '') . ($this->noReload ? '
 <p class="tl_error">'.$GLOBALS['TL_LANG']['ERR']['general'].'</p>' : '') . '
 <div id="tl_buttons">' . (\Input::get('nb') ? '&nbsp;' : '
 <a href="'.$this->getReferer(true).'" class="header_back" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b" onclick="Backend.getScrollOffset()">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>') . '


### PR DESCRIPTION
Messages get lost e.g. in the backend user profile when purging session and cache data, when `Contao\Message::generate()` is called with it's underlying flash message in post submits with subsequent reload.

In Contao 3 excluding post submits from message consumption resides in `Contao\Message::generate()`.