### PR TITLE
BUGFIX: BackendAccessVoter ensure string when checking for supported attribute

### DIFF
--- a/src/Security/Voter/BackendAccessVoter.php
+++ b/src/Security/Voter/BackendAccessVoter.php
@@ -23,7 +23,7 @@ class BackendAccessVoter extends Voter
      */
     protected function supports($attribute, $subject): bool
     {
-        return 0 === strncmp($attribute, 'contao_user.', 12);
+        return is_string($attribute) && 0 === strncmp($attribute, 'contao_user.', 12);
     }
 
     /**


### PR DESCRIPTION
Ensure that the e.g. ExpressionLanguage objects are ignored when checking for support in the BackendAccessVoter.

Fixes: #1710 