### PR TITLE
Fix 'undefined index' PHP notices

### DIFF
--- a/src/Resources/contao/library/Contao/Model.php
+++ b/src/Resources/contao/library/Contao/Model.php
@@ -379,7 +379,7 @@ abstract class Model
 	{
 		if (!isset($this->arrModified[$strKey]))
 		{
-			$this->arrModified[$strKey] = $this->arrData[$strKey];
+			$this->arrModified[$strKey] = (isset($this->arrData[$strKey])) ? $this->arrData[$strKey] : null;
 		}
 	}
 

--- a/src/Resources/contao/library/Contao/Model/QueryBuilder.php
+++ b/src/Resources/contao/library/Contao/Model/QueryBuilder.php
@@ -64,25 +64,25 @@ class QueryBuilder
 		}
 
 		// Where condition
-		if ($arrOptions['column'] !== null)
+		if (isset($arrOptions['column']))
 		{
 			$strQuery .= " WHERE " . (\is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteIdentifier($arrOptions['column']) . "=?");
 		}
 
 		// Group by
-		if ($arrOptions['group'] !== null)
+		if (isset($arrOptions['group']))
 		{
 			$strQuery .= " GROUP BY " . $arrOptions['group'];
 		}
 
 		// Having (see #6446)
-		if ($arrOptions['having'] !== null)
+		if (isset($arrOptions['having']))
 		{
 			$strQuery .= " HAVING " . $arrOptions['having'];
 		}
 
 		// Order by
-		if ($arrOptions['order'] !== null)
+		if (isset($arrOptions['order']))
 		{
 			$strQuery .= " ORDER BY " . $arrOptions['order'];
 		}

--- a/src/Resources/contao/library/Contao/Model/Registry.php
+++ b/src/Resources/contao/library/Contao/Model/Registry.php
@@ -158,12 +158,12 @@ class Registry implements \Countable
 
 		$strTable = $objModel->getTable();
 
-		if (!\is_array($this->arrAliases[$strTable]))
+		if (!isset($this->arrAliases[$strTable]) || !\is_array($this->arrAliases[$strTable]))
 		{
 			$this->arrAliases[$strTable] = array();
 		}
 
-		if (!\is_array($this->arrRegistry[$strTable]))
+		if (!isset($this->arrRegistry[$strTable]) || !\is_array($this->arrRegistry[$strTable]))
 		{
 			$this->arrRegistry[$strTable] = array();
 		}


### PR DESCRIPTION
I implemented some unit tests to my Contao app and some of the tests fail because of the `Undefined Index` PHP notices.

Some of my changes are already implemented in newer versions of Contao.