### PR TITLE
task | add foreignKey declaration for form and module fields

### DIFF
--- a/contao/dca/tl_content.php
+++ b/contao/dca/tl_content.php
@@ -741,6 +741,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'inputType'               => 'select',
 			'options_callback'        => array('tl_content', 'getForms'),
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50 wizard'),
+			'foreignKey'              => 'tl_form.title',
 			'wizard' => array
 			(
 				array('tl_content', 'editForm')
@@ -751,6 +752,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'inputType'               => 'select',
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50 wizard'),
+			'foreignKey'              => 'tl_module.name',
 			'wizard' => array
 			(
 				array('tl_content', 'editModule')


### PR DESCRIPTION
As asked in the slack support channel, there seems to be no reason why the tl_content fields form and module should not have a relation/foreignKey declaration. For the use of "getRelated" or other logic following the "foreignKey" DCA standards there should be a declaration in my opinion. Hence the pull request.